### PR TITLE
refactor!: improve `ArrayBuilder` and `{Array,Chunk}Representation` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ ArrayBuilder::new(
 - Bump `zarrs_metadata_ext` to 0.2.0
 - Bump `blosc-src` to 0.3.6
 
+### Fixed
+- Permit data types with empty configurations that do not require one
+
 ## [0.21.2] - 2025-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `index_location` support to `vlen` codec
   - Add `VlenCodec::with_index_location()`
+- Add `ArrayBuilder{ChunkGrid,DataType,FillValue}`
 
 ### Changed
+- **Breaking**: change `ArrayBuilder::new()` to take a broader range of types for each parameter. See below
+```diff
+ArrayBuilder::new(
+    // array shape
+    vec![8, 8], // or [8, 8], &[8, 8], etc.
+    // data type, data type name, or data type metadata
+    DataType::Float32, // or "float32" or MetadataV3::new("float32"), etc.
+    // regular chunk shape, chunk grid, or chunk grid metadata
+-    vec![4, 4].try_into()?, // no longer valid
++    vec![4, 4],
+    // scalar/string, fill value, or fill value metadata
+-    f32::NAN.into(), // no longer valid
++    f32::NAN, // or "NaN", FillValue, FillValueMetadataV3
+)
+.build()
+```
+- **Breaking**: change the `{Array,Chunk}Representation::new[_unchecked]` `fill_value` parameter to take `impl Into<FillValue>` instead of `FillValue`
+```diff
+-  ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into())?,
++  ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32)?,
+```
 - **Breaking**: `VlenCodec::new` gains an `index_location` parameter
 - Bump `zarrs_metadata_ext` to 0.2.0
 - Bump `blosc-src` to 0.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `index_location` support to `vlen` codec
   - Add `VlenCodec::with_index_location()`
 - Add `ArrayBuilder{ChunkGrid,DataType,FillValue}`
+- Add `ArrayBuilder::metadata()`
 
 ### Changed
 - **Breaking**: change `ArrayBuilder::new()` to take a broader range of types for each parameter. See below
@@ -19,10 +20,10 @@ ArrayBuilder::new(
     // array shape
     vec![8, 8], // or [8, 8], &[8, 8], etc.
     // data type, data type name, or data type metadata
-    DataType::Float32, // or "float32" or MetadataV3::new("float32"), etc.
+    DataType::Float32, // or "float32", "{"name":"float32"}", MetadataV3::new("float32").
     // regular chunk shape, chunk grid, or chunk grid metadata
 -    vec![4, 4].try_into()?, // no longer valid
-+    vec![4, 4],
++    vec![4, 4], // or [4, 4], &[4, 4], "{"name":"regular",...}", MetadataV3::new_with_configuration(...)
     // scalar/string, fill value, or fill value metadata
 -    f32::NAN.into(), // no longer valid
 +    f32::NAN, // or "NaN", FillValue, FillValueMetadataV3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `VlenCodec::with_index_location()`
 - Add `ArrayBuilder{ChunkGrid,DataType,FillValue}`
 - Add `ArrayBuilder::metadata()`
-- Implement `From<&[FillValueMetadataV3; N]>` for `FillValueMetadataV3`
 
 ### Changed
 - **Breaking**: change `ArrayBuilder::new()` to take a broader range of types for each parameter. See below

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `VlenCodec::with_index_location()`
 - Add `ArrayBuilder{ChunkGrid,DataType,FillValue}`
 - Add `ArrayBuilder::metadata()`
+- Implement `From<&[FillValueMetadataV3; N]>` for `FillValueMetadataV3`
 
 ### Changed
 - **Breaking**: change `ArrayBuilder::new()` to take a broader range of types for each parameter. See below

--- a/zarrs/benches/array_blosc.rs
+++ b/zarrs/benches/array_blosc.rs
@@ -17,8 +17,8 @@ fn array_blosc_write_all(c: &mut Criterion) {
                 let array = zarrs::array::ArrayBuilder::new(
                     vec![size; 3],
                     zarrs::array::DataType::UInt8,
-                    vec![32; 3].try_into().unwrap(),
-                    zarrs::array::FillValue::from(0u8),
+                    vec![32; 3],
+                    0u8,
                 )
                 .bytes_to_bytes_codecs(vec![Arc::new(
                     BloscCodec::new(
@@ -52,8 +52,8 @@ fn array_blosc_read_all(c: &mut Criterion) {
             let array = zarrs::array::ArrayBuilder::new(
                 vec![size; 3],
                 zarrs::array::DataType::UInt8,
-                vec![32; 3].try_into().unwrap(),
-                zarrs::array::FillValue::from(0u8),
+                vec![32; 3],
+                0u8,
             )
             .bytes_to_bytes_codecs(vec![Arc::new(
                 BloscCodec::new(

--- a/zarrs/benches/array_uncompressed.rs
+++ b/zarrs/benches/array_uncompressed.rs
@@ -14,8 +14,8 @@ fn array_write_all(c: &mut Criterion) {
                 let array = zarrs::array::ArrayBuilder::new(
                     vec![size; 3],
                     zarrs::array::DataType::UInt8,
-                    vec![32; 3].try_into().unwrap(),
-                    zarrs::array::FillValue::from(0u8),
+                    vec![32; 3],
+                    0u8,
                 )
                 .build(store.into(), "/")
                 .unwrap();
@@ -41,8 +41,8 @@ fn array_write_all_sharded(c: &mut Criterion) {
                 let array = zarrs::array::ArrayBuilder::new(
                     vec![size; 3],
                     zarrs::array::DataType::UInt16,
-                    vec![size; 3].try_into().unwrap(),
-                    zarrs::array::FillValue::from(0u16),
+                    vec![size; 3],
+                    0u16,
                 )
                 .array_to_bytes_codec(sharding_codec)
                 .build(store.into(), "/")
@@ -67,8 +67,8 @@ fn array_read_all(c: &mut Criterion) {
             let array = zarrs::array::ArrayBuilder::new(
                 vec![size; 3],
                 zarrs::array::DataType::UInt16,
-                vec![32; 3].try_into().unwrap(),
-                zarrs::array::FillValue::from(0u16),
+                vec![32; 3],
+                0u16,
             )
             .build(store.into(), "/")
             .unwrap();
@@ -98,8 +98,8 @@ fn array_read_all_sharded(c: &mut Criterion) {
             let array = zarrs::array::ArrayBuilder::new(
                 vec![size; 3],
                 zarrs::array::DataType::UInt8,
-                vec![size; 3].try_into().unwrap(),
-                zarrs::array::FillValue::from(1u8),
+                vec![size; 3],
+                1u8,
             )
             .array_to_bytes_codec(sharding_codec)
             .build(store.into(), "/")

--- a/zarrs/benches/codecs.rs
+++ b/zarrs/benches/codecs.rs
@@ -29,7 +29,7 @@ fn codec_bytes(c: &mut Criterion) {
         let rep = ChunkRepresentation::new(
             vec![num_elements.try_into().unwrap(); 1],
             DataType::UInt16,
-            0u16.into(),
+            0u16,
         )
         .unwrap();
 

--- a/zarrs/examples/array_write_read.rs
+++ b/zarrs/examples/array_write_read.rs
@@ -8,7 +8,7 @@ use zarrs::storage::{
 fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     use std::sync::Arc;
     use zarrs::{
-        array::{DataType, FillValue, ZARR_NAN_F32},
+        array::{DataType, ZARR_NAN_F32},
         array_subset::ArraySubset,
         node::Node,
         storage::store,
@@ -58,8 +58,8 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
         DataType::Float32,
-        vec![4, 4].try_into()?, // regular chunk shape
-        FillValue::from(ZARR_NAN_F32),
+        vec![4, 4], // regular chunk shape
+        ZARR_NAN_F32,
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
     .dimension_names(["y", "x"].into())

--- a/zarrs/examples/array_write_read_ndarray.rs
+++ b/zarrs/examples/array_write_read_ndarray.rs
@@ -9,7 +9,7 @@ use zarrs::storage::{
 fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     use std::sync::Arc;
     use zarrs::{
-        array::{DataType, FillValue, ZARR_NAN_F32},
+        array::{DataType, ZARR_NAN_F32},
         array_subset::ArraySubset,
         node::Node,
         storage::store,
@@ -59,8 +59,8 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
         DataType::Float32,
-        vec![4, 4].try_into()?, // regular chunk shape
-        FillValue::from(ZARR_NAN_F32),
+        vec![4, 4], // regular chunk shape
+        ZARR_NAN_F32,
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
     .dimension_names(["y", "x"].into())

--- a/zarrs/examples/array_write_read_string.rs
+++ b/zarrs/examples/array_write_read_string.rs
@@ -9,11 +9,7 @@ use zarrs::{
 
 fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     use std::sync::Arc;
-    use zarrs::{
-        array::{DataType, FillValue},
-        array_subset::ArraySubset,
-        storage::store,
-    };
+    use zarrs::{array::DataType, array_subset::ArraySubset, storage::store};
 
     // Create a store
     // let path = tempfile::TempDir::new()?;
@@ -59,8 +55,8 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array = zarrs::array::ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::String,
-        vec![2, 2].try_into()?, // regular chunk shape
-        FillValue::from("_"),
+        vec![2, 2], // regular chunk shape
+        "_",
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
     .dimension_names(["y", "x"].into())

--- a/zarrs/examples/async_array_write_read.rs
+++ b/zarrs/examples/async_array_write_read.rs
@@ -9,7 +9,7 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     use futures::StreamExt;
     use std::sync::Arc;
     use zarrs::{
-        array::{DataType, FillValue, ZARR_NAN_F32},
+        array::{DataType, ZARR_NAN_F32},
         array_subset::ArraySubset,
         node::Node,
     };
@@ -55,8 +55,8 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
         DataType::Float32,
-        vec![4, 4].try_into()?, // regular chunk shape
-        FillValue::from(ZARR_NAN_F32),
+        vec![4, 4], // regular chunk shape
+        ZARR_NAN_F32,
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
     .dimension_names(["y", "x"].into())

--- a/zarrs/examples/custom_data_type_fixed_size.rs
+++ b/zarrs/examples/custom_data_type_fixed_size.rs
@@ -273,7 +273,7 @@ fn main() {
     let array = ArrayBuilder::new(
         vec![4, 1], // array shape
         DataType::Extension(Arc::new(CustomDataTypeFixedSize)),
-        vec![2, 1].try_into().unwrap(), // regular chunk shape
+        vec![2, 1], // regular chunk shape
         FillValue::new(fill_value.to_ne_bytes().to_vec()),
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/custom_data_type_float8_e3m4.rs
+++ b/zarrs/examples/custom_data_type_float8_e3m4.rs
@@ -221,7 +221,7 @@ fn main() {
     let array = ArrayBuilder::new(
         vec![6, 1], // array shape
         DataType::Extension(Arc::new(CustomDataTypeFloat8e3m4)),
-        vec![5, 1].try_into().unwrap(), // regular chunk shape
+        vec![5, 1], // regular chunk shape
         FillValue::new(fill_value.to_ne_bytes().to_vec()),
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/custom_data_type_uint12.rs
+++ b/zarrs/examples/custom_data_type_uint12.rs
@@ -209,7 +209,7 @@ fn main() {
     let array = ArrayBuilder::new(
         vec![4096, 1], // array shape
         DataType::Extension(Arc::new(CustomDataTypeUInt12)),
-        vec![5, 1].try_into().unwrap(), // regular chunk shape
+        vec![5, 1], // regular chunk shape
         FillValue::new(fill_value.to_le_bytes().to_vec()),
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/custom_data_type_uint4.rs
+++ b/zarrs/examples/custom_data_type_uint4.rs
@@ -207,7 +207,7 @@ fn main() {
     let array = ArrayBuilder::new(
         vec![6, 1], // array shape
         DataType::Extension(Arc::new(CustomDataTypeUInt4)),
-        vec![5, 1].try_into().unwrap(), // regular chunk shape
+        vec![5, 1], // regular chunk shape
         FillValue::new(fill_value.to_ne_bytes().to_vec()),
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/custom_data_type_variable_size.rs
+++ b/zarrs/examples/custom_data_type_variable_size.rs
@@ -122,6 +122,8 @@ impl DataTypeExtension for CustomDataTypeVariableSize {
             Ok(FillValue::new(f.to_ne_bytes().to_vec()))
         } else if fill_value_metadata.is_null() {
             Ok(FillValue::new(vec![]))
+        } else if let Some(bytes) = fill_value_metadata.as_bytes() {
+            Ok(FillValue::new(bytes))
         } else {
             Err(DataTypeFillValueMetadataError::new(
                 self.name(),
@@ -156,8 +158,8 @@ fn main() {
     let array = ArrayBuilder::new(
         vec![4, 1], // array shape
         DataType::Extension(Arc::new(CustomDataTypeVariableSize)),
-        vec![3, 1].try_into().unwrap(), // regular chunk shape
-        FillValue::from(vec![]),
+        vec![3, 1], // regular chunk shape
+        [],
     )
     .array_to_array_codecs(vec![
         #[cfg(feature = "transpose")]

--- a/zarrs/examples/rectangular_array_write_read.rs
+++ b/zarrs/examples/rectangular_array_write_read.rs
@@ -9,7 +9,7 @@ fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     use rayon::prelude::{IntoParallelIterator, ParallelIterator};
     use zarrs::array::ChunkGrid;
     use zarrs::{
-        array::{chunk_grid::RectangularChunkGrid, codec, FillValue},
+        array::{chunk_grid::RectangularChunkGrid, codec},
         node::Node,
     };
     use zarrs::{
@@ -63,7 +63,7 @@ fn rectangular_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
             [1, 2, 3, 2].try_into()?,
             4.try_into()?,
         ])),
-        FillValue::from(ZARR_NAN_F32),
+        ZARR_NAN_F32,
     )
     .bytes_to_bytes_codecs(vec![
         #[cfg(feature = "gzip")]

--- a/zarrs/examples/sharded_array_write_read.rs
+++ b/zarrs/examples/sharded_array_write_read.rs
@@ -12,7 +12,7 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     use zarrs::{
         array::{
             codec::{self, array_to_bytes::sharding::ShardingCodecBuilder},
-            DataType, FillValue,
+            DataType,
         },
         array_subset::ArraySubset,
         node::Node,
@@ -69,8 +69,8 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
         DataType::UInt16,
-        shard_shape.try_into()?,
-        FillValue::from(0u16),
+        shard_shape,
+        0u16,
     )
     .array_to_bytes_codec(Arc::new(sharding_codec_builder.build()))
     .dimension_names(["y", "x"].into())

--- a/zarrs/examples/zip_array_write_read.rs
+++ b/zarrs/examples/zip_array_write_read.rs
@@ -9,7 +9,7 @@ use std::{
 use walkdir::WalkDir;
 
 use zarrs::{
-    array::{codec, Array, DataType, FillValue, ZARR_NAN_F32},
+    array::{codec, Array, DataType, ZARR_NAN_F32},
     array_subset::ArraySubset,
     filesystem::FilesystemStore,
     node::Node,
@@ -31,8 +31,8 @@ fn write_array_to_storage<TStorage: ReadableWritableStorageTraits + ?Sized + 'st
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
         DataType::Float32,
-        vec![4, 4].try_into()?, // regular chunk shape
-        FillValue::from(ZARR_NAN_F32),
+        vec![4, 4], // regular chunk shape
+        ZARR_NAN_F32,
     )
     .bytes_to_bytes_codecs(vec![
         #[cfg(feature = "gzip")]

--- a/zarrs/src/array/array_async_sharded_readable_ext.rs
+++ b/zarrs/src/array/array_async_sharded_readable_ext.rs
@@ -737,7 +737,7 @@ mod tests {
     use crate::{
         array::{
             codec::{array_to_bytes::sharding::ShardingCodecBuilder, TransposeCodec},
-            ArrayBuilder, DataType, FillValue,
+            ArrayBuilder, DataType,
         },
         array_subset::ArraySubset,
         storage::storage_adapter::performance_metrics::PerformanceMetricsStorageAdapter,
@@ -753,8 +753,8 @@ mod tests {
         let mut builder = ArrayBuilder::new(
             vec![8, 8], // array shape
             DataType::UInt16,
-            vec![4, 4].try_into()?, // regular chunk shape
-            FillValue::from(0u16),
+            vec![4, 4], // regular chunk shape
+            0u16,
         );
         if sharded {
             builder.array_to_bytes_codec(Arc::new(
@@ -973,8 +973,8 @@ mod tests {
         let mut builder = ArrayBuilder::new(
             vec![16, 16, 9], // array shape
             DataType::UInt32,
-            vec![8, 4, 3].try_into()?, // regular chunk shape
-            FillValue::from(0u32),
+            vec![8, 4, 3], // regular chunk shape
+            0u32,
         );
         builder.array_to_array_codecs(vec![Arc::new(TransposeCodec::new(TransposeOrder::new(
             &[1, 0, 2],

--- a/zarrs/src/array/array_builder.rs
+++ b/zarrs/src/array/array_builder.rs
@@ -575,29 +575,50 @@ mod tests {
 
     #[test]
     fn array_builder_variants_array_shape() {
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i8);
-        let _ = ArrayBuilder::new(&[8, 8], DataType::Int8, vec![2, 2], 0i8);
-        let _ = ArrayBuilder::new([8, 8], DataType::Int8, vec![2, 2], 0i8);
-        let _ = ArrayBuilder::new([8, 8].as_slice(), DataType::Int8, vec![2, 2], 0i8);
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(&[8, 8], DataType::Int8, vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new([8, 8], DataType::Int8, vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new([8, 8].as_slice(), DataType::Int8, vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
     }
 
     #[test]
     fn array_builder_variants_data_type() {
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], "int8", vec![2, 2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], r#"{"name":"int8"}"#, vec![2, 2], 0i8);
-        let _ = ArrayBuilder::new(
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], "int8", vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], r#"{"name":"int8"}"#, vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(
             vec![8, 8],
             r#"{"name":"int8"}"#.to_string(),
             vec![2, 2],
             0i8,
-        );
-        let _ = ArrayBuilder::new(
+        )
+        .metadata()
+        .unwrap();
+        ArrayBuilder::new(
             vec![8, 8],
             r#"{"name":"int8", "configuration":{},"must_understand":true}"#,
             vec![2, 2],
             0i8,
-        );
+        )
+        .metadata()
+        .unwrap();
+        ArrayBuilder::new(vec![8, 8], MetadataV3::new("int8"), vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
     }
 
     #[test]
@@ -615,43 +636,69 @@ mod tests {
         assert!(ArrayBuilder::new(vec![8, 8], DataType::Int8, "{", 0i8)
             .metadata()
             .is_err());
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, &[2, 2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, [2, 2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, [2, 2].as_slice(), 0i8);
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, &[2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, [2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, [2, 2].as_slice(), 0i8)
+            .metadata()
+            .unwrap();
         let nz2 = NonZeroU64::new(2).unwrap();
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![nz2, nz2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, &[nz2, nz2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, [nz2, nz2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, [nz2, nz2].as_slice(), 0i8);
-        let _ = ArrayBuilder::new(
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![nz2, nz2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, &[nz2, nz2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, [nz2, nz2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, [nz2, nz2].as_slice(), 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(
             vec![8, 8],
             DataType::Int8,
             r#"{"name":"regular","configuration":{"chunk_shape":[2,2]}}"#,
             0i8,
-        );
-        let _ = ArrayBuilder::new(
+        )
+        .metadata()
+        .unwrap();
+        ArrayBuilder::new(
             vec![8, 8],
             DataType::Int8,
             r#"{"name":"regular","configuration":{"chunk_shape":[2,2]}}"#.to_string(),
             0i8,
-        );
-        let _ = ArrayBuilder::new(
+        )
+        .metadata()
+        .unwrap();
+        ArrayBuilder::new(
             vec![8, 8],
             DataType::Int8,
             RegularChunkGrid::new([2, 2].try_into().unwrap()),
             0i8,
-        );
+        )
+        .metadata()
+        .unwrap();
         let chunk_grid: Arc<dyn ChunkGridTraits> =
             Arc::new(RegularChunkGrid::new([2, 2].try_into().unwrap()));
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, chunk_grid, 0i8);
-        let _ = ArrayBuilder::new(
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, chunk_grid, 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(
             vec![8, 8],
             DataType::Int8,
             ChunkGrid::new(RegularChunkGrid::new([2, 2].try_into().unwrap())),
             0i8,
-        );
-        let _ = ArrayBuilder::new(
+        )
+        .metadata()
+        .unwrap();
+        ArrayBuilder::new(
             vec![8, 8],
             DataType::Int8,
             MetadataV3::new_with_configuration(
@@ -661,34 +708,50 @@ mod tests {
                 },
             ),
             0i8,
-        );
+        )
+        .metadata()
+        .unwrap();
     }
 
     #[test]
     fn array_builder_variants_fill_value() {
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i8);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i16); // 0i16 -> 0 metadata -> 0i8
-        let _ = ArrayBuilder::new(
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i8)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], 0i16)
+            .metadata()
+            .unwrap(); // 0i16 -> 0 metadata -> 0i8
+        ArrayBuilder::new(
             vec![8, 8],
             DataType::Int8,
             vec![2, 2],
             FillValue::new(vec![0u8]),
-        );
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], vec![0u8]);
-        // let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], &[0u8]);
-        // let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], [0u8]);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], [0u8].as_slice());
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], FillValue::from(0u8));
-        let _ = ArrayBuilder::new(
+        )
+        .metadata()
+        .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Int8, vec![2, 2], FillValue::from(0u8))
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(
             vec![8, 8],
             DataType::Int8,
             vec![2, 2],
             FillValueMetadataV3::Number(serde_json::Number::from(0u8)),
-        );
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], f32::NAN);
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], "NaN");
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], "Infinity");
-        let _ = ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], "-Infinity");
+        )
+        .metadata()
+        .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], f32::NAN)
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], "NaN")
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], "Infinity")
+            .metadata()
+            .unwrap();
+        ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], "-Infinity")
+            .metadata()
+            .unwrap();
         let ab = ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![2, 2], "0x7fc00000");
         assert_eq!(
             ab.metadata().unwrap().fill_value,

--- a/zarrs/src/array/array_builder/array_builder_chunk_grid.rs
+++ b/zarrs/src/array/array_builder/array_builder_chunk_grid.rs
@@ -1,0 +1,140 @@
+use std::{num::NonZeroU64, sync::Arc};
+
+use derive_more::From;
+use serde::Serialize;
+use zarrs_metadata::{v3::MetadataV3, ArrayShape, ChunkShape};
+use zarrs_plugin::PluginMetadataInvalidError;
+
+use crate::array::{
+    chunk_grid::{ChunkGridTraits, RegularChunkGrid},
+    ArrayCreateError, ChunkGrid,
+};
+
+/// An input that can be mapped to a chunk grid.
+#[derive(Debug, From)]
+pub struct ArrayBuilderChunkGrid(ArrayBuilderChunkGridImpl);
+
+#[derive(Debug, From)]
+enum ArrayBuilderChunkGridImpl {
+    ChunkGrid(ChunkGrid),
+    Metadata(MetadataV3),
+    MetadataString(String),
+    ArrayShape(ArrayShape),
+    ChunkShape(ChunkShape),
+}
+
+impl ArrayBuilderChunkGrid {
+    pub(crate) fn to_chunk_grid(&self, shape: &ArrayShape) -> Result<ChunkGrid, ArrayCreateError> {
+        match &self.0 {
+            ArrayBuilderChunkGridImpl::ChunkGrid(chunk_grid) => Ok(chunk_grid.clone()),
+            ArrayBuilderChunkGridImpl::Metadata(metadata) => {
+                let chunk_grid = ChunkGrid::from_metadata(metadata)
+                    .map_err(ArrayCreateError::ChunkGridCreateError)?;
+                debug_assert_eq!(chunk_grid.dimensionality(), shape.len());
+                Ok(chunk_grid)
+            }
+            ArrayBuilderChunkGridImpl::MetadataString(metadata) => {
+                let metadata = MetadataV3::try_from(metadata.as_str()).map_err(|_| {
+                    ArrayCreateError::ChunkGridCreateError(zarrs_plugin::PluginCreateError::from(
+                        "chunk grid string cannot be parsed as metadata",
+                    ))
+                })?;
+                let chunk_grid = ChunkGrid::from_metadata(&metadata)
+                    .map_err(ArrayCreateError::ChunkGridCreateError)?;
+                debug_assert_eq!(chunk_grid.dimensionality(), shape.len());
+                Ok(chunk_grid)
+            }
+            ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape) => {
+                let chunk_shape: ChunkShape = chunk_shape.clone().try_into().map_err(|_| {
+                    #[derive(Serialize)]
+                    struct RegularChunkGridConfigurationInvalid {
+                        chunk_shape: ArrayShape,
+                    }
+                    let metadata = MetadataV3::new_with_serializable_configuration(
+                        "regular".to_string(),
+                        &RegularChunkGridConfigurationInvalid {
+                            chunk_shape: chunk_shape.clone(),
+                        },
+                    )
+                    .expect("RegularChunkGridConfigurationInvalid is serialisable");
+                    ArrayCreateError::ChunkGridCreateError(
+                        PluginMetadataInvalidError::new(
+                            "regular",
+                            "chunk_grid",
+                            metadata.to_string(),
+                        )
+                        .into(),
+                    )
+                })?;
+                Ok(ChunkGrid::new(RegularChunkGrid::new(chunk_shape)))
+            }
+            ArrayBuilderChunkGridImpl::ChunkShape(chunk_shape) => {
+                Ok(ChunkGrid::new(RegularChunkGrid::new(chunk_shape.clone())))
+            }
+        }
+    }
+}
+
+impl From<ChunkGrid> for ArrayBuilderChunkGrid {
+    fn from(value: ChunkGrid) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ChunkGrid(value))
+    }
+}
+
+impl From<Arc<dyn ChunkGridTraits>> for ArrayBuilderChunkGrid {
+    fn from(value: Arc<dyn ChunkGridTraits>) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ChunkGrid(value.into()))
+    }
+}
+
+impl From<MetadataV3> for ArrayBuilderChunkGrid {
+    fn from(value: MetadataV3) -> Self {
+        Self(ArrayBuilderChunkGridImpl::Metadata(value))
+    }
+}
+
+impl From<String> for ArrayBuilderChunkGrid {
+    fn from(value: String) -> Self {
+        Self(ArrayBuilderChunkGridImpl::MetadataString(value))
+    }
+}
+
+impl From<&str> for ArrayBuilderChunkGrid {
+    fn from(value: &str) -> Self {
+        Self(ArrayBuilderChunkGridImpl::MetadataString(value.to_string()))
+    }
+}
+
+impl<const N: usize> From<[u64; N]> for ArrayBuilderChunkGrid {
+    fn from(chunk_shape: [u64; N]) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape.to_vec()))
+    }
+}
+
+impl<const N: usize> From<[NonZeroU64; N]> for ArrayBuilderChunkGrid {
+    fn from(chunk_shape: [NonZeroU64; N]) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ChunkShape(
+            chunk_shape.to_vec().into(),
+        ))
+    }
+}
+
+impl From<&[NonZeroU64]> for ArrayBuilderChunkGrid {
+    fn from(chunk_shape: &[NonZeroU64]) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ChunkShape(
+            chunk_shape.to_vec().into(),
+        ))
+    }
+}
+
+impl From<Vec<NonZeroU64>> for ArrayBuilderChunkGrid {
+    fn from(chunk_shape: Vec<NonZeroU64>) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ChunkShape(chunk_shape.into()))
+    }
+}
+
+impl From<Vec<u64>> for ArrayBuilderChunkGrid {
+    fn from(chunk_shape: Vec<u64>) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape))
+    }
+}

--- a/zarrs/src/array/array_builder/array_builder_chunk_grid.rs
+++ b/zarrs/src/array/array_builder/array_builder_chunk_grid.rs
@@ -81,6 +81,12 @@ impl From<ChunkGrid> for ArrayBuilderChunkGrid {
     }
 }
 
+impl<T: ChunkGridTraits + 'static> From<T> for ArrayBuilderChunkGrid {
+    fn from(value: T) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ChunkGrid(ChunkGrid::new(value)))
+    }
+}
+
 impl From<Arc<dyn ChunkGridTraits>> for ArrayBuilderChunkGrid {
     fn from(value: Arc<dyn ChunkGridTraits>) -> Self {
         Self(ArrayBuilderChunkGridImpl::ChunkGrid(value.into()))
@@ -111,8 +117,28 @@ impl<const N: usize> From<[u64; N]> for ArrayBuilderChunkGrid {
     }
 }
 
+impl<const N: usize> From<&[u64; N]> for ArrayBuilderChunkGrid {
+    fn from(chunk_shape: &[u64; N]) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape.to_vec()))
+    }
+}
+
+impl From<&[u64]> for ArrayBuilderChunkGrid {
+    fn from(chunk_shape: &[u64]) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape.to_vec()))
+    }
+}
+
 impl<const N: usize> From<[NonZeroU64; N]> for ArrayBuilderChunkGrid {
     fn from(chunk_shape: [NonZeroU64; N]) -> Self {
+        Self(ArrayBuilderChunkGridImpl::ChunkShape(
+            chunk_shape.to_vec().into(),
+        ))
+    }
+}
+
+impl<const N: usize> From<&[NonZeroU64; N]> for ArrayBuilderChunkGrid {
+    fn from(chunk_shape: &[NonZeroU64; N]) -> Self {
         Self(ArrayBuilderChunkGridImpl::ChunkShape(
             chunk_shape.to_vec().into(),
         ))

--- a/zarrs/src/array/array_builder/array_builder_data_type.rs
+++ b/zarrs/src/array/array_builder/array_builder_data_type.rs
@@ -1,0 +1,61 @@
+use zarrs_metadata::v3::MetadataV3;
+
+use crate::{
+    array::{ArrayCreateError, DataType},
+    config::global_config,
+};
+
+/// An input that can be mapped to a data type.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ArrayBuilderDataType(ArrayBuilderDataTypeImpl);
+
+#[derive(Debug, PartialEq, Clone)]
+enum ArrayBuilderDataTypeImpl {
+    DataType(DataType),
+    Metadata(MetadataV3),
+    MetadataString(String),
+}
+
+impl ArrayBuilderDataType {
+    pub(crate) fn to_data_type(&self) -> Result<DataType, ArrayCreateError> {
+        match &self.0 {
+            ArrayBuilderDataTypeImpl::DataType(data_type) => Ok(data_type.clone()),
+            ArrayBuilderDataTypeImpl::Metadata(metadata) => {
+                DataType::from_metadata(metadata, global_config().data_type_aliases_v3())
+                    .map_err(ArrayCreateError::DataTypeCreateError)
+            }
+            ArrayBuilderDataTypeImpl::MetadataString(metadata) => {
+                // assume the metadata corresponds to a "name" if it cannot be parsed as MetadataV3
+                // this makes "float32" work for example, where normally r#""float32""# would be required
+                let metadata =
+                    MetadataV3::try_from(metadata.as_str()).unwrap_or(MetadataV3::new(metadata));
+                DataType::from_metadata(&metadata, global_config().data_type_aliases_v3())
+                    .map_err(ArrayCreateError::DataTypeCreateError)
+            }
+        }
+    }
+}
+
+impl From<DataType> for ArrayBuilderDataType {
+    fn from(value: DataType) -> Self {
+        Self(ArrayBuilderDataTypeImpl::DataType(value))
+    }
+}
+
+impl From<MetadataV3> for ArrayBuilderDataType {
+    fn from(value: MetadataV3) -> Self {
+        Self(ArrayBuilderDataTypeImpl::Metadata(value))
+    }
+}
+
+impl From<String> for ArrayBuilderDataType {
+    fn from(value: String) -> Self {
+        Self(ArrayBuilderDataTypeImpl::MetadataString(value))
+    }
+}
+
+impl From<&str> for ArrayBuilderDataType {
+    fn from(value: &str) -> Self {
+        Self(ArrayBuilderDataTypeImpl::MetadataString(value.to_string()))
+    }
+}

--- a/zarrs/src/array/array_builder/array_builder_fill_value.rs
+++ b/zarrs/src/array/array_builder/array_builder_fill_value.rs
@@ -1,0 +1,143 @@
+use half::{bf16, f16};
+use zarrs_data_type::FillValue;
+use zarrs_metadata::v3::{
+    FillValueMetadataV3, ZARR_NAN_BF16, ZARR_NAN_F16, ZARR_NAN_F32, ZARR_NAN_F64,
+};
+
+use crate::array::{ArrayCreateError, DataType};
+use serde_json::Number;
+
+/// An input that can be mapped to a fill value.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ArrayBuilderFillValue(ArrayBuilderFillValueImpl);
+
+#[derive(Debug, PartialEq, Clone)]
+enum ArrayBuilderFillValueImpl {
+    FillValue(FillValue),
+    Metadata(FillValueMetadataV3),
+}
+
+impl ArrayBuilderFillValue {
+    pub(crate) fn to_fill_value(
+        &self,
+        data_type: &DataType,
+    ) -> Result<FillValue, ArrayCreateError> {
+        match &self.0 {
+            ArrayBuilderFillValueImpl::Metadata(metadata) => {
+                Ok(data_type.fill_value_from_metadata(metadata)?)
+            }
+            ArrayBuilderFillValueImpl::FillValue(fill_value) => Ok(fill_value.clone()),
+        }
+    }
+}
+
+impl From<FillValue> for ArrayBuilderFillValue {
+    fn from(value: FillValue) -> Self {
+        Self(ArrayBuilderFillValueImpl::FillValue(value))
+    }
+}
+
+impl From<FillValueMetadataV3> for ArrayBuilderFillValue {
+    fn from(value: FillValueMetadataV3) -> Self {
+        Self(ArrayBuilderFillValueImpl::Metadata(value))
+    }
+}
+
+// TODO needs Rust specialisation, then everything below can be removed
+// impl<T: Into<FillValueMetadataV3>> From<T> for ArrayBuilderFillValue {
+//     fn from(value: T) -> Self {
+//         Self(ArrayBuilderFillValueImpl::MetadataV3(value.into()))
+//     }
+// }
+
+impl From<&[u8]> for ArrayBuilderFillValue {
+    fn from(value: &[u8]) -> Self {
+        Self(ArrayBuilderFillValueImpl::Metadata(
+            FillValueMetadataV3::Array(
+                value
+                    .iter()
+                    .map(|v| FillValueMetadataV3::from(*v))
+                    .collect(),
+            ),
+        ))
+    }
+}
+
+impl From<Vec<u8>> for ArrayBuilderFillValue {
+    fn from(value: Vec<u8>) -> Self {
+        Self(ArrayBuilderFillValueImpl::Metadata(
+            FillValueMetadataV3::Array(value.into_iter().map(FillValueMetadataV3::from).collect()),
+        ))
+    }
+}
+
+impl From<&str> for ArrayBuilderFillValue {
+    fn from(value: &str) -> Self {
+        Self(ArrayBuilderFillValueImpl::Metadata(
+            FillValueMetadataV3::String(value.to_string()),
+        ))
+    }
+}
+
+impl<const N: usize> From<[FillValueMetadataV3; N]> for ArrayBuilderFillValue {
+    fn from(value: [FillValueMetadataV3; N]) -> Self {
+        Self(ArrayBuilderFillValueImpl::Metadata(
+            FillValueMetadataV3::Array(value.to_vec()),
+        ))
+    }
+}
+
+macro_rules! impl_from_for_int_fill_value_metadata_v3 {
+    ($($t:ty),*) => {
+        $(
+            impl From<$t> for ArrayBuilderFillValue {
+                fn from(value: $t) -> Self {
+                    Self(ArrayBuilderFillValueImpl::Metadata(FillValueMetadataV3::Number(Number::from(value))))
+                }
+            }
+        )*
+    };
+}
+
+impl_from_for_int_fill_value_metadata_v3!(u8, u16, u32, u64, i8, i16, i32, i64);
+
+macro_rules! impl_from_for_float_fill_value_metadata_v3 {
+    ($type:ty, $nan_value:expr, $value_conversion:expr) => {
+        impl From<$type> for ArrayBuilderFillValue {
+            fn from(value: $type) -> Self {
+                Self(ArrayBuilderFillValueImpl::Metadata(
+                    if value.is_infinite() && value.is_sign_positive() {
+                        FillValueMetadataV3::String("Infinity".to_string())
+                    } else if value.is_infinite() && value.is_sign_negative() {
+                        FillValueMetadataV3::String("-Infinity".to_string())
+                    } else if value.to_bits() == $nan_value.to_bits() {
+                        FillValueMetadataV3::String("NaN".to_string())
+                    } else if value.is_nan() {
+                        FillValueMetadataV3::String(bytes_to_hex_string(&value.to_be_bytes()))
+                    } else {
+                        FillValueMetadataV3::Number(
+                            Number::from_f64($value_conversion(value))
+                                .expect("already checked finite"),
+                        )
+                    },
+                ))
+            }
+        }
+    };
+}
+
+impl_from_for_float_fill_value_metadata_v3!(bf16, ZARR_NAN_BF16, f64::from);
+impl_from_for_float_fill_value_metadata_v3!(f16, ZARR_NAN_F16, f64::from);
+impl_from_for_float_fill_value_metadata_v3!(f32, ZARR_NAN_F32, f64::from);
+impl_from_for_float_fill_value_metadata_v3!(f64, ZARR_NAN_F64, |v| v);
+
+fn bytes_to_hex_string(v: &[u8]) -> String {
+    let mut string = String::with_capacity(2 + v.len() * 2);
+    string.push('0');
+    string.push('x');
+    for byte in v {
+        string.push(char::from_digit((byte / 16).into(), 16).unwrap());
+        string.push(char::from_digit((byte % 16).into(), 16).unwrap());
+    }
+    string
+}

--- a/zarrs/src/array/array_builder/array_builder_fill_value.rs
+++ b/zarrs/src/array/array_builder/array_builder_fill_value.rs
@@ -63,10 +63,26 @@ impl From<&[u8]> for ArrayBuilderFillValue {
     }
 }
 
+// impl<const N: usize> From<[u8; N]> for ArrayBuilderFillValue {
+//     fn from(value: [u8; N]) -> Self {
+//         Self(ArrayBuilderFillValueImpl::Metadata(
+//             FillValueMetadataV3::from(value.as_slice()),
+//         ))
+//     }
+// }
+
+// impl<const N: usize> From<&[u8; N]> for ArrayBuilderFillValue {
+//     fn from(value: &[u8; N]) -> Self {
+//         Self(ArrayBuilderFillValueImpl::Metadata(
+//             FillValueMetadataV3::from(value.as_slice()),
+//         ))
+//     }
+// }
+
 impl From<Vec<u8>> for ArrayBuilderFillValue {
     fn from(value: Vec<u8>) -> Self {
         Self(ArrayBuilderFillValueImpl::Metadata(
-            FillValueMetadataV3::Array(value.into_iter().map(FillValueMetadataV3::from).collect()),
+            FillValueMetadataV3::from(value.as_slice()),
         ))
     }
 }

--- a/zarrs/src/array/array_builder/array_builder_fill_value.rs
+++ b/zarrs/src/array/array_builder/array_builder_fill_value.rs
@@ -63,26 +63,10 @@ impl From<&[u8]> for ArrayBuilderFillValue {
     }
 }
 
-// impl<const N: usize> From<[u8; N]> for ArrayBuilderFillValue {
-//     fn from(value: [u8; N]) -> Self {
-//         Self(ArrayBuilderFillValueImpl::Metadata(
-//             FillValueMetadataV3::from(value.as_slice()),
-//         ))
-//     }
-// }
-
-// impl<const N: usize> From<&[u8; N]> for ArrayBuilderFillValue {
-//     fn from(value: &[u8; N]) -> Self {
-//         Self(ArrayBuilderFillValueImpl::Metadata(
-//             FillValueMetadataV3::from(value.as_slice()),
-//         ))
-//     }
-// }
-
 impl From<Vec<u8>> for ArrayBuilderFillValue {
     fn from(value: Vec<u8>) -> Self {
         Self(ArrayBuilderFillValueImpl::Metadata(
-            FillValueMetadataV3::from(value.as_slice()),
+            FillValueMetadataV3::Array(value.into_iter().map(FillValueMetadataV3::from).collect()),
         ))
     }
 }
@@ -97,6 +81,14 @@ impl From<&str> for ArrayBuilderFillValue {
 
 impl<const N: usize> From<[FillValueMetadataV3; N]> for ArrayBuilderFillValue {
     fn from(value: [FillValueMetadataV3; N]) -> Self {
+        Self(ArrayBuilderFillValueImpl::Metadata(
+            FillValueMetadataV3::Array(value.to_vec()),
+        ))
+    }
+}
+
+impl<const N: usize> From<&[FillValueMetadataV3; N]> for ArrayBuilderFillValue {
+    fn from(value: &[FillValueMetadataV3; N]) -> Self {
         Self(ArrayBuilderFillValueImpl::Metadata(
             FillValueMetadataV3::Array(value.to_vec()),
         ))

--- a/zarrs/src/array/array_dlpack_ext.rs
+++ b/zarrs/src/array/array_dlpack_ext.rs
@@ -145,21 +145,16 @@ mod tests {
     use zarrs_storage::store::MemoryStore;
 
     use crate::{
-        array::{codec::CodecOptions, ArrayBuilder, ArrayDlPackExt, DataType, FillValue},
+        array::{codec::CodecOptions, ArrayBuilder, ArrayDlPackExt, DataType},
         array_subset::ArraySubset,
     };
 
     #[test]
     fn array_dlpack_ext_sync() {
         let store = MemoryStore::new();
-        let array = ArrayBuilder::new(
-            vec![4, 4],
-            DataType::Float32,
-            vec![2, 2].try_into().unwrap(),
-            FillValue::from(-1.0f32),
-        )
-        .build(store.into(), "/")
-        .unwrap();
+        let array = ArrayBuilder::new(vec![4, 4], DataType::Float32, vec![2, 2], -1.0f32)
+            .build(store.into(), "/")
+            .unwrap();
         array
             .store_chunk_elements::<f32>(&[0, 0], &[0.0, 1.0, 2.0, 3.0])
             .unwrap();

--- a/zarrs/src/array/array_errors.rs
+++ b/zarrs/src/array/array_errors.rs
@@ -29,6 +29,15 @@ pub enum ArrayCreateError {
     /// Invalid fill value.
     #[error(transparent)]
     InvalidFillValue(#[from] DataTypeFillValueError),
+    // /// Unparseable metadata.
+    // #[error("unparseable metadata: {_0:?}")]
+    // UnparseableMetadata(String),
+    // /// Invalid data type metadata.
+    // #[error("unsupported data type metadata: {_0:?}")]
+    // UnsupportedDataTypeMetadata(MetadataV3),
+    // /// Invalid chunk grid metadata.
+    // #[error("unsupported chunk grid metadata: {_0:?}")]
+    // UnsupportedChunkGridMetadata(MetadataV3),
     /// Invalid fill value metadata.
     #[error(transparent)]
     InvalidFillValueMetadata(#[from] DataTypeFillValueMetadataError),

--- a/zarrs/src/array/array_representation.rs
+++ b/zarrs/src/array/array_representation.rs
@@ -107,8 +107,9 @@ where
     pub fn new(
         array_shape: Vec<TDim>,
         data_type: DataType,
-        fill_value: FillValue,
+        fill_value: impl Into<FillValue>,
     ) -> Result<Self, DataTypeFillValueError> {
+        let fill_value = fill_value.into();
         match data_type.size() {
             DataTypeSize::Fixed(size) => {
                 if size == fill_value.size() {
@@ -137,8 +138,9 @@ where
     pub unsafe fn new_unchecked(
         array_shape: Vec<TDim>,
         data_type: DataType,
-        fill_value: FillValue,
+        fill_value: impl Into<FillValue>,
     ) -> Self {
+        let fill_value = fill_value.into();
         if let Some(data_type_size) = data_type.fixed_size() {
             debug_assert_eq!(data_type_size, fill_value.size());
         }

--- a/zarrs/src/array/array_sync_sharded_readable_ext.rs
+++ b/zarrs/src/array/array_sync_sharded_readable_ext.rs
@@ -687,7 +687,7 @@ mod tests {
     use crate::{
         array::{
             codec::{array_to_bytes::sharding::ShardingCodecBuilder, TransposeCodec},
-            ArrayBuilder, DataType, FillValue,
+            ArrayBuilder, DataType,
         },
         array_subset::ArraySubset,
         storage::{
@@ -704,8 +704,8 @@ mod tests {
         let mut builder = ArrayBuilder::new(
             vec![8, 8], // array shape
             DataType::UInt16,
-            vec![4, 4].try_into()?, // regular chunk shape
-            FillValue::from(0u16),
+            vec![4, 4], // regular chunk shape
+            0u16,
         );
         if sharded {
             builder.array_to_bytes_codec(Arc::new(
@@ -881,8 +881,8 @@ mod tests {
         let mut builder = ArrayBuilder::new(
             vec![16, 16, 9], // array shape
             DataType::UInt32,
-            vec![8, 4, 3].try_into()?, // regular chunk shape
-            FillValue::from(0u32),
+            vec![8, 4, 3], // regular chunk shape
+            0u32,
         );
         builder.array_to_array_codecs(vec![Arc::new(TransposeCodec::new(TransposeOrder::new(
             &[1, 0, 2],

--- a/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
@@ -365,7 +365,7 @@ mod tests {
         array::{
             codec::CodecOptions, ArrayBuilder, ArrayChunkCacheExt, ChunkCacheDecodedLruChunkLimit,
             ChunkCacheDecodedLruSizeLimit, ChunkCacheEncodedLruChunkLimit,
-            ChunkCacheEncodedLruSizeLimit, ChunkCacheType, DataType, FillValue,
+            ChunkCacheEncodedLruSizeLimit, ChunkCacheType, DataType,
         },
         array_subset::ArraySubset,
         storage::{
@@ -383,8 +383,8 @@ mod tests {
         let builder = ArrayBuilder::new(
             vec![8, 8], // array shape
             DataType::UInt8,
-            vec![4, 4].try_into().unwrap(), // regular chunk shape
-            FillValue::from(0u8),
+            vec![4, 4], // regular chunk shape
+            0u8,
         );
         let array = builder.build(store.clone(), "/").unwrap();
 

--- a/zarrs/src/array/codec/array_to_array/bitround.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround.rs
@@ -307,12 +307,9 @@ mod tests {
     fn codec_bitround_float() {
         // 1 sign bit, 8 exponent, 3 mantissa
         const JSON: &'static str = r#"{ "keepbits": 3 }"#;
-        let chunk_representation = ChunkRepresentation::new(
-            vec![NonZeroU64::new(4).unwrap()],
-            DataType::Float32,
-            0.0f32.into(),
-        )
-        .unwrap();
+        let chunk_representation =
+            ChunkRepresentation::new(vec![NonZeroU64::new(4).unwrap()], DataType::Float32, 0.0f32)
+                .unwrap();
         let elements: Vec<f32> = vec![
             //                         |
             0.0,
@@ -351,12 +348,9 @@ mod tests {
     #[test]
     fn codec_bitround_uint() {
         const JSON: &'static str = r#"{ "keepbits": 3 }"#;
-        let chunk_representation = ChunkRepresentation::new(
-            vec![NonZeroU64::new(4).unwrap()],
-            DataType::UInt32,
-            0u32.into(),
-        )
-        .unwrap();
+        let chunk_representation =
+            ChunkRepresentation::new(vec![NonZeroU64::new(4).unwrap()], DataType::UInt32, 0u32)
+                .unwrap();
         let elements: Vec<u32> = vec![0, 1024, 1280, 1664, 1685, 123145182, 4294967295];
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes = ArrayBytes::from(bytes);
@@ -389,12 +383,9 @@ mod tests {
     #[test]
     fn codec_bitround_uint8() {
         const JSON: &'static str = r#"{ "keepbits": 3 }"#;
-        let chunk_representation = ChunkRepresentation::new(
-            vec![NonZeroU64::new(4).unwrap()],
-            DataType::UInt8,
-            0u8.into(),
-        )
-        .unwrap();
+        let chunk_representation =
+            ChunkRepresentation::new(vec![NonZeroU64::new(4).unwrap()], DataType::UInt8, 0u8)
+                .unwrap();
         let elements: Vec<u32> = vec![0, 3, 7, 15, 17, 54, 89, 128, 255];
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes = ArrayBytes::from(bytes);
@@ -431,7 +422,7 @@ mod tests {
         let chunk_representation = ChunkRepresentation::new(
             vec![(elements.len() as u64).try_into().unwrap()],
             DataType::Float32,
-            0.0f32.into(),
+            0.0f32,
         )
         .unwrap();
         let bytes: ArrayBytes = crate::array::transmute_to_bytes_vec(elements).into();
@@ -490,7 +481,7 @@ mod tests {
         let chunk_representation = ChunkRepresentation::new(
             vec![(elements.len() as u64).try_into().unwrap()],
             DataType::Float32,
-            0.0f32.into(),
+            0.0f32,
         )
         .unwrap();
         let bytes = crate::array::transmute_to_bytes_vec(elements);

--- a/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
+++ b/zarrs/src/array/codec/array_to_array/fixedscaleoffset.rs
@@ -89,12 +89,9 @@ mod tests {
         // 1 sign bit, 8 exponent, 3 mantissa
         const JSON: &'static str =
             r#"{ "offset": 1000, "scale": 10, "dtype": "f8", "astype": "u1" }"#;
-        let chunk_representation = ChunkRepresentation::new(
-            vec![NonZeroU64::new(4).unwrap()],
-            DataType::Float64,
-            0.0f64.into(),
-        )
-        .unwrap();
+        let chunk_representation =
+            ChunkRepresentation::new(vec![NonZeroU64::new(4).unwrap()], DataType::Float64, 0.0f64)
+                .unwrap();
         let elements: Vec<f64> = vec![
             1000.,
             1000.11111111,

--- a/zarrs/src/array/codec/array_to_array/squeeze.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze.rs
@@ -75,7 +75,11 @@ mod tests {
 
     use super::*;
 
-    fn codec_squeeze_round_trip_impl(json: &str, data_type: DataType, fill_value: FillValue) {
+    fn codec_squeeze_round_trip_impl(
+        json: &str,
+        data_type: DataType,
+        fill_value: impl Into<FillValue>,
+    ) {
         let chunk_representation = ChunkRepresentation::new(
             vec![
                 NonZeroU64::new(2).unwrap(),
@@ -132,7 +136,7 @@ mod tests {
     #[test]
     fn codec_squeeze_round_trip_array1() {
         const JSON: &str = r#"{}"#;
-        codec_squeeze_round_trip_impl(JSON, DataType::UInt8, FillValue::from(0u8));
+        codec_squeeze_round_trip_impl(JSON, DataType::UInt8, 0u8);
     }
 
     #[test]
@@ -149,7 +153,7 @@ mod tests {
                 NonZeroU64::new(1).unwrap(),
             ],
             DataType::Float32,
-            0.0f32.into(),
+            0.0f32,
         )
         .unwrap();
         let bytes = crate::array::transmute_to_bytes_vec(elements);

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -165,7 +165,11 @@ mod tests {
 
     use super::*;
 
-    fn codec_transpose_round_trip_impl(json: &str, data_type: DataType, fill_value: FillValue) {
+    fn codec_transpose_round_trip_impl(
+        json: &str,
+        data_type: DataType,
+        fill_value: impl Into<FillValue>,
+    ) {
         let chunk_representation = ChunkRepresentation::new(
             vec![
                 NonZeroU64::new(2).unwrap(),
@@ -213,7 +217,7 @@ mod tests {
         const JSON: &str = r#"{
             "order": [0, 2, 1]
         }"#;
-        codec_transpose_round_trip_impl(JSON, DataType::UInt8, FillValue::from(0u8));
+        codec_transpose_round_trip_impl(JSON, DataType::UInt8, 0u8);
     }
 
     #[test]
@@ -221,7 +225,7 @@ mod tests {
         const JSON: &str = r#"{
             "order": [2, 1, 0]
         }"#;
-        codec_transpose_round_trip_impl(JSON, DataType::UInt16, FillValue::from(0u16));
+        codec_transpose_round_trip_impl(JSON, DataType::UInt16, 0u16);
     }
 
     #[test]
@@ -232,7 +236,7 @@ mod tests {
         let chunk_representation = ChunkRepresentation::new(
             vec![NonZeroU64::new(4).unwrap(), NonZeroU64::new(4).unwrap()],
             DataType::Float32,
-            0.0f32.into(),
+            0.0f32,
         )
         .unwrap();
         let bytes = crate::array::transmute_to_bytes_vec(elements);
@@ -291,7 +295,7 @@ mod tests {
         let chunk_representation = ChunkRepresentation::new(
             vec![NonZeroU64::new(4).unwrap(), NonZeroU64::new(4).unwrap()],
             DataType::Float32,
-            0.0f32.into(),
+            0.0f32,
         )
         .unwrap();
         let bytes = crate::array::transmute_to_bytes_vec(elements);

--- a/zarrs/src/array/codec/array_to_bytes/bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes.rs
@@ -200,7 +200,7 @@ mod tests {
     fn codec_bytes_round_trip_impl(
         endianness: Option<Endianness>,
         data_type: DataType,
-        fill_value: FillValue,
+        fill_value: impl Into<FillValue>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let chunk_shape = vec![NonZeroU64::new(10).unwrap(), NonZeroU64::new(10).unwrap()];
         let chunk_representation =
@@ -225,80 +225,38 @@ mod tests {
 
     #[test]
     fn codec_bytes_round_trip_f32() {
-        codec_bytes_round_trip_impl(
-            Some(Endianness::Big),
-            DataType::Float32,
-            FillValue::from(0.0f32),
-        )
-        .unwrap();
-        codec_bytes_round_trip_impl(
-            Some(Endianness::Little),
-            DataType::Float32,
-            FillValue::from(0.0f32),
-        )
-        .unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Big), DataType::Float32, 0.0f32).unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Little), DataType::Float32, 0.0f32).unwrap();
     }
 
     #[test]
     fn codec_bytes_round_trip_u32() {
-        codec_bytes_round_trip_impl(
-            Some(Endianness::Big),
-            DataType::UInt32,
-            FillValue::from(0u32),
-        )
-        .unwrap();
-        codec_bytes_round_trip_impl(
-            Some(Endianness::Little),
-            DataType::UInt32,
-            FillValue::from(0u32),
-        )
-        .unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Big), DataType::UInt32, 0u32).unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Little), DataType::UInt32, 0u32).unwrap();
     }
 
     #[test]
     fn codec_bytes_round_trip_u16() {
-        codec_bytes_round_trip_impl(
-            Some(Endianness::Big),
-            DataType::UInt16,
-            FillValue::from(0u16),
-        )
-        .unwrap();
-        codec_bytes_round_trip_impl(
-            Some(Endianness::Little),
-            DataType::UInt16,
-            FillValue::from(0u16),
-        )
-        .unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Big), DataType::UInt16, 0u16).unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Little), DataType::UInt16, 0u16).unwrap();
     }
 
     #[test]
     fn codec_bytes_round_trip_u8() {
-        codec_bytes_round_trip_impl(Some(Endianness::Big), DataType::UInt8, FillValue::from(0u8))
-            .unwrap();
-        codec_bytes_round_trip_impl(
-            Some(Endianness::Little),
-            DataType::UInt8,
-            FillValue::from(0u8),
-        )
-        .unwrap();
-        codec_bytes_round_trip_impl(None, DataType::UInt8, FillValue::from(0u8)).unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Big), DataType::UInt8, 0u8).unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Little), DataType::UInt8, 0u8).unwrap();
+        codec_bytes_round_trip_impl(None, DataType::UInt8, 0u8).unwrap();
     }
 
     #[test]
     fn codec_bytes_round_trip_i32() {
-        codec_bytes_round_trip_impl(Some(Endianness::Big), DataType::Int32, FillValue::from(0))
-            .unwrap();
-        codec_bytes_round_trip_impl(
-            Some(Endianness::Little),
-            DataType::Int32,
-            FillValue::from(0),
-        )
-        .unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Big), DataType::Int32, 0).unwrap();
+        codec_bytes_round_trip_impl(Some(Endianness::Little), DataType::Int32, 0).unwrap();
     }
 
     #[test]
     fn codec_bytes_round_trip_i32_endianness_none() {
-        assert!(codec_bytes_round_trip_impl(None, DataType::Int32, FillValue::from(0)).is_err());
+        assert!(codec_bytes_round_trip_impl(None, DataType::Int32, 0).is_err());
     }
 
     #[test]
@@ -306,13 +264,13 @@ mod tests {
         codec_bytes_round_trip_impl(
             Some(Endianness::Big),
             DataType::Complex64,
-            FillValue::from(num::complex::Complex32::new(0.0, 0.0)),
+            num::complex::Complex32::new(0.0, 0.0),
         )
         .unwrap();
         codec_bytes_round_trip_impl(
             Some(Endianness::Little),
             DataType::Complex64,
-            FillValue::from(num::complex::Complex32::new(0.0, 0.0)),
+            num::complex::Complex32::new(0.0, 0.0),
         )
         .unwrap();
     }
@@ -322,13 +280,13 @@ mod tests {
         codec_bytes_round_trip_impl(
             Some(Endianness::Big),
             DataType::Complex128,
-            FillValue::from(num::complex::Complex64::new(0.0, 0.0)),
+            num::complex::Complex64::new(0.0, 0.0),
         )
         .unwrap();
         codec_bytes_round_trip_impl(
             Some(Endianness::Little),
             DataType::Complex128,
-            FillValue::from(num::complex::Complex64::new(0.0, 0.0)),
+            num::complex::Complex64::new(0.0, 0.0),
         )
         .unwrap();
     }
@@ -337,8 +295,7 @@ mod tests {
     fn codec_bytes_partial_decode() {
         let chunk_shape: ChunkShape = vec![4, 4].try_into().unwrap();
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, FillValue::from(0u8))
-                .unwrap();
+            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, 0u8).unwrap();
         let elements: Vec<u8> = (0..chunk_representation.num_elements() as u8).collect();
         let bytes: ArrayBytes = elements.into();
 
@@ -381,8 +338,7 @@ mod tests {
     async fn codec_bytes_async_partial_decode() {
         let chunk_shape: ChunkShape = vec![4, 4].try_into().unwrap();
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, FillValue::from(0u8))
-                .unwrap();
+            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, 0u8).unwrap();
         let elements: Vec<u8> = (0..chunk_representation.num_elements() as u8).collect();
         let bytes: ArrayBytes = elements.into();
 

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -752,10 +752,7 @@ impl ArrayCodecTraits for CodecChain {
 mod tests {
     use std::num::NonZeroU64;
 
-    use crate::{
-        array::{DataType, FillValue},
-        array_subset::ArraySubset,
-    };
+    use crate::{array::DataType, array_subset::ArraySubset};
 
     use super::*;
 
@@ -935,8 +932,7 @@ mod tests {
             NonZeroU64::new(2).unwrap(),
         ];
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape, DataType::Float32, FillValue::from(0f32))
-                .unwrap();
+            ChunkRepresentation::new(chunk_shape, DataType::Float32, 0f32).unwrap();
         let elements: Vec<f32> = (0..chunk_representation.num_elements())
             .map(|i| i as f32)
             .collect();
@@ -961,8 +957,7 @@ mod tests {
             NonZeroU64::new(2).unwrap(),
         ];
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape, DataType::Float32, FillValue::from(0f32))
-                .unwrap();
+            ChunkRepresentation::new(chunk_shape, DataType::Float32, 0f32).unwrap();
         let elements: Vec<f32> = (0..chunk_representation.num_elements())
             .map(|i| i as f32)
             .collect();

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -231,7 +231,7 @@ mod tests {
         array::{
             codec::{ArrayToBytesCodecTraits, BytesCodec, CodecOptions},
             element::{Element, ElementOwned},
-            ArrayBytes, ChunkRepresentation, DataType, FillValue,
+            ArrayBytes, ChunkRepresentation, DataType,
         },
         array_subset::ArraySubset,
     };
@@ -270,7 +270,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::Bool;
-            let fill_value = FillValue::from(false);
+            let fill_value = false;
 
             let chunk_shape = vec![NonZeroU64::new(8).unwrap(), NonZeroU64::new(5).unwrap()];
             let chunk_representation =
@@ -334,7 +334,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::Float32;
-            let fill_value = FillValue::from(0.0f32);
+            let fill_value = 0.0f32;
 
             let chunk_shape = vec![NonZeroU64::new(8).unwrap(), NonZeroU64::new(5).unwrap()];
             let chunk_representation =
@@ -387,7 +387,7 @@ mod tests {
                             .unwrap(),
                     );
                     let data_type = DataType::Int16;
-                    let fill_value = FillValue::from(0i16);
+                    let fill_value = 0i16;
 
                     let chunk_shape =
                         vec![NonZeroU64::new(8).unwrap(), NonZeroU64::new(5).unwrap()];
@@ -431,7 +431,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::UInt2;
-            let fill_value = FillValue::from(0u8);
+            let fill_value = 0u8;
 
             let chunk_shape = vec![NonZeroU64::new(4).unwrap(), NonZeroU64::new(1).unwrap()];
             let chunk_representation =
@@ -469,7 +469,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::UInt4;
-            let fill_value = FillValue::from(0u8);
+            let fill_value = 0u8;
 
             let chunk_shape = vec![NonZeroU64::new(16).unwrap(), NonZeroU64::new(1).unwrap()];
             let chunk_representation =
@@ -507,7 +507,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::Int2;
-            let fill_value = FillValue::from(0i8);
+            let fill_value = 0i8;
 
             let chunk_shape = vec![NonZeroU64::new(4).unwrap(), NonZeroU64::new(1).unwrap()];
             let chunk_representation =
@@ -545,7 +545,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::Int4;
-            let fill_value = FillValue::from(0i8);
+            let fill_value = 0i8;
 
             let chunk_shape = vec![NonZeroU64::new(16).unwrap(), NonZeroU64::new(1).unwrap()];
             let chunk_representation =
@@ -583,7 +583,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::Float4E2M1FN;
-            let fill_value = FillValue::from(0u8);
+            let fill_value = 0u8;
 
             let chunk_shape = vec![NonZeroU64::new(16).unwrap(), NonZeroU64::new(1).unwrap()];
             let chunk_representation =
@@ -620,7 +620,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::Float6E2M3FN;
-            let fill_value = FillValue::from(0u8);
+            let fill_value = 0u8;
 
             let chunk_shape = vec![NonZeroU64::new(64).unwrap(), NonZeroU64::new(1).unwrap()];
             let chunk_representation =
@@ -657,7 +657,7 @@ mod tests {
         ] {
             let codec = Arc::new(super::PackBitsCodec::new(encoding, None, None).unwrap());
             let data_type = DataType::Float6E3M2FN;
-            let fill_value = FillValue::from(0u8);
+            let fill_value = 0u8;
 
             let chunk_shape = vec![NonZeroU64::new(64).unwrap(), NonZeroU64::new(1).unwrap()];
             let chunk_representation =

--- a/zarrs/src/array/codec/array_to_bytes/pcodec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec.rs
@@ -146,7 +146,7 @@ mod tests {
     fn codec_pcodec_round_trip_impl(
         codec: &PcodecCodec,
         data_type: DataType,
-        fill_value: FillValue,
+        fill_value: impl Into<FillValue>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let chunk_shape = vec![NonZeroU64::new(10).unwrap(), NonZeroU64::new(10).unwrap()];
         let chunk_representation =
@@ -176,7 +176,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::UInt16,
-            FillValue::from(0u16),
+            0u16,
         )
         .unwrap();
     }
@@ -187,7 +187,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::UInt32,
-            FillValue::from(0u32),
+            0u32,
         )
         .unwrap();
     }
@@ -198,7 +198,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::UInt64,
-            FillValue::from(0u64),
+            0u64,
         )
         .unwrap();
     }
@@ -209,7 +209,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::Int16,
-            FillValue::from(0i16),
+            0i16,
         )
         .unwrap();
     }
@@ -220,7 +220,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::Int32,
-            FillValue::from(0i32),
+            0i32,
         )
         .unwrap();
     }
@@ -231,7 +231,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::Int64,
-            FillValue::from(0i64),
+            0i64,
         )
         .unwrap();
     }
@@ -242,7 +242,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::Float16,
-            FillValue::from(half::f16::from_f32(0.0)),
+            half::f16::from_f32(0.0),
         )
         .unwrap();
     }
@@ -253,7 +253,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::Float32,
-            FillValue::from(0f32),
+            0f32,
         )
         .unwrap();
     }
@@ -264,7 +264,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::Float64,
-            FillValue::from(0f64),
+            0f64,
         )
         .unwrap();
     }
@@ -275,10 +275,10 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::ComplexFloat16,
-            FillValue::from(num::complex::Complex::<half::f16>::new(
+            num::complex::Complex::<half::f16>::new(
                 half::f16::from_f32(0f32),
                 half::f16::from_f32(0f32),
-            )),
+            ),
         )
         .unwrap();
     }
@@ -289,7 +289,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::ComplexFloat32,
-            FillValue::from(num::complex::Complex::<f32>::new(0f32, 0f32)),
+            num::complex::Complex::<f32>::new(0f32, 0f32),
         )
         .unwrap();
     }
@@ -300,7 +300,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::ComplexFloat64,
-            FillValue::from(num::complex::Complex::<f64>::new(0f64, 0f64)),
+            num::complex::Complex::<f64>::new(0f64, 0f64),
         )
         .unwrap();
     }
@@ -311,7 +311,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::Complex64,
-            FillValue::from(num::complex::Complex32::new(0f32, 0f32)),
+            num::complex::Complex32::new(0f32, 0f32),
         )
         .unwrap();
     }
@@ -322,7 +322,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::Complex128,
-            FillValue::from(num::complex::Complex64::new(0f64, 0f64)),
+            num::complex::Complex64::new(0f64, 0f64),
         )
         .unwrap();
     }
@@ -333,7 +333,7 @@ mod tests {
             &PcodecCodec::new_with_configuration(&serde_json::from_str(JSON_VALID).unwrap())
                 .unwrap(),
             DataType::UInt8,
-            FillValue::from(0u8),
+            0u8,
         )
         .is_err());
     }
@@ -341,12 +341,8 @@ mod tests {
     #[test]
     fn codec_pcodec_partial_decode() {
         let chunk_shape: ChunkShape = vec![4, 4].try_into().unwrap();
-        let chunk_representation = ChunkRepresentation::new(
-            chunk_shape.to_vec(),
-            DataType::UInt32,
-            FillValue::from(0u32),
-        )
-        .unwrap();
+        let chunk_representation =
+            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt32, 0u32).unwrap();
         let elements: Vec<u32> = (0..chunk_representation.num_elements() as u32).collect();
         let bytes = transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
@@ -392,12 +388,8 @@ mod tests {
     #[tokio::test]
     async fn codec_pcodec_async_partial_decode() {
         let chunk_shape: ChunkShape = vec![4, 4].try_into().unwrap();
-        let chunk_representation = ChunkRepresentation::new(
-            chunk_shape.to_vec(),
-            DataType::UInt32,
-            FillValue::from(0u32),
-        )
-        .unwrap();
+        let chunk_representation =
+            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt32, 0u32).unwrap();
         let elements: Vec<u32> = (0..chunk_representation.num_elements() as u32).collect();
         let bytes = transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -76,7 +76,7 @@ use crate::{
             ArrayToBytesCodecTraits, BytesPartialDecoderTraits, Codec, CodecError, CodecOptions,
             CodecPlugin,
         },
-        BytesRepresentation, ChunkRepresentation, ChunkShape, CodecChain, DataType, FillValue,
+        BytesRepresentation, ChunkRepresentation, ChunkShape, CodecChain, DataType,
     },
     byte_range::ByteRange,
     metadata::v3::MetadataV3,
@@ -125,7 +125,7 @@ fn sharding_index_decoded_representation(chunks_per_shard: &[NonZeroU64]) -> Chu
     let mut index_shape = Vec::with_capacity(chunks_per_shard.len() + 1);
     index_shape.extend(chunks_per_shard);
     index_shape.push(unsafe { NonZeroU64::new_unchecked(2) });
-    ChunkRepresentation::new(index_shape, DataType::UInt64, FillValue::from(u64::MAX)).unwrap()
+    ChunkRepresentation::new(index_shape, DataType::UInt64, u64::MAX).unwrap()
 }
 
 fn compute_index_encoded_size(
@@ -337,7 +337,7 @@ mod tests {
         let chunk_representation = ChunkRepresentation::new(
             ChunkShape::try_from(vec![4, 4]).unwrap().into(),
             DataType::UInt16,
-            FillValue::from(0u16),
+            0u16,
         )
         .unwrap();
         let elements: Vec<u16> = if all_fill_value {
@@ -432,7 +432,7 @@ mod tests {
         let chunk_representation = ChunkRepresentation::new(
             ChunkShape::try_from(vec![4, 4]).unwrap().into(),
             DataType::UInt16,
-            FillValue::from(0u16),
+            0u16,
         )
         .unwrap();
         let elements: Vec<u16> = if all_fill_value {
@@ -497,8 +497,7 @@ mod tests {
     ) {
         let chunk_shape: ChunkShape = vec![4, 4].try_into().unwrap();
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, FillValue::from(0u8))
-                .unwrap();
+            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, 0u8).unwrap();
         let elements: Vec<u8> = if all_fill_value {
             vec![0; chunk_representation.num_elements() as usize]
         } else {
@@ -581,8 +580,7 @@ mod tests {
     ) {
         let chunk_shape: ChunkShape = vec![4, 4].try_into().unwrap();
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, FillValue::from(0u8))
-                .unwrap();
+            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, 0u8).unwrap();
         let elements: Vec<u8> = if all_fill_value {
             vec![0; chunk_representation.num_elements() as usize]
         } else {
@@ -664,12 +662,8 @@ mod tests {
     #[test]
     fn codec_sharding_partial_decode2() {
         let chunk_shape: ChunkShape = vec![2, 4, 4].try_into().unwrap();
-        let chunk_representation = ChunkRepresentation::new(
-            chunk_shape.to_vec(),
-            DataType::UInt16,
-            FillValue::from(0u16),
-        )
-        .unwrap();
+        let chunk_representation =
+            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt16, 0u16).unwrap();
         let elements: Vec<u16> = (0..chunk_representation.num_elements() as u16).collect();
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
@@ -711,8 +705,7 @@ mod tests {
     fn codec_sharding_partial_decode3() {
         let chunk_shape: ChunkShape = vec![4, 4].try_into().unwrap();
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, FillValue::from(0u8))
-                .unwrap();
+            ChunkRepresentation::new(chunk_shape.to_vec(), DataType::UInt8, 0u8).unwrap();
         let elements: Vec<u8> = (0..chunk_representation.num_elements() as u8).collect();
         let bytes: ArrayBytes = elements.into();
 

--- a/zarrs/src/array/codec/array_to_bytes/vlen.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen.rs
@@ -105,8 +105,7 @@ use zarrs_metadata_ext::codec::vlen::VlenIndexLocation;
 
 use crate::array::{
     codec::{ArrayToBytesCodecTraits, CodecError, CodecOptions, InvalidBytesLengthError},
-    convert_from_bytes_slice, ChunkRepresentation, CodecChain, DataType, Endianness, FillValue,
-    RawBytes,
+    convert_from_bytes_slice, ChunkRepresentation, CodecChain, DataType, Endianness, RawBytes,
 };
 pub use zarrs_metadata_ext::codec::vlen::{
     VlenCodecConfiguration, VlenCodecConfigurationV0, VlenCodecConfigurationV0_1,
@@ -217,7 +216,7 @@ fn get_vlen_bytes_and_offsets(
                     ChunkRepresentation::new_unchecked(
                         vec![data_len_expected],
                         DataType::UInt8,
-                        FillValue::from(0u8),
+                        0u8,
                     )
                 },
                 options,

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_codec.rs
@@ -11,7 +11,7 @@ use crate::{
             RecommendedConcurrency,
         },
         transmute_to_bytes_vec, ArrayBytes, BytesRepresentation, ChunkRepresentation, CodecChain,
-        DataType, DataTypeSize, Endianness, FillValue, RawBytes, RawBytesOffsets,
+        DataType, DataTypeSize, Endianness, RawBytes, RawBytesOffsets,
     },
     plugin::PluginCreateError,
 };
@@ -189,7 +189,7 @@ impl ArrayToBytesCodecTraits for VlenCodec {
             //     let index_chunk_rep = ChunkRepresentation::new(
             //         vec![num_offsets],
             //         DataType::UInt8,
-            //         FillValue::from(0u8),
+            //         0u8,
             //     )
             //     .unwrap();
             //     self.index_codecs
@@ -209,7 +209,7 @@ impl ArrayToBytesCodecTraits for VlenCodec {
             //     let index_chunk_rep = ChunkRepresentation::new(
             //         vec![num_offsets],
             //         DataType::UInt16,
-            //         FillValue::from(0u16),
+            //         0u16,
             //     )
             //     .unwrap();
             //     self.index_codecs
@@ -226,12 +226,8 @@ impl ArrayToBytesCodecTraits for VlenCodec {
                         )
                     })?;
                 let offsets = transmute_to_bytes_vec(offsets);
-                let index_chunk_rep = ChunkRepresentation::new(
-                    vec![num_offsets],
-                    DataType::UInt32,
-                    FillValue::from(0u32),
-                )
-                .unwrap();
+                let index_chunk_rep =
+                    ChunkRepresentation::new(vec![num_offsets], DataType::UInt32, 0u32).unwrap();
                 self.index_codecs
                     .encode(offsets.into(), &index_chunk_rep, options)?
             }
@@ -241,12 +237,8 @@ impl ArrayToBytesCodecTraits for VlenCodec {
                     .map(|offset| u64::try_from(*offset).unwrap())
                     .collect::<Vec<u64>>();
                 let offsets = transmute_to_bytes_vec(offsets);
-                let index_chunk_rep = ChunkRepresentation::new(
-                    vec![num_offsets],
-                    DataType::UInt64,
-                    FillValue::from(0u64),
-                )
-                .unwrap();
+                let index_chunk_rep =
+                    ChunkRepresentation::new(vec![num_offsets], DataType::UInt64, 0u64).unwrap();
                 self.index_codecs
                     .encode(offsets.into(), &index_chunk_rep, options)?
             }
@@ -256,8 +248,7 @@ impl ArrayToBytesCodecTraits for VlenCodec {
         let data = if let Ok(data_len) = NonZeroU64::try_from(data.len() as u64) {
             self.data_codecs.encode(
                 data.into(),
-                &ChunkRepresentation::new(vec![data_len], DataType::UInt8, FillValue::from(0u8))
-                    .unwrap(),
+                &ChunkRepresentation::new(vec![data_len], DataType::UInt8, 0u8).unwrap(),
                 options,
             )?
         } else {
@@ -293,16 +284,16 @@ impl ArrayToBytesCodecTraits for VlenCodec {
         let index_shape = vec![NonZeroU64::try_from(num_elements as u64 + 1).unwrap()];
         let index_chunk_rep = match self.index_data_type {
             // VlenIndexDataType::UInt8 => {
-            //     ChunkRepresentation::new(index_shape, DataType::UInt8, FillValue::from(0u8))
+            //     ChunkRepresentation::new(index_shape, DataType::UInt8, 0u8)
             // }
             // VlenIndexDataType::UInt16 => {
-            //     ChunkRepresentation::new(index_shape, DataType::UInt16, FillValue::from(0u16))
+            //     ChunkRepresentation::new(index_shape, DataType::UInt16, 0u16)
             // }
             VlenIndexDataType::UInt32 => {
-                ChunkRepresentation::new(index_shape, DataType::UInt32, FillValue::from(0u32))
+                ChunkRepresentation::new(index_shape, DataType::UInt32, 0u32)
             }
             VlenIndexDataType::UInt64 => {
-                ChunkRepresentation::new(index_shape, DataType::UInt64, FillValue::from(0u64))
+                ChunkRepresentation::new(index_shape, DataType::UInt64, 0u64)
             }
         }
         .unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
@@ -62,16 +62,16 @@ fn decode_vlen_bytes<'a>(
         let index_shape = vec![unsafe { NonZeroU64::new_unchecked(1 + num_elements as u64) }];
         let index_chunk_representation = match index_data_type {
             // VlenIndexDataType::UInt8 => {
-            //     ChunkRepresentation::new(index_shape, DataType::UInt8, FillValue::from(0u8))
+            //     ChunkRepresentation::new(index_shape, DataType::UInt8, 0u8)
             // }
             // VlenIndexDataType::UInt16 => {
-            //     ChunkRepresentation::new(index_shape, DataType::UInt16, FillValue::from(0u16))
+            //     ChunkRepresentation::new(index_shape, DataType::UInt16, 0u16)
             // }
             VlenIndexDataType::UInt32 => {
-                ChunkRepresentation::new(index_shape, DataType::UInt32, FillValue::from(0u32))
+                ChunkRepresentation::new(index_shape, DataType::UInt32, 0u32)
             }
             VlenIndexDataType::UInt64 => {
-                ChunkRepresentation::new(index_shape, DataType::UInt64, FillValue::from(0u64))
+                ChunkRepresentation::new(index_shape, DataType::UInt64, 0u64)
             }
         }
         .expect("all data types/fill values are compatible");

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -509,7 +509,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_i8() {
         codec_zfp_round_trip::<i8>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Int8, 0i8.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Int8, 0i8).unwrap(),
             JSON_REVERSIBLE,
         );
         // codec_zfp_round_trip::<i8>(
@@ -522,7 +522,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_u8() {
         codec_zfp_round_trip::<u8>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::UInt8, 0u8.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::UInt8, 0u8).unwrap(),
             JSON_REVERSIBLE,
         );
         // codec_zfp_round_trip::<u8>(
@@ -535,7 +535,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_i16() {
         codec_zfp_round_trip::<i16>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Int16, 0i16.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Int16, 0i16).unwrap(),
             JSON_REVERSIBLE,
         );
         // codec_zfp_round_trip::<i16>(
@@ -548,7 +548,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_u16() {
         codec_zfp_round_trip::<u16>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::UInt16, 0u16.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::UInt16, 0u16).unwrap(),
             JSON_REVERSIBLE,
         );
         // codec_zfp_round_trip::<u16>(
@@ -561,7 +561,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_i32() {
         codec_zfp_round_trip::<i32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Int32, 0i32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Int32, 0i32).unwrap(),
             JSON_REVERSIBLE,
         );
         // codec_zfp_round_trip::<i32>(
@@ -574,7 +574,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_u32() {
         codec_zfp_round_trip::<u32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::UInt32, 0u32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::UInt32, 0u32).unwrap(),
             JSON_REVERSIBLE,
         );
         // codec_zfp_round_trip::<u32>(
@@ -587,7 +587,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_i64() {
         codec_zfp_round_trip::<i64>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Int64, 0i64.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Int64, 0i64).unwrap(),
             JSON_REVERSIBLE,
         );
         // codec_zfp_round_trip::<i64>(
@@ -600,11 +600,11 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_u64() {
         codec_zfp_round_trip::<u64>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::UInt64, 0u64.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::UInt64, 0u64).unwrap(),
             JSON_REVERSIBLE,
         );
         // codec_zfp_round_trip::<u64>(
-        //     &ChunkRepresentation::new(chunk_shape(), DataType::UInt64, 0u64.into()).unwrap(),
+        //     &ChunkRepresentation::new(chunk_shape(), DataType::UInt64, 0u64).unwrap(),
         //     &json_fixedprecision(64),
         // );
     }
@@ -613,19 +613,19 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_f32() {
         codec_zfp_round_trip::<f32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32).unwrap(),
             JSON_REVERSIBLE,
         );
         codec_zfp_round_trip::<f32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32).unwrap(),
             &json_fixedrate(2.5),
         );
         codec_zfp_round_trip::<f32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32).unwrap(),
             &json_fixedaccuracy(1.0),
         );
         codec_zfp_round_trip::<f32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32).unwrap(),
             &json_fixedprecision(13),
         );
     }
@@ -634,19 +634,19 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zfp_round_trip_f64() {
         codec_zfp_round_trip::<f64>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float64, 0.0f64.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float64, 0.0f64).unwrap(),
             JSON_REVERSIBLE,
         );
         codec_zfp_round_trip::<f64>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float64, 0.0f64.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float64, 0.0f64).unwrap(),
             &json_fixedrate(2.5),
         );
         codec_zfp_round_trip::<f64>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float64, 0.0f64.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float64, 0.0f64).unwrap(),
             &json_fixedaccuracy(1.0),
         );
         codec_zfp_round_trip::<f64>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float64, 0.0f64.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float64, 0.0f64).unwrap(),
             &json_fixedprecision(16),
         );
     }
@@ -660,7 +660,7 @@ mod tests {
             NonZeroU64::new(3).unwrap(),
         ];
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape, DataType::Float32, 0.0f32.into()).unwrap();
+            ChunkRepresentation::new(chunk_shape, DataType::Float32, 0.0f32).unwrap();
         let elements: Vec<f32> = (0..27).map(|i| i as f32).collect();
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
@@ -716,7 +716,7 @@ mod tests {
             NonZeroU64::new(3).unwrap(),
         ];
         let chunk_representation =
-            ChunkRepresentation::new(chunk_shape, DataType::Float32, 0.0f32.into()).unwrap();
+            ChunkRepresentation::new(chunk_shape, DataType::Float32, 0.0f32).unwrap();
         let elements: Vec<f32> = (0..27).map(|i| i as f32).collect();
         let bytes = crate::array::transmute_to_bytes_vec(elements);
         let bytes: ArrayBytes = bytes.into();
@@ -781,19 +781,19 @@ mod tests {
         };
 
         codec_zfp_round_trip::<f32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32).unwrap(),
             JSON_REVERSIBLE,
         );
         codec_zfp_round_trip::<f32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32).unwrap(),
             &json_fixedrate(2.5),
         );
         codec_zfp_round_trip::<f32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32).unwrap(),
             &json_fixedaccuracy(1.0),
         );
         codec_zfp_round_trip::<f32>(
-            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into()).unwrap(),
+            &ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32).unwrap(),
             &json_fixedprecision(13),
         );
     }

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
@@ -266,7 +266,7 @@ mod tests {
     use crate::{
         array::{
             codec::{BytesToBytesCodecTraits, CodecOptions},
-            ArrayRepresentation, BytesRepresentation, DataType, FillValue,
+            ArrayRepresentation, BytesRepresentation, DataType,
         },
         array_subset::ArraySubset,
         byte_range::ByteRange,
@@ -368,8 +368,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_blosc_partial_decode() {
         let array_representation =
-            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, FillValue::from(0u16))
-                .unwrap();
+            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, 0u16).unwrap();
         let data_type_size = array_representation.data_type().fixed_size().unwrap();
         let array_size = array_representation.num_elements_usize() * data_type_size;
         let bytes_representation = BytesRepresentation::FixedSize(array_size as u64);
@@ -415,8 +414,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     async fn codec_blosc_async_partial_decode() {
         let array_representation =
-            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, FillValue::from(0u16))
-                .unwrap();
+            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, 0u16).unwrap();
         let data_type_size = array_representation.data_type().fixed_size().unwrap();
         let array_size = array_representation.num_elements_usize() * data_type_size;
         let bytes_representation = BytesRepresentation::FixedSize(array_size as u64);

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
@@ -73,7 +73,7 @@ mod tests {
     use crate::{
         array::{
             codec::{BytesToBytesCodecTraits, CodecOptions},
-            ArrayRepresentation, BytesRepresentation, DataType, FillValue,
+            ArrayRepresentation, BytesRepresentation, DataType,
         },
         array_subset::ArraySubset,
         byte_range::ByteRange,
@@ -109,8 +109,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_bz2_partial_decode() {
         let array_representation =
-            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, FillValue::from(0u16))
-                .unwrap();
+            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, 0u16).unwrap();
         let data_type_size = array_representation.data_type().fixed_size().unwrap();
         let array_size = array_representation.num_elements_usize() * data_type_size;
         let bytes_representation = BytesRepresentation::FixedSize(array_size as u64);
@@ -155,8 +154,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     async fn codec_bz2_async_partial_decode() {
         let array_representation =
-            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, FillValue::from(0u16))
-                .unwrap();
+            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, 0u16).unwrap();
         let data_type_size = array_representation.data_type().fixed_size().unwrap();
         let array_size = array_representation.num_elements_usize() * data_type_size;
         let bytes_representation = BytesRepresentation::FixedSize(array_size as u64);

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
@@ -72,7 +72,7 @@ mod tests {
     use crate::{
         array::{
             codec::{BytesToBytesCodecTraits, CodecOptions},
-            ArrayRepresentation, BytesRepresentation, DataType, FillValue,
+            ArrayRepresentation, BytesRepresentation, DataType,
         },
         array_subset::ArraySubset,
         byte_range::ByteRange,
@@ -109,8 +109,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn codec_zlib_partial_decode() {
         let array_representation =
-            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, FillValue::from(0u16))
-                .unwrap();
+            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, 0u16).unwrap();
         let data_type_size = array_representation.data_type().fixed_size().unwrap();
         let array_size = array_representation.num_elements_usize() * data_type_size;
         let bytes_representation = BytesRepresentation::FixedSize(array_size as u64);
@@ -156,8 +155,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     async fn codec_zlib_async_partial_decode() {
         let array_representation =
-            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, FillValue::from(0u16))
-                .unwrap();
+            ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, 0u16).unwrap();
         let data_type_size = array_representation.data_type().fixed_size().unwrap();
         let array_size = array_representation.num_elements_usize() * data_type_size;
         let bytes_representation = BytesRepresentation::FixedSize(array_size as u64);

--- a/zarrs/src/array/data_type.rs
+++ b/zarrs/src/array/data_type.rs
@@ -2422,10 +2422,8 @@ mod tests {
 
     #[test]
     fn incompatible_fill_value() {
-        let err = DataTypeFillValueError::new(
-            zarrs_registry::data_type::BOOL.to_string(),
-            FillValue::from(1.0f32),
-        );
+        let err =
+            DataTypeFillValueError::new(zarrs_registry::data_type::BOOL.to_string(), 1.0f32.into());
         assert_eq!(
             err.to_string(),
             "incompatible fill value [0, 0, 128, 63] for data type bool"

--- a/zarrs/src/array/data_type.rs
+++ b/zarrs/src/array/data_type.rs
@@ -467,7 +467,9 @@ impl DataType {
                 }
                 _ => {}
             }
-        } else {
+        }
+
+        if metadata.configuration_is_none_or_empty() {
             // Data types with no configuration
             match metadata.name() {
                 zarrs_registry::data_type::BOOL => return Ok(Self::Bool),

--- a/zarrs/src/lib.rs
+++ b/zarrs/src/lib.rs
@@ -112,8 +112,8 @@
 //! let array = zarrs::array::ArrayBuilder::new(
 //!     vec![3, 4], // array shape
 //!     zarrs::array::DataType::Float32,
-//!     vec![2, 2].try_into()?, // regular chunk (shard) shape
-//!     zarrs::array::FillValue::from(0.0f32),
+//!     vec![2, 2], // regular chunk (shard) shape
+//!     0.0f32, // fill value
 //! )
 //! .array_to_bytes_codec(Arc::new(
 //!     // The sharding codec requires the sharding feature

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -461,7 +461,7 @@ impl Node {
 #[cfg(test)]
 mod tests {
     use crate::{
-        array::{ArrayBuilder, ArrayMetadataOptions, FillValue},
+        array::{ArrayBuilder, ArrayMetadataOptions},
         group::{GroupMetadata, GroupMetadataV3},
         storage::{store::MemoryStore, StoreKey, WritableStorageTraits},
     };
@@ -554,8 +554,8 @@ mod tests {
         let array = ArrayBuilder::new(
             vec![1, 2, 3],
             crate::array::DataType::Float32,
-            vec![1, 1, 1].try_into().unwrap(),
-            FillValue::from(0.0f32),
+            vec![1, 1, 1],
+            0.0f32,
         )
         .build(store.clone(), node_path)
         .unwrap();

--- a/zarrs/tests/array_async.rs
+++ b/zarrs/tests/array_async.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use zarrs::array::codec::array_to_bytes::vlen::VlenCodec;
 use zarrs::array::codec::{CodecOptions, TransposeCodec};
-use zarrs::array::{Array, ArrayBuilder, DataType, FillValue};
+use zarrs::array::{Array, ArrayBuilder, DataType};
 use zarrs::array_subset::ArraySubset;
 
 use object_store::memory::InMemory;

--- a/zarrs/tests/array_async.rs
+++ b/zarrs/tests/array_async.rs
@@ -20,8 +20,8 @@ async fn array_async_read(shard: bool) -> Result<(), Box<dyn std::error::Error>>
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::UInt8,
-        vec![2, 2].try_into().unwrap(), // regular chunk shape
-        FillValue::from(0u8),
+        vec![2, 2], // regular chunk shape
+        0u8,
     );
     builder.bytes_to_bytes_codecs(vec![]);
     // builder.storage_transformers(vec![].into());
@@ -279,8 +279,8 @@ async fn array_str_async_simple() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::String,
-        vec![2, 2].try_into().unwrap(), // regular chunk shape
-        FillValue::from(""),
+        vec![2, 2], // regular chunk shape
+        "",
     );
     builder.bytes_to_bytes_codecs(vec![
         #[cfg(feature = "gzip")]
@@ -299,8 +299,8 @@ async fn array_str_async_sharded_transpose() -> Result<(), Box<dyn std::error::E
         let mut builder = ArrayBuilder::new(
             vec![4, 4], // array shape
             DataType::String,
-            vec![2, 2].try_into().unwrap(), // regular chunk shape
-            FillValue::from(""),
+            vec![2, 2], // regular chunk shape
+            "",
         );
         builder.array_to_array_codecs(vec![Arc::new(TransposeCodec::new(
             TransposeOrder::new(&[1, 0]).unwrap(),

--- a/zarrs/tests/array_async_to_sync.rs
+++ b/zarrs/tests/array_async_to_sync.rs
@@ -8,7 +8,7 @@ use zarrs::storage::{
     ReadableWritableStorage,
 };
 use zarrs::{
-    array::{DataType, FillValue, ZARR_NAN_F32},
+    array::{DataType, ZARR_NAN_F32},
     array_subset::ArraySubset,
 };
 
@@ -47,15 +47,11 @@ fn array_read_and_write_async_storage_adapter() {
     assert_eq!(group.attributes().get("foo"), Some(&json!("bar")));
 
     // Create an array
-    let array = zarrs::array::ArrayBuilder::new(
-        vec![8, 8],
-        DataType::Float32,
-        vec![4, 4].try_into().unwrap(),
-        FillValue::from(ZARR_NAN_F32),
-    )
-    .dimension_names(["y", "x"].into())
-    .build(store.clone(), ARRAY_PATH)
-    .unwrap();
+    let array =
+        zarrs::array::ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![4, 4], ZARR_NAN_F32)
+            .dimension_names(["y", "x"].into())
+            .build(store.clone(), ARRAY_PATH)
+            .unwrap();
     array.store_metadata().unwrap();
     assert_eq!(array.shape(), &[8, 8]);
 

--- a/zarrs/tests/array_partial_encode.rs
+++ b/zarrs/tests/array_partial_encode.rs
@@ -9,7 +9,7 @@ use zarrs::{
             array_to_bytes::sharding::ShardingCodecBuilder, BytesToBytesCodecTraits,
             CodecOptionsBuilder,
         },
-        ArrayBuilder, DataType, FillValue,
+        ArrayBuilder, DataType,
     },
     array_subset::ArraySubset,
 };
@@ -46,8 +46,8 @@ fn array_partial_encode_sharding(
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::UInt16,
-        vec![2, 2].try_into().unwrap(), // regular chunk shape
-        FillValue::from(0u16),
+        vec![2, 2], // regular chunk shape
+        0u16,
     );
     builder
         .array_to_bytes_codec(Arc::new(

--- a/zarrs/tests/array_sync.rs
+++ b/zarrs/tests/array_sync.rs
@@ -107,8 +107,8 @@ fn array_sync_read_uncompressed() -> Result<(), Box<dyn std::error::Error>> {
     let array = ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::UInt8,
-        vec![2, 2].try_into().unwrap(), // regular chunk shape
-        FillValue::from(0u8),
+        vec![2, 2], // regular chunk shape
+        0u8,
     )
     .bytes_to_bytes_codecs(vec![])
     // .storage_transformers(vec![].into())
@@ -136,8 +136,8 @@ fn array_sync_read_shard_compress() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::UInt8,
-        vec![2, 2].try_into().unwrap(), // regular chunk shape
-        FillValue::from(0u8),
+        vec![2, 2], // regular chunk shape
+        0u8,
     );
     builder.array_to_bytes_codec(Arc::new(
         zarrs::array::codec::array_to_bytes::sharding::ShardingCodecBuilder::new(
@@ -268,8 +268,8 @@ fn array_str_sync_simple() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::String,
-        vec![2, 2].try_into().unwrap(), // regular chunk shape
-        FillValue::from(""),
+        vec![2, 2], // regular chunk shape
+        "",
     );
     builder.bytes_to_bytes_codecs(vec![
         #[cfg(feature = "gzip")]
@@ -291,8 +291,8 @@ fn array_str_sync_sharded_transpose() -> Result<(), Box<dyn std::error::Error>> 
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::String,
-        vec![2, 2].try_into().unwrap(), // regular chunk shape
-        FillValue::from(""),
+        vec![2, 2], // regular chunk shape
+        "",
     );
     builder.array_to_array_codecs(vec![Arc::new(TransposeCodec::new(
         TransposeOrder::new(&[1, 0]).unwrap(),
@@ -322,8 +322,8 @@ fn array_binary() -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
         DataType::Bytes,
-        vec![2, 2].try_into().unwrap(), // regular chunk shape
-        FillValue::from([]),
+        vec![2, 2], // regular chunk shape
+        [],
     );
     builder.bytes_to_bytes_codecs(vec![
         #[cfg(feature = "gzip")]

--- a/zarrs/tests/array_sync.rs
+++ b/zarrs/tests/array_sync.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use zarrs::array::codec::CodecOptions;
-use zarrs::array::{Array, ArrayBuilder, ArrayCodecTraits, DataType, FillValue};
+use zarrs::array::{Array, ArrayBuilder, ArrayCodecTraits, DataType};
 use zarrs::array_subset::ArraySubset;
 use zarrs::storage::store::MemoryStore;
 

--- a/zarrs/tests/cities.rs
+++ b/zarrs/tests/cities.rs
@@ -49,8 +49,8 @@ fn cities_impl(
     let mut builder = ArrayBuilder::new(
         vec![cities.len() as u64], // array shape
         DataType::String,
-        vec![chunk_size].try_into()?, // regular chunk shape
-        FillValue::from(""),
+        vec![chunk_size], // regular chunk shape
+        "",
     );
     if let Some(shard_size) = shard_size {
         builder.array_to_bytes_codec(Arc::new(

--- a/zarrs/tests/cities.rs
+++ b/zarrs/tests/cities.rs
@@ -16,7 +16,7 @@ use zarrs::{
             },
             ArrayToBytesCodecTraits, VlenCodecConfiguration, ZstdCodec,
         },
-        ArrayBuilder, ArrayMetadataOptions, DataType, FillValue,
+        ArrayBuilder, ArrayMetadataOptions, DataType,
     },
     storage::{store::MemoryStore, ReadableWritableListableStorage},
 };

--- a/zarrs/tests/zarr_python_numpy_time.rs
+++ b/zarrs/tests/zarr_python_numpy_time.rs
@@ -184,8 +184,8 @@ fn zarr_python_v3_numpy_datetime_write() -> Result<(), Box<dyn Error>> {
                 unit,
                 scale_factor: 1.try_into().unwrap(),
             },
-            vec![5].try_into().unwrap(),
-            FillValue::from(i64::MIN),
+            vec![5],
+            i64::MIN,
         )
         .build(store.clone(), "/")?;
         array.store_metadata()?;
@@ -384,8 +384,8 @@ fn zarr_python_v3_numpy_timedelta_write() -> Result<(), Box<dyn Error>> {
                     unit,
                     scale_factor: scale_factor.try_into().unwrap(),
                 },
-                vec![5].try_into().unwrap(),
-                FillValue::from(i64::MIN),
+                vec![5],
+                i64::MIN,
             )
             .build(store.clone(), "/")?;
             array.store_metadata()?;

--- a/zarrs_metadata/src/v3/array/fill_value.rs
+++ b/zarrs_metadata/src/v3/array/fill_value.rs
@@ -234,12 +234,6 @@ impl<const N: usize> From<[FillValueMetadataV3; N]> for FillValueMetadataV3 {
     }
 }
 
-impl<const N: usize> From<&[FillValueMetadataV3; N]> for FillValueMetadataV3 {
-    fn from(value: &[FillValueMetadataV3; N]) -> Self {
-        Self::Array(value.to_vec())
-    }
-}
-
 macro_rules! impl_from_for_int_fill_value_metadata_v3 {
     ($($t:ty),*) => {
         $(

--- a/zarrs_metadata/src/v3/array/fill_value.rs
+++ b/zarrs_metadata/src/v3/array/fill_value.rs
@@ -234,6 +234,12 @@ impl<const N: usize> From<[FillValueMetadataV3; N]> for FillValueMetadataV3 {
     }
 }
 
+impl<const N: usize> From<&[FillValueMetadataV3; N]> for FillValueMetadataV3 {
+    fn from(value: &[FillValueMetadataV3; N]) -> Self {
+        Self::Array(value.to_vec())
+    }
+}
+
 macro_rules! impl_from_for_int_fill_value_metadata_v3 {
     ($($t:ty),*) => {
         $(


### PR DESCRIPTION
- **Breaking**: change `ArrayBuilder::new()` to take a broader range of types for each parameter. See below
```diff
ArrayBuilder::new(
    // array shape
    vec![8, 8], // or [8, 8], &[8, 8], etc.
    // data type, data type name, or data type metadata
    DataType::Float32, // or "float32" or MetadataV3::new("float32"), etc.
    // regular chunk shape, chunk grid, or chunk grid metadata
-    vec![4, 4].try_into()?, // no longer valid
+    vec![4, 4],
    // scalar/string, fill value, or fill value metadata
-    f32::NAN.into(), // no longer valid
+    f32::NAN, // or "NaN", FillValue, FillValueMetadataV3
)
.build()
```
- **Breaking**: change the `{Array,Chunk}Representation::new[_unchecked]` `fill_value` parameter to take `impl Into<FillValue>` instead of `FillValue`
```diff
-  ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32.into())?,
+  ChunkRepresentation::new(chunk_shape(), DataType::Float32, 0.0f32)?,
```