### PR TITLE
feat: add partial support for `float8_*` data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Implement `Element` for `&[u8; N]` for `r*` data type
-- Add `Complex{BFloat16,Float16,Float32,Float64}` data types
+- Add `complex_{bfloat16,float16,float32,float64}` data types
+- Add `float8_{e3m4,e4m3,e4m3b11fnuz,e4m3fnuz,e5m2,e5m2fnuz,e8m0fnu}` data types
+  - These have no associated `Element`/`ElementOwned` type and cannot be used with `Array::*_elements()` methods
+  - Only hex string fill values are supported
 
 ### Fixed
 - **Breaking**: Resolve bugs in `Group::child_*` methods and remove no-op `recursive` boolean ([#200] by [@jder])

--- a/zarrs/doc/status/data_types.md
+++ b/zarrs/doc/status/data_types.md
@@ -1,27 +1,34 @@
-| [`DataType`]        | V3 `name`        | V2 `dtype`  | [`ElementOwned`] / [`Element`] | Feature Flag |
-| ------------------- | ---------------- | ----------- | ------------------------------ | ------------ |
-| [`Bool`]            | bool             | \|b1        | [`bool`]                       |              |
-| [`Int8`]            | int8             | \|i1        | [`i8`]                         |              |
-| [`Int16`]           | int16            | >i2 <i2     | [`i16`]                        |              |
-| [`Int32`]           | int32            | >i4 <i4     | [`i32`]                        |              |
-| [`Int64`]           | int64            | >i8 <i8     | [`i64`]                        |              |
-| [`UInt8`]           | uint8            | \|u1        | [`u8`]                         |              |
-| [`UInt16`]          | uint16           | >u2 <u2     | [`u16`]                        |              |
-| [`UInt32`]          | uint32           | >u4 <u4     | [`u32`]                        |              |
-| [`UInt64`]          | uint64           | >u8 <u8     | [`u64`]                        |              |
-| [`BFloat16`]        | bfloat16         |             | [`half::bf16`]                 |              |
-| [`Float16`]         | float16          | >f2 <f2     | [`half::f16`]                  |              |
-| [`Float32`]         | float32          | >f4 <f4     | [`f32`]                        |              |
-| [`Float64`]         | float64          | >f8 <f8     | [`f64`]                        |              |
-| [`ComplexBFloat16`] | complex_bfloat16 |             | [`Complex<half::bf16>`]        |              |
-| [`ComplexFloat16`]  | complex_float16  |             | [`Complex<half::f16>`]         |              |
-| [`ComplexFloat32`]  | complex_float32  |             | [`Complex<f32>`]               |              |
-| [`ComplexFloat64`]  | complex_float64  |             | [`Complex<f64>`]               |              |
-| [`Complex64`]       | complex64        | >c8 <c8     | [`Complex<f32>`]               |              |
-| [`Complex128`]      | complex128       | >c16 <c16   | [`Complex<f64>`]               |              |
-| [`RawBits`]         | r                |             | `[u8; N]` / `&[u8; N]`         |              |
-| [`String`]          | string           | \|O         | [`String`] / [`&str`]          |              |
-| [`Bytes`]           | bytes<br>binary  | \|VX        | [`Vec<u8>`] / `&[u8]`          |              |
+| [`DataType`]          | V3 `name`          | V2 `dtype`  | [`ElementOwned`] / [`Element`] | Feature Flag |
+| --------------------- | ------------------ | ----------- | ------------------------------ | ------------ |
+| [`Bool`]              | bool               | \|b1        | [`bool`]                       |              |
+| [`Int8`]              | int8               | \|i1        | [`i8`]                         |              |
+| [`Int16`]             | int16              | >i2 <i2     | [`i16`]                        |              |
+| [`Int32`]             | int32              | >i4 <i4     | [`i32`]                        |              |
+| [`Int64`]             | int64              | >i8 <i8     | [`i64`]                        |              |
+| [`UInt8`]             | uint8              | \|u1        | [`u8`]                         |              |
+| [`UInt16`]            | uint16             | >u2 <u2     | [`u16`]                        |              |
+| [`UInt32`]            | uint32             | >u4 <u4     | [`u32`]                        |              |
+| [`UInt64`]            | uint64             | >u8 <u8     | [`u64`]                        |              |
+| [`Float8E3M4`]        | float8_e3m4        |             |                                |              |
+| [`Float8E4M3`]        | float8_e4m3        |             |                                |              |
+| [`Float8E4M3B11FNUZ`] | float8_e4m3b11fnuz |             |                                |              |
+| [`Float8E4M3FNUZ`]    | float8_e4m3fnuz    |             |                                |              |
+| [`Float8E5M2`]        | float8_e5m2        |             |                                |              |
+| [`Float8E5M2FNUZ`]    | float8_e5m2fnuz    |             |                                |              |
+| [`Float8E8M0FNU`]     | float8_e8m0fnu     |             |                                |              |
+| [`BFloat16`]          | bfloat16           |             | [`half::bf16`]                 |              |
+| [`Float16`]           | float16            | >f2 <f2     | [`half::f16`]                  |              |
+| [`Float32`]           | float32            | >f4 <f4     | [`f32`]                        |              |
+| [`Float64`]           | float64            | >f8 <f8     | [`f64`]                        |              |
+| [`ComplexBFloat16`]   | complex_bfloat16   |             | [`Complex<half::bf16>`]        |              |
+| [`ComplexFloat16`]    | complex_float16    |             | [`Complex<half::f16>`]         |              |
+| [`ComplexFloat32`]    | complex_float32    |             | [`Complex<f32>`]               |              |
+| [`ComplexFloat64`]    | complex_float64    |             | [`Complex<f64>`]               |              |
+| [`Complex64`]         | complex64          | >c8 <c8     | [`Complex<f32>`]               |              |
+| [`Complex128`]        | complex128         | >c16 <c16   | [`Complex<f64>`]               |              |
+| [`RawBits`]           | r                  |             | `[u8; N]` / `&[u8; N]`         |              |
+| [`String`]            | string             | \|O         | [`String`] / [`&str`]          |              |
+| [`Bytes`]             | bytes<br>binary    | \|VX        | [`Vec<u8>`] / `&[u8]`          |              |
 
 [`DataType`]: crate::array::DataType
 
@@ -34,6 +41,13 @@
 [`Uint16`]: crate::array::DataType::UInt16
 [`Uint32`]: crate::array::DataType::UInt32
 [`Uint64`]: crate::array::DataType::UInt64
+[`Float8E3M4`]: crate::array::DataType::Float8E3M4
+[`Float8E4M3`]: crate::array::DataType::Float8E4M3
+[`Float8E4M3B11FNUZ`]: crate::array::DataType::Float8E4M3B11FNUZ
+[`Float8E4M3FNUZ`]: crate::array::DataType::Float8E4M3FNUZ
+[`Float8E5M2`]: crate::array::DataType::Float8E5M2
+[`Float8E5M2FNUZ`]: crate::array::DataType::Float8E5M2FNUZ
+[`Float8E8M0FNU`]: crate::array::DataType::Float8E8M0FNU
 [`BFloat16`]: crate::array::DataType::BFloat16
 [`Float16`]: crate::array::DataType::Float16
 [`Float32`]: crate::array::DataType::Float32

--- a/zarrs/src/array/data_type.rs
+++ b/zarrs/src/array/data_type.rs
@@ -44,6 +44,34 @@ pub enum DataType {
     UInt32,
     /// `uint64` Integer in `[0, 2^64-1]`.
     UInt64,
+    /// `float8_e3m4` an 8-bit floating point representation: sign bit, 3 bit exponent (bias 3), 4 bit mantissa.
+    /// - IEEE 754-compliant, with NaN and +/-inf.
+    //  - Subnormal numbers when biased exponent is 0.
+    Float8E3M4,
+    /// `float8_e4m3` an 8-bit floating point representation: sign bit, 4 bit exponent (bias 7), 3 bit mantissa.
+    /// - IEEE 754-compliant, with NaN and +/-inf.
+    //  - Subnormal numbers when biased exponent is 0.
+    Float8E4M3,
+    /// `float8_e4m3b11fnuz` an 8-bit floating point representation: sign bit, 4 bit exponent (bias 11), 3 bit mantissa.
+    /// - Extended range: no infinity, NaN represented by `0b1000'0000`.
+    /// - Subnormal numbers when biased exponent is 0.
+    Float8E4M3B11FNUZ,
+    /// `float8_e4m3fnuz` an 8-bit floating point representation: sign bit, 4 bit exponent (bias 8), 3 bit mantissa.
+    /// - Extended range: no infinity, NaN represented by `0b1000'0000`.
+    /// - Subnormal numbers when biased exponent is 0.
+    Float8E4M3FNUZ,
+    /// `float8_e5m2` an 8-bit floating point representation: sign bit, 5 bit exponent (bias 15), 2 bit mantissa.
+    /// - IEEE 754-compliant, with NaN and +/-inf.
+    /// - Subnormal numbers when biased exponent is 0.
+    Float8E5M2,
+    /// `float8_e5m2fnuz` an 8-bit floating point representation: sign bit, 5 bit exponent (bias 16), 2 bit mantissa.
+    /// - Extended range: no infinity, NaN represented by `0b1000'0000`.
+    /// - Subnormal numbers when biased exponent is 0.
+    Float8E5M2FNUZ,
+    /// `float8_e8m0fnu` an 8-bit floating point representation: no sign bit, 8 bit exponent (bias 127), 0 bit mantissa.
+    /// - No zero, no infinity, NaN represented by `0b1111'1111`.
+    /// - No subnormal numbers.
+    Float8E8M0FNU,
     /// `float16` IEEE 754 half-precision floating point: sign bit, 5 bits exponent, 10 bits mantissa.
     Float16,
     /// `float32` IEEE 754 single-precision floating point: sign bit, 8 bits exponent, 23 bits mantissa.
@@ -102,6 +130,13 @@ impl DataType {
             Self::UInt16 => zarrs_registry::data_type::UINT16.to_string(),
             Self::UInt32 => zarrs_registry::data_type::UINT32.to_string(),
             Self::UInt64 => zarrs_registry::data_type::UINT64.to_string(),
+            Self::Float8E3M4 => zarrs_registry::data_type::FLOAT8_E3M4.to_string(),
+            Self::Float8E4M3 => zarrs_registry::data_type::FLOAT8_E4M3.to_string(),
+            Self::Float8E4M3B11FNUZ => zarrs_registry::data_type::FLOAT8_E4M3B11FNUZ.to_string(),
+            Self::Float8E4M3FNUZ => zarrs_registry::data_type::FLOAT8_E4M3FNUZ.to_string(),
+            Self::Float8E5M2 => zarrs_registry::data_type::FLOAT8_E5M2.to_string(),
+            Self::Float8E5M2FNUZ => zarrs_registry::data_type::FLOAT8_E5M2FNUZ.to_string(),
+            Self::Float8E8M0FNU => zarrs_registry::data_type::FLOAT8_E8M0FNU.to_string(),
             Self::Float16 => zarrs_registry::data_type::FLOAT16.to_string(),
             Self::Float32 => zarrs_registry::data_type::FLOAT32.to_string(),
             Self::Float64 => zarrs_registry::data_type::FLOAT64.to_string(),
@@ -132,6 +167,15 @@ impl DataType {
             Self::UInt16 => MetadataV3::new(zarrs_registry::data_type::UINT16),
             Self::UInt32 => MetadataV3::new(zarrs_registry::data_type::UINT32),
             Self::UInt64 => MetadataV3::new(zarrs_registry::data_type::UINT64),
+            Self::Float8E3M4 => MetadataV3::new(zarrs_registry::data_type::FLOAT8_E3M4),
+            Self::Float8E4M3 => MetadataV3::new(zarrs_registry::data_type::FLOAT8_E4M3),
+            Self::Float8E4M3B11FNUZ => {
+                MetadataV3::new(zarrs_registry::data_type::FLOAT8_E4M3B11FNUZ)
+            }
+            Self::Float8E4M3FNUZ => MetadataV3::new(zarrs_registry::data_type::FLOAT8_E4M3FNUZ),
+            Self::Float8E5M2 => MetadataV3::new(zarrs_registry::data_type::FLOAT8_E5M2),
+            Self::Float8E5M2FNUZ => MetadataV3::new(zarrs_registry::data_type::FLOAT8_E5M2FNUZ),
+            Self::Float8E8M0FNU => MetadataV3::new(zarrs_registry::data_type::FLOAT8_E8M0FNU),
             Self::Float16 => MetadataV3::new(zarrs_registry::data_type::FLOAT16),
             Self::Float32 => MetadataV3::new(zarrs_registry::data_type::FLOAT32),
             Self::Float64 => MetadataV3::new(zarrs_registry::data_type::FLOAT64),
@@ -155,7 +199,16 @@ impl DataType {
     #[must_use]
     pub fn size(&self) -> DataTypeSize {
         match self {
-            Self::Bool | Self::Int8 | Self::UInt8 => DataTypeSize::Fixed(1),
+            Self::Bool
+            | Self::Int8
+            | Self::UInt8
+            | Self::Float8E3M4
+            | Self::Float8E4M3
+            | Self::Float8E4M3B11FNUZ
+            | Self::Float8E4M3FNUZ
+            | Self::Float8E5M2
+            | Self::Float8E5M2FNUZ
+            | Self::Float8E8M0FNU => DataTypeSize::Fixed(1),
             Self::Int16 | Self::UInt16 | Self::Float16 | Self::BFloat16 => DataTypeSize::Fixed(2),
             Self::Int32
             | Self::UInt32
@@ -257,6 +310,7 @@ impl DataType {
     /// # Errors
     ///
     /// Returns [`DataTypeFillValueMetadataError`] if the fill value is incompatible with the data type.
+    #[allow(clippy::too_many_lines)]
     pub fn fill_value_from_metadata(
         &self,
         fill_value: &FillValueMetadataV3,
@@ -304,6 +358,20 @@ impl DataType {
                 let int = fill_value.as_u64().ok_or_else(err0)?;
                 Ok(FV::from(int))
             }
+            Self::Float8E3M4
+            | Self::Float8E4M3
+            | Self::Float8E4M3B11FNUZ
+            | Self::Float8E4M3FNUZ
+            | Self::Float8E5M2
+            | Self::Float8E5M2FNUZ
+            | Self::Float8E8M0FNU => match fill_value {
+                // FIXME: Support normal floating point fill value metadata for these data types.
+                FillValueMetadataV3::String(string) => match string.as_str() {
+                    "Infinity" | "-Infinity" | "NaN" => Err(err0()),
+                    _ => Ok(FV::from(hex_string_to_be_bytes(string).ok_or_else(err0)?)),
+                },
+                _ => Err(err0()),
+            },
             Self::BFloat16 => Ok(FV::from(fill_value.as_bf16().ok_or_else(err0)?)),
             Self::Float16 => Ok(FV::from(fill_value.as_f16().ok_or_else(err0)?)),
             Self::Float32 => Ok(FV::from(fill_value.as_f32().ok_or_else(err0)?)),
@@ -421,6 +489,18 @@ impl DataType {
                 let number = u64::from_ne_bytes(bytes);
                 Ok(FillValueMetadataV3::from(number))
             }
+            Self::Float8E3M4
+            | Self::Float8E4M3
+            | Self::Float8E4M3B11FNUZ
+            | Self::Float8E4M3FNUZ
+            | Self::Float8E5M2
+            | Self::Float8E5M2FNUZ
+            | Self::Float8E8M0FNU => {
+                // FIXME: Support normal floating point fill value metadata for these data types.
+                let bytes: [u8; 1] = fill_value.as_ne_bytes().try_into().map_err(|_| error())?;
+                let hex_string = bytes_to_hex_string(&bytes);
+                Ok(FillValueMetadataV3::from(hex_string))
+            }
             Self::Float16 => {
                 let bytes: [u8; 2] = fill_value.as_ne_bytes().try_into().map_err(|_| error())?;
                 let number = half::f16::from_ne_bytes(bytes);
@@ -497,6 +577,31 @@ impl DataType {
 impl core::fmt::Display for DataType {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "{}", self.name())
+    }
+}
+
+// copy of zarrs_metadata::v3::array::bytes_to_hex_string
+fn bytes_to_hex_string(v: &[u8]) -> String {
+    let mut string = String::with_capacity(2 + v.len() * 2);
+    string.push('0');
+    string.push('x');
+    for byte in v {
+        string.push(char::from_digit((byte / 16).into(), 16).unwrap());
+        string.push(char::from_digit((byte % 16).into(), 16).unwrap());
+    }
+    string
+}
+
+// copy of zarrs_metadata::v3::array::hex_string_to_be_bytes
+fn hex_string_to_be_bytes(s: &str) -> Option<Vec<u8>> {
+    if s.starts_with("0x") && s.len() % 2 == 0 {
+        (2..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
+            .collect::<Result<Vec<_>, _>>()
+            .ok()
+    } else {
+        None
     }
 }
 

--- a/zarrs/src/array/data_type.rs
+++ b/zarrs/src/array/data_type.rs
@@ -260,6 +260,15 @@ impl DataType {
                 zarrs_registry::data_type::UINT16 => return Ok(Self::UInt16),
                 zarrs_registry::data_type::UINT32 => return Ok(Self::UInt32),
                 zarrs_registry::data_type::UINT64 => return Ok(Self::UInt64),
+                zarrs_registry::data_type::FLOAT8_E3M4 => return Ok(Self::Float8E3M4),
+                zarrs_registry::data_type::FLOAT8_E4M3 => return Ok(Self::Float8E4M3),
+                zarrs_registry::data_type::FLOAT8_E4M3B11FNUZ => {
+                    return Ok(Self::Float8E4M3B11FNUZ)
+                }
+                zarrs_registry::data_type::FLOAT8_E4M3FNUZ => return Ok(Self::Float8E4M3FNUZ),
+                zarrs_registry::data_type::FLOAT8_E5M2 => return Ok(Self::Float8E5M2),
+                zarrs_registry::data_type::FLOAT8_E5M2FNUZ => return Ok(Self::Float8E5M2FNUZ),
+                zarrs_registry::data_type::FLOAT8_E8M0FNU => return Ok(Self::Float8E8M0FNU),
                 zarrs_registry::data_type::FLOAT16 => return Ok(Self::Float16),
                 zarrs_registry::data_type::FLOAT32 => return Ok(Self::Float32),
                 zarrs_registry::data_type::FLOAT64 => return Ok(Self::Float64),
@@ -961,6 +970,132 @@ mod tests {
                 .unwrap()
                 .as_ne_bytes(),
             f64::NEG_INFINITY.to_ne_bytes()
+        );
+    }
+
+    #[test]
+    fn data_type_float8_e3m4() {
+        let json = r#""float8_e3m4""#;
+        let metadata: MetadataV3 = serde_json::from_str(json).unwrap();
+        let data_type =
+            DataType::from_metadata(&metadata, &ExtensionAliasesDataTypeV3::default()).unwrap();
+        assert_eq!(json, serde_json::to_string(&data_type.metadata()).unwrap());
+        assert_eq!(data_type.name(), "float8_e3m4");
+
+        let metadata = serde_json::from_str::<FillValueMetadataV3>(r#""0xaa""#).unwrap();
+        let fill_value = data_type.fill_value_from_metadata(&metadata).unwrap();
+        assert_eq!(fill_value.as_ne_bytes(), [170]);
+        assert_eq!(
+            metadata,
+            data_type.metadata_fill_value(&fill_value).unwrap()
+        );
+    }
+
+    #[test]
+    fn data_type_float8_e4m3() {
+        let json = r#""float8_e4m3""#;
+        let metadata: MetadataV3 = serde_json::from_str(json).unwrap();
+        let data_type =
+            DataType::from_metadata(&metadata, &ExtensionAliasesDataTypeV3::default()).unwrap();
+        assert_eq!(json, serde_json::to_string(&data_type.metadata()).unwrap());
+        assert_eq!(data_type.name(), "float8_e4m3");
+
+        let metadata = serde_json::from_str::<FillValueMetadataV3>(r#""0xaa""#).unwrap();
+        let fill_value = data_type.fill_value_from_metadata(&metadata).unwrap();
+        assert_eq!(fill_value.as_ne_bytes(), [170]);
+        assert_eq!(
+            metadata,
+            data_type.metadata_fill_value(&fill_value).unwrap()
+        );
+    }
+
+    #[test]
+    fn data_type_float8_e4m3b11fnuz() {
+        let json = r#""float8_e4m3b11fnuz""#;
+        let metadata: MetadataV3 = serde_json::from_str(json).unwrap();
+        let data_type =
+            DataType::from_metadata(&metadata, &ExtensionAliasesDataTypeV3::default()).unwrap();
+        assert_eq!(json, serde_json::to_string(&data_type.metadata()).unwrap());
+        assert_eq!(data_type.name(), "float8_e4m3b11fnuz");
+
+        let metadata = serde_json::from_str::<FillValueMetadataV3>(r#""0xaa""#).unwrap();
+        let fill_value = data_type.fill_value_from_metadata(&metadata).unwrap();
+        assert_eq!(fill_value.as_ne_bytes(), [170]);
+        assert_eq!(
+            metadata,
+            data_type.metadata_fill_value(&fill_value).unwrap()
+        );
+    }
+
+    #[test]
+    fn data_type_float8_e4m3fnuz() {
+        let json = r#""float8_e4m3fnuz""#;
+        let metadata: MetadataV3 = serde_json::from_str(json).unwrap();
+        let data_type =
+            DataType::from_metadata(&metadata, &ExtensionAliasesDataTypeV3::default()).unwrap();
+        assert_eq!(json, serde_json::to_string(&data_type.metadata()).unwrap());
+        assert_eq!(data_type.name(), "float8_e4m3fnuz");
+
+        let metadata = serde_json::from_str::<FillValueMetadataV3>(r#""0xaa""#).unwrap();
+        let fill_value = data_type.fill_value_from_metadata(&metadata).unwrap();
+        assert_eq!(fill_value.as_ne_bytes(), [170]);
+        assert_eq!(
+            metadata,
+            data_type.metadata_fill_value(&fill_value).unwrap()
+        );
+    }
+
+    #[test]
+    fn data_type_float8_e5m2() {
+        let json = r#""float8_e5m2""#;
+        let metadata: MetadataV3 = serde_json::from_str(json).unwrap();
+        let data_type =
+            DataType::from_metadata(&metadata, &ExtensionAliasesDataTypeV3::default()).unwrap();
+        assert_eq!(json, serde_json::to_string(&data_type.metadata()).unwrap());
+        assert_eq!(data_type.name(), "float8_e5m2");
+
+        let metadata = serde_json::from_str::<FillValueMetadataV3>(r#""0xaa""#).unwrap();
+        let fill_value = data_type.fill_value_from_metadata(&metadata).unwrap();
+        assert_eq!(fill_value.as_ne_bytes(), [170]);
+        assert_eq!(
+            metadata,
+            data_type.metadata_fill_value(&fill_value).unwrap()
+        );
+    }
+
+    #[test]
+    fn data_type_float8_e5m2fnuz() {
+        let json = r#""float8_e5m2fnuz""#;
+        let metadata: MetadataV3 = serde_json::from_str(json).unwrap();
+        let data_type =
+            DataType::from_metadata(&metadata, &ExtensionAliasesDataTypeV3::default()).unwrap();
+        assert_eq!(json, serde_json::to_string(&data_type.metadata()).unwrap());
+        assert_eq!(data_type.name(), "float8_e5m2fnuz");
+
+        let metadata = serde_json::from_str::<FillValueMetadataV3>(r#""0xaa""#).unwrap();
+        let fill_value = data_type.fill_value_from_metadata(&metadata).unwrap();
+        assert_eq!(fill_value.as_ne_bytes(), [170]);
+        assert_eq!(
+            metadata,
+            data_type.metadata_fill_value(&fill_value).unwrap()
+        );
+    }
+
+    #[test]
+    fn data_type_float8_e8m0fnu() {
+        let json = r#""float8_e8m0fnu""#;
+        let metadata: MetadataV3 = serde_json::from_str(json).unwrap();
+        let data_type =
+            DataType::from_metadata(&metadata, &ExtensionAliasesDataTypeV3::default()).unwrap();
+        assert_eq!(json, serde_json::to_string(&data_type.metadata()).unwrap());
+        assert_eq!(data_type.name(), "float8_e8m0fnu");
+
+        let metadata = serde_json::from_str::<FillValueMetadataV3>(r#""0xaa""#).unwrap();
+        let fill_value = data_type.fill_value_from_metadata(&metadata).unwrap();
+        assert_eq!(fill_value.as_ne_bytes(), [170]);
+        assert_eq!(
+            metadata,
+            data_type.metadata_fill_value(&fill_value).unwrap()
         );
     }
 

--- a/zarrs_registry/src/data_type.rs
+++ b/zarrs_registry/src/data_type.rs
@@ -25,6 +25,27 @@ pub const UINT32: &str = "uint32";
 /// Unique identifier for the `uint64` data type (core).
 pub const UINT64: &str = "uint64";
 
+/// Unique identifier for the `float8_e3m4` data type (registered).
+pub const FLOAT8_E3M4: &str = "float8_e3m4";
+
+/// Unique identifier for the `float8_e4m3` data type (registered).
+pub const FLOAT8_E4M3: &str = "float8_e4m3";
+
+/// Unique identifier for the `float8_e4m3b11fnuz` data type (registered).
+pub const FLOAT8_E4M3B11FNUZ: &str = "float8_e4m3b11fnuz";
+
+/// Unique identifier for the `float8_e4m3fnuz` data type (registered).
+pub const FLOAT8_E4M3FNUZ: &str = "float8_e4m3fnuz";
+
+/// Unique identifier for the `float8_e5m2` data type (registered).
+pub const FLOAT8_E5M2: &str = "float8_e5m2";
+
+/// Unique identifier for the `float8_e5m2fnuz` data type (registered).
+pub const FLOAT8_E5M2FNUZ: &str = "float8_e5m2fnuz";
+
+/// Unique identifier for the `float8_e8m0fnu` data type (registered).
+pub const FLOAT8_E8M0FNU: &str = "float8_e8m0fnu";
+
 /// Unique identifier for the `float16` data type (core).
 pub const FLOAT16: &str = "float16";
 


### PR DESCRIPTION
These data types have no native Rust types, and likely won't for years (if ever).