### PR TITLE
Resolve bugs in Group::child_* methods and remove no-op `recursive` boolean

### DIFF
--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -312,6 +312,9 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Group<TStorage> {
 impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TStorage> {
     /// Return the children of the group
     ///
+    /// The `recursive` argument determines whether the returned `Node`s will have their
+    /// children (and their children, etc.) populated.
+    ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is a metadata related error, or an underlying store error.
     pub fn children(&self, recursive: bool) -> Result<Vec<Node>, NodeCreateError> {
@@ -322,16 +325,16 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     ///
     /// # Errors
     /// Returns [`GroupCreateError`] if there is a storage error or any metadata is invalid.
-    pub fn child_groups(&self, recursive: bool) -> Result<Vec<Self>, GroupCreateError> {
-        self.children(recursive)?
+    pub fn child_groups(&self) -> Result<Vec<Self>, GroupCreateError> {
+        self.children(false)?
             .into_iter()
             .filter_map(|node| {
-                let name = node.name();
+                let path = node.path().to_string();
                 let metadata: NodeMetadata = node.into();
                 match metadata {
                     NodeMetadata::Group(metadata) => Some(Group::new_with_metadata(
                         self.storage.clone(),
-                        name.as_str(),
+                        path.as_str(),
                         metadata,
                     )),
                     NodeMetadata::Array(_) => None,
@@ -344,17 +347,17 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     ///
     /// # Errors
     /// Returns [`ArrayCreateError`] if there is a storage error or any metadata is invalid.
-    pub fn child_arrays(&self, recursive: bool) -> Result<Vec<Array<TStorage>>, ArrayCreateError> {
-        self.children(recursive)?
+    pub fn child_arrays(&self) -> Result<Vec<Array<TStorage>>, ArrayCreateError> {
+        self.children(false)?
             .into_iter()
             .filter_map(|node| {
-                let name = node.name();
+                let path = node.path().to_string();
                 let metadata: NodeMetadata = node.into();
                 match metadata {
                     NodeMetadata::Array(metadata) => Some(Array::new_with_metadata(
                         self.storage.clone(),
-                        name.as_str(),
-                        metadata.clone(),
+                        path.as_str(),
+                        metadata,
                     )),
                     NodeMetadata::Group(_) => None,
                 }
@@ -366,12 +369,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is an underlying error with the store.
-    pub fn child_paths(&self, recursive: bool) -> Result<Vec<NodePath>, NodeCreateError> {
-        let paths = self
-            .children(recursive)?
-            .into_iter()
-            .map(Into::into)
-            .collect();
+    pub fn child_paths(&self) -> Result<Vec<NodePath>, NodeCreateError> {
+        let paths = self.children(false)?.into_iter().map(Into::into).collect();
         Ok(paths)
     }
 
@@ -379,9 +378,9 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is an underlying error with the store.
-    pub fn child_group_paths(&self, recursive: bool) -> Result<Vec<NodePath>, NodeCreateError> {
+    pub fn child_group_paths(&self) -> Result<Vec<NodePath>, NodeCreateError> {
         let paths = self
-            .children(recursive)?
+            .children(false)?
             .into_iter()
             .filter_map(|node| match node.metadata() {
                 NodeMetadata::Group(_) => Some(node.into()),
@@ -395,9 +394,9 @@ impl<TStorage: ?Sized + ReadableStorageTraits + ListableStorageTraits> Group<TSt
     ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is an underlying error with the store.
-    pub fn child_array_paths(&self, recursive: bool) -> Result<Vec<NodePath>, NodeCreateError> {
+    pub fn child_array_paths(&self) -> Result<Vec<NodePath>, NodeCreateError> {
         let paths = self
-            .children(recursive)?
+            .children(false)?
             .into_iter()
             .filter_map(|node| match node.metadata() {
                 NodeMetadata::Array(_) => Some(node.into()),

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -470,6 +470,9 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> Group<TStorage> {
 impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits> Group<TStorage> {
     /// Return the children of the group
     ///
+    /// The `recursive` argument determines whether the returned `Node`s will have their
+    /// children (and their children, etc.) populated.
+    ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is a metadata related error, or an underlying store error.
     pub async fn async_children(&self, recursive: bool) -> Result<Vec<Node>, NodeCreateError> {
@@ -480,17 +483,17 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits>
     ///
     /// # Errors
     /// Returns [`GroupCreateError`] if there is a storage error or any metadata is invalid.
-    pub async fn async_child_groups(&self, recursive: bool) -> Result<Vec<Self>, GroupCreateError> {
-        self.async_children(recursive)
+    pub async fn async_child_groups(&self) -> Result<Vec<Self>, GroupCreateError> {
+        self.async_children(false)
             .await?
             .into_iter()
             .filter_map(|node| {
-                let name = node.name();
+                let path = node.path().to_string();
                 let metadata: NodeMetadata = node.into();
                 match metadata {
                     NodeMetadata::Group(metadata) => Some(Group::new_with_metadata(
                         self.storage.clone(),
-                        name.as_str(),
+                        path.as_str(),
                         metadata,
                     )),
                     NodeMetadata::Array(_) => None,
@@ -503,21 +506,18 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits>
     ///
     /// # Errors
     /// Returns [`ArrayCreateError`] if there is a storage error or any metadata is invalid.
-    pub async fn async_child_arrays(
-        &self,
-        recursive: bool,
-    ) -> Result<Vec<Array<TStorage>>, ArrayCreateError> {
-        self.async_children(recursive)
+    pub async fn async_child_arrays(&self) -> Result<Vec<Array<TStorage>>, ArrayCreateError> {
+        self.async_children(false)
             .await?
             .into_iter()
             .filter_map(|node| {
-                let name = node.name();
+                let path = node.path().to_string();
                 let metadata: NodeMetadata = node.into();
                 match metadata {
                     NodeMetadata::Array(metadata) => Some(Array::new_with_metadata(
                         self.storage.clone(),
-                        name.as_str(),
-                        metadata.clone(),
+                        path.as_str(),
+                        metadata,
                     )),
                     NodeMetadata::Group(_) => None,
                 }
@@ -529,12 +529,9 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits>
     ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is an underlying error with the store.
-    pub async fn async_child_paths(
-        &self,
-        recursive: bool,
-    ) -> Result<Vec<NodePath>, NodeCreateError> {
+    pub async fn async_child_paths(&self) -> Result<Vec<NodePath>, NodeCreateError> {
         let paths = self
-            .async_children(recursive)
+            .async_children(false)
             .await?
             .into_iter()
             .map(Into::into)
@@ -546,12 +543,9 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits>
     ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is an underlying error with the store.
-    pub async fn async_child_group_paths(
-        &self,
-        recursive: bool,
-    ) -> Result<Vec<NodePath>, NodeCreateError> {
+    pub async fn async_child_group_paths(&self) -> Result<Vec<NodePath>, NodeCreateError> {
         let paths = self
-            .async_children(recursive)
+            .async_children(false)
             .await?
             .into_iter()
             .filter_map(|node| match node.metadata() {
@@ -566,12 +560,9 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + AsyncListableStorageTraits>
     ///
     /// # Errors
     /// Returns [`NodeCreateError`] if there is an underlying error with the store.
-    pub async fn async_child_array_paths(
-        &self,
-        recursive: bool,
-    ) -> Result<Vec<NodePath>, NodeCreateError> {
+    pub async fn async_child_array_paths(&self) -> Result<Vec<NodePath>, NodeCreateError> {
         let paths = self
-            .async_children(recursive)
+            .async_children(false)
             .await?
             .into_iter()
             .filter_map(|node| match node.metadata() {

--- a/zarrs/src/node/node_name.rs
+++ b/zarrs/src/node/node_name.rs
@@ -35,7 +35,9 @@ impl NodeName {
     /// `name` is not validated, so this can result in an invalid node name.
     #[must_use]
     pub unsafe fn new_unchecked(name: impl Into<String>) -> Self {
-        Self(name.into())
+        let name: String = name.into();
+        debug_assert!(Self::validate(&name));
+        Self(name)
     }
 
     /// The root node.

--- a/zarrs/tests/data/hierarchy.zarr/a/foo/zarr.json
+++ b/zarrs/tests/data/hierarchy.zarr/a/foo/zarr.json
@@ -16,12 +16,20 @@
           "separator": "/"
       }
   },
-  "codecs": [{
+  "codecs": [
+    {
+      "name": "bytes",
+      "configuration": {
+          "endian": "little"
+      }
+    },
+    {
       "name": "gzip",
       "configuration": {
           "level": 1
       }
-  }],
+    }
+  ],
   "fill_value": "NaN",
   "attributes": {
       "foo": 42,

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -5,14 +5,29 @@ use std::sync::Arc;
 
 use zarrs::{filesystem::FilesystemStore, group::Group, node::Node};
 use zarrs_metadata_ext::group::consolidated_metadata::ConsolidatedMetadata;
+#[cfg(feature = "async")]
+use zarrs_storage::{AsyncListableStorageTraits, AsyncReadableStorageTraits};
 
-#[test]
-fn hierarchy_tree() {
-    let store = Arc::new(
+fn sync_store() -> Arc<FilesystemStore> {
+    Arc::new(
         FilesystemStore::new("./tests/data/hierarchy.zarr")
             .unwrap()
             .sorted(),
-    );
+    )
+}
+
+#[cfg(feature = "async")]
+async fn async_store() -> Arc<impl AsyncReadableStorageTraits + AsyncListableStorageTraits> {
+    use object_store::local::LocalFileSystem;
+
+    Arc::new(zarrs_object_store::AsyncObjectStore::new(
+        LocalFileSystem::new_with_prefix("./tests/data/hierarchy.zarr").unwrap(),
+    ))
+}
+
+#[test]
+fn hierarchy_tree() {
+    let store = sync_store();
     let node = Node::open(&store, "/").unwrap();
     let tree = node.hierarchy_tree();
     println!("{:?}", tree);
@@ -29,11 +44,7 @@ fn hierarchy_tree() {
 
 #[test]
 fn consolidated_metadata() {
-    let store = Arc::new(
-        FilesystemStore::new("./tests/data/hierarchy.zarr")
-            .unwrap()
-            .sorted(),
-    );
+    let store = sync_store();
     let node = Node::open(&store, "/").unwrap();
     let consolidated_metadata = node.consolidate_metadata().unwrap();
     println!("{:#?}", consolidated_metadata);
@@ -66,11 +77,7 @@ fn consolidated_metadata() {
 
 #[test]
 fn child_arrays() {
-    let store = Arc::new(
-        FilesystemStore::new("./tests/data/hierarchy.zarr")
-            .unwrap()
-            .sorted(),
-    );
+    let store = sync_store();
 
     // Two arrays in /a
     let group = Group::open(store.clone(), "/a").unwrap();
@@ -86,11 +93,7 @@ fn child_arrays() {
 
 #[test]
 fn child_groups() {
-    let store = Arc::new(
-        FilesystemStore::new("./tests/data/hierarchy.zarr")
-            .unwrap()
-            .sorted(),
-    );
+    let store = sync_store();
 
     // At root, there are two groups: a and b
     let group = Group::open(store.clone(), "/").unwrap();
@@ -106,11 +109,7 @@ fn child_groups() {
 
 #[test]
 fn child_paths() {
-    let store = Arc::new(
-        FilesystemStore::new("./tests/data/hierarchy.zarr")
-            .unwrap()
-            .sorted(),
-    );
+    let store = sync_store();
 
     // At root, there are two child paths: a and b (both groups)
     let group = Group::open(store.clone(), "/").unwrap();
@@ -127,11 +126,7 @@ fn child_paths() {
 
 #[test]
 fn child_group_paths() {
-    let store = Arc::new(
-        FilesystemStore::new("./tests/data/hierarchy.zarr")
-            .unwrap()
-            .sorted(),
-    );
+    let store = sync_store();
 
     // At root, there are two group paths: a and b
     let group = Group::open(store.clone(), "/").unwrap();
@@ -147,11 +142,7 @@ fn child_group_paths() {
 
 #[test]
 fn child_array_paths() {
-    let store = Arc::new(
-        FilesystemStore::new("./tests/data/hierarchy.zarr")
-            .unwrap()
-            .sorted(),
-    );
+    let store = sync_store();
 
     // At root, there are no array paths (only groups)
     let group = Group::open(store.clone(), "/").unwrap();
@@ -161,6 +152,92 @@ fn child_array_paths() {
     // In /a, there are two array paths: baz and foo
     let group = Group::open(store.clone(), "/a").unwrap();
     let paths = group.child_array_paths().unwrap();
+    let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
+    assert_eq!(path_strings, ["/a/baz", "/a/foo"]);
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_child_arrays() {
+    let store = async_store().await;
+
+    // Two arrays in /a
+    let group = Group::async_open(store.clone(), "/a").await.unwrap();
+    let arrays = group.async_child_arrays().await.unwrap();
+    let array_paths: Vec<_> = arrays.iter().map(|a| a.path().as_str()).collect();
+    assert_eq!(array_paths, ["/a/baz", "/a/foo"]);
+
+    // At root, there are no arrays
+    let group = Group::async_open(store.clone(), "/").await.unwrap();
+    let arrays = group.async_child_arrays().await.unwrap();
+    assert!(arrays.is_empty());
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_child_groups() {
+    let store = async_store().await;
+
+    // At root, there are two groups: a and b
+    let group = Group::async_open(store.clone(), "/").await.unwrap();
+    let groups = group.async_child_groups().await.unwrap();
+    let group_paths: Vec<_> = groups.iter().map(|g| g.path().as_str()).collect();
+    assert_eq!(group_paths, ["/a", "/b"]);
+
+    // In /a, there are no child groups (only arrays)
+    let group = Group::async_open(store.clone(), "/a").await.unwrap();
+    let groups = group.async_child_groups().await.unwrap();
+    assert!(groups.is_empty());
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_child_paths() {
+    let store = async_store().await;
+
+    // At root, there are two child paths: a and b (both groups)
+    let group = Group::async_open(store.clone(), "/").await.unwrap();
+    let paths = group.async_child_paths().await.unwrap();
+    let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
+    assert_eq!(path_strings, ["/a", "/b"]);
+
+    // In /a, there are two child paths: baz and foo (both arrays)
+    let group = Group::async_open(store.clone(), "/a").await.unwrap();
+    let paths = group.async_child_paths().await.unwrap();
+    let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
+    assert_eq!(path_strings, ["/a/baz", "/a/foo"]);
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_child_group_paths() {
+    let store = async_store().await;
+
+    // At root, there are two group paths: a and b
+    let group = Group::async_open(store.clone(), "/").await.unwrap();
+    let paths = group.async_child_group_paths().await.unwrap();
+    let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
+    assert_eq!(path_strings, ["/a", "/b"]);
+
+    // In /a, there are no child group paths (only arrays)
+    let group = Group::async_open(store.clone(), "/a").await.unwrap();
+    let paths = group.async_child_group_paths().await.unwrap();
+    assert!(paths.is_empty());
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn async_child_array_paths() {
+    let store = async_store().await;
+
+    // At root, there are no array paths (only groups)
+    let group = Group::async_open(store.clone(), "/").await.unwrap();
+    let paths = group.async_child_array_paths().await.unwrap();
+    assert!(paths.is_empty());
+
+    // In /a, there are two array paths: baz and foo
+    let group = Group::async_open(store.clone(), "/a").await.unwrap();
+    let paths = group.async_child_array_paths().await.unwrap();
     let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
     assert_eq!(path_strings, ["/a/baz", "/a/foo"]);
 }

--- a/zarrs/tests/hierarchy.rs
+++ b/zarrs/tests/hierarchy.rs
@@ -63,3 +63,104 @@ fn consolidated_metadata() {
         assert_eq!(consolidated, actual.metadata());
     }
 }
+
+#[test]
+fn child_arrays() {
+    let store = Arc::new(
+        FilesystemStore::new("./tests/data/hierarchy.zarr")
+            .unwrap()
+            .sorted(),
+    );
+
+    // Two arrays in /a
+    let group = Group::open(store.clone(), "/a").unwrap();
+    let arrays = group.child_arrays().unwrap();
+    let array_paths: Vec<_> = arrays.iter().map(|a| a.path().as_str()).collect();
+    assert_eq!(array_paths, ["/a/baz", "/a/foo"]);
+
+    // At root, there are no arrays
+    let group = Group::open(store.clone(), "/").unwrap();
+    let arrays = group.child_arrays().unwrap();
+    assert!(arrays.is_empty());
+}
+
+#[test]
+fn child_groups() {
+    let store = Arc::new(
+        FilesystemStore::new("./tests/data/hierarchy.zarr")
+            .unwrap()
+            .sorted(),
+    );
+
+    // At root, there are two groups: a and b
+    let group = Group::open(store.clone(), "/").unwrap();
+    let groups = group.child_groups().unwrap();
+    let group_paths: Vec<_> = groups.iter().map(|g| g.path().as_str()).collect();
+    assert_eq!(group_paths, ["/a", "/b"]);
+
+    // In /a, there are no child groups (only arrays)
+    let group = Group::open(store.clone(), "/a").unwrap();
+    let groups = group.child_groups().unwrap();
+    assert!(groups.is_empty());
+}
+
+#[test]
+fn child_paths() {
+    let store = Arc::new(
+        FilesystemStore::new("./tests/data/hierarchy.zarr")
+            .unwrap()
+            .sorted(),
+    );
+
+    // At root, there are two child paths: a and b (both groups)
+    let group = Group::open(store.clone(), "/").unwrap();
+    let paths = group.child_paths().unwrap();
+    let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
+    assert_eq!(path_strings, ["/a", "/b"]);
+
+    // In /a, there are two child paths: baz and foo (both arrays)
+    let group = Group::open(store.clone(), "/a").unwrap();
+    let paths = group.child_paths().unwrap();
+    let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
+    assert_eq!(path_strings, ["/a/baz", "/a/foo"]);
+}
+
+#[test]
+fn child_group_paths() {
+    let store = Arc::new(
+        FilesystemStore::new("./tests/data/hierarchy.zarr")
+            .unwrap()
+            .sorted(),
+    );
+
+    // At root, there are two group paths: a and b
+    let group = Group::open(store.clone(), "/").unwrap();
+    let paths = group.child_group_paths().unwrap();
+    let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
+    assert_eq!(path_strings, ["/a", "/b"]);
+
+    // In /a, there are no child group paths (only arrays)
+    let group = Group::open(store.clone(), "/a").unwrap();
+    let paths = group.child_group_paths().unwrap();
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn child_array_paths() {
+    let store = Arc::new(
+        FilesystemStore::new("./tests/data/hierarchy.zarr")
+            .unwrap()
+            .sorted(),
+    );
+
+    // At root, there are no array paths (only groups)
+    let group = Group::open(store.clone(), "/").unwrap();
+    let paths = group.child_array_paths().unwrap();
+    assert!(paths.is_empty());
+
+    // In /a, there are two array paths: baz and foo
+    let group = Group::open(store.clone(), "/a").unwrap();
+    let paths = group.child_array_paths().unwrap();
+    let path_strings: Vec<_> = paths.iter().map(|p| p.as_str()).collect();
+    assert_eq!(path_strings, ["/a/baz", "/a/foo"]);
+}


### PR DESCRIPTION
I ran into a bug in `Group::child_arrays` which was producing an invalid node path by using node.name() instead of node.path(). In adding tests for this, I realized that the `recursive` boolean wasn't doing anything since `Group::children` (and `get_child_nodes`) only use it to tell if the Node children should be populated -- neither actually returned all nodes recursively. I documented this, and removed the no-op `recursive` boolean from the various methods that had it. (The latter is a breaking change, but if anyone was passing true here, the behavior was probably already broken.) We might also consider renaming it to `populate_children` or something?

Alternatively, we could have these return all nodes/paths/arrays/groups recursively if that was the intent but then it is serving a dual purpose in Group::children of populating the Node's children and also returning all Nodes recursively, which seems funny to me and I wasn't sure exactly what use cases we're expecting for that. 

I also didn't make any changes to the async_* versions yet but happy to apply the same changes there once you're with these. 

Thanks for taking the time to take a look!