### PR TITLE
refactor!: array shape at construction in the chunk grid API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,12 +41,12 @@ ArrayBuilder::new(
 ```
 - **Breaking**: `Array::set_shape()` now returns a `Result`
   - Previously it was possible to resize an array to a shape incompatible with a `rectangular` chunk grid
-- **Breaking**: Refactor `ChunkGridTraits`
-  - The `ArrayShape` argument has been removed from all methods, and chunk grids are instead initialised with an `ArrayShape`
+- **Breaking**: Refactor `ChunkGridTraits` and `ChunkGridPlugin`, chunk grids are initialised with the array shape
+  - `ChunkGrid::from_metadata()` and `{Regular,Rectangular}ChunkGrid::new()` now have an `ArrayShape` parameter
   - Implementations must now implement `ChunkGridTraits::grid_shape()` as `grid_shape_unchecked()` has been removed
   - Add `ChunkGridTraits::array_shape()`
-  - `ChunkGrid::from_metadata()` and `{Regular,Rectangular}ChunkGrid::new()` now have an `ArrayShape` parameter
 - **Breaking**: `VlenCodec::new()` gains an `index_location` parameter
+- **Breaking**: `ArrayShardedExt::inner_chunk_grid_shape()` no longer returns an `Option`
 - Bump `zarrs_metadata_ext` to 0.2.0
 - Bump `blosc-src` to 0.3.6
 

--- a/zarrs/examples/array_write_read.rs
+++ b/zarrs/examples/array_write_read.rs
@@ -57,8 +57,8 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/group/array";
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
-        DataType::Float32,
         vec![4, 4], // regular chunk shape
+        DataType::Float32,
         ZARR_NAN_F32,
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
@@ -77,12 +77,9 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Write some chunks
     (0..2).into_par_iter().try_for_each(|i| {
         let chunk_indices: Vec<u64> = vec![0, i];
-        let chunk_subset = array
-            .chunk_grid()
-            .subset(&chunk_indices, array.shape())?
-            .ok_or_else(|| {
-                zarrs::array::ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec())
-            })?;
+        let chunk_subset = array.chunk_grid().subset(&chunk_indices)?.ok_or_else(|| {
+            zarrs::array::ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec())
+        })?;
         array.store_chunk_elements(
             &chunk_indices,
             &vec![i as f32 * 0.1; chunk_subset.num_elements() as usize],

--- a/zarrs/examples/array_write_read_ndarray.rs
+++ b/zarrs/examples/array_write_read_ndarray.rs
@@ -58,8 +58,8 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/group/array";
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
-        DataType::Float32,
         vec![4, 4], // regular chunk shape
+        DataType::Float32,
         ZARR_NAN_F32,
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
@@ -78,12 +78,9 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     // Write some chunks
     (0..2).into_par_iter().try_for_each(|i| {
         let chunk_indices: Vec<u64> = vec![0, i];
-        let chunk_subset = array
-            .chunk_grid()
-            .subset(&chunk_indices, array.shape())?
-            .ok_or_else(|| {
-                zarrs::array::ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec())
-            })?;
+        let chunk_subset = array.chunk_grid().subset(&chunk_indices)?.ok_or_else(|| {
+            zarrs::array::ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec())
+        })?;
         array.store_chunk_ndarray(
             &chunk_indices,
             ArrayD::<f32>::from_shape_vec(

--- a/zarrs/examples/array_write_read_string.rs
+++ b/zarrs/examples/array_write_read_string.rs
@@ -54,8 +54,8 @@ fn array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/group/array";
     let array = zarrs::array::ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::String,
         vec![2, 2], // regular chunk shape
+        DataType::String,
         "_",
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed

--- a/zarrs/examples/async_array_write_read.rs
+++ b/zarrs/examples/async_array_write_read.rs
@@ -54,8 +54,8 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/group/array";
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
-        DataType::Float32,
         vec![4, 4], // regular chunk shape
+        DataType::Float32,
         ZARR_NAN_F32,
     )
     // .bytes_to_bytes_codecs(vec![]) // uncompressed
@@ -76,12 +76,9 @@ async fn async_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
         let array = array.clone();
         async move {
             let chunk_indices: Vec<u64> = vec![0, i];
-            let chunk_subset = array
-                .chunk_grid()
-                .subset(&chunk_indices, array.shape())?
-                .ok_or_else(|| {
-                    zarrs::array::ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec())
-                })?;
+            let chunk_subset = array.chunk_grid().subset(&chunk_indices)?.ok_or_else(|| {
+                zarrs::array::ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec())
+            })?;
             array
                 .async_store_chunk_elements(
                     &chunk_indices,

--- a/zarrs/examples/custom_data_type_fixed_size.rs
+++ b/zarrs/examples/custom_data_type_fixed_size.rs
@@ -272,8 +272,8 @@ fn main() {
     let fill_value = CustomDataTypeFixedSizeElement { x: 1, y: 2.3 };
     let array = ArrayBuilder::new(
         vec![4, 1], // array shape
-        DataType::Extension(Arc::new(CustomDataTypeFixedSize)),
         vec![2, 1], // regular chunk shape
+        DataType::Extension(Arc::new(CustomDataTypeFixedSize)),
         FillValue::new(fill_value.to_ne_bytes().to_vec()),
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/custom_data_type_float8_e3m4.rs
+++ b/zarrs/examples/custom_data_type_float8_e3m4.rs
@@ -220,8 +220,8 @@ fn main() {
     let fill_value = CustomDataTypeFloat8e3m4Element::from(1.23);
     let array = ArrayBuilder::new(
         vec![6, 1], // array shape
-        DataType::Extension(Arc::new(CustomDataTypeFloat8e3m4)),
         vec![5, 1], // regular chunk shape
+        DataType::Extension(Arc::new(CustomDataTypeFloat8e3m4)),
         FillValue::new(fill_value.to_ne_bytes().to_vec()),
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/custom_data_type_uint12.rs
+++ b/zarrs/examples/custom_data_type_uint12.rs
@@ -208,8 +208,8 @@ fn main() {
     let fill_value = CustomDataTypeUInt12Element::try_from(15).unwrap();
     let array = ArrayBuilder::new(
         vec![4096, 1], // array shape
+        vec![5, 1],    // regular chunk shape
         DataType::Extension(Arc::new(CustomDataTypeUInt12)),
-        vec![5, 1], // regular chunk shape
         FillValue::new(fill_value.to_le_bytes().to_vec()),
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/custom_data_type_uint4.rs
+++ b/zarrs/examples/custom_data_type_uint4.rs
@@ -206,8 +206,8 @@ fn main() {
     let fill_value = CustomDataTypeUInt4Element::try_from(15).unwrap();
     let array = ArrayBuilder::new(
         vec![6, 1], // array shape
-        DataType::Extension(Arc::new(CustomDataTypeUInt4)),
         vec![5, 1], // regular chunk shape
+        DataType::Extension(Arc::new(CustomDataTypeUInt4)),
         FillValue::new(fill_value.to_ne_bytes().to_vec()),
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/custom_data_type_variable_size.rs
+++ b/zarrs/examples/custom_data_type_variable_size.rs
@@ -157,8 +157,8 @@ fn main() {
     let array_path = "/array";
     let array = ArrayBuilder::new(
         vec![4, 1], // array shape
-        DataType::Extension(Arc::new(CustomDataTypeVariableSize)),
         vec![3, 1], // regular chunk shape
+        DataType::Extension(Arc::new(CustomDataTypeVariableSize)),
         [],
     )
     .array_to_array_codecs(vec![

--- a/zarrs/examples/sharded_array_write_read.rs
+++ b/zarrs/examples/sharded_array_write_read.rs
@@ -68,8 +68,8 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     ]);
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
-        DataType::UInt16,
         shard_shape,
+        DataType::UInt16,
         0u16,
     )
     .array_to_bytes_codec(Arc::new(sharding_codec_builder.build()))
@@ -93,7 +93,7 @@ fn sharded_array_write_read() -> Result<(), Box<dyn std::error::Error>> {
     (0..2).into_par_iter().try_for_each(|s| {
         let chunk_grid = array.chunk_grid();
         let chunk_indices = vec![s, 0];
-        if let Some(chunk_shape) = chunk_grid.chunk_shape(&chunk_indices, array.shape())? {
+        if let Some(chunk_shape) = chunk_grid.chunk_shape(&chunk_indices)? {
             let chunk_array = ndarray::ArrayD::<u16>::from_shape_fn(
                 chunk_shape
                     .iter()

--- a/zarrs/examples/zip_array_write_read.rs
+++ b/zarrs/examples/zip_array_write_read.rs
@@ -30,8 +30,8 @@ fn write_array_to_storage<TStorage: ReadableWritableStorageTraits + ?Sized + 'st
     // Create an array
     let array = zarrs::array::ArrayBuilder::new(
         vec![8, 8], // array shape
-        DataType::Float32,
         vec![4, 4], // regular chunk shape
+        DataType::Float32,
         ZARR_NAN_F32,
     )
     .bytes_to_bytes_codecs(vec![
@@ -51,7 +51,7 @@ fn write_array_to_storage<TStorage: ReadableWritableStorageTraits + ?Sized + 'st
         .try_for_each(|i| {
             let chunk_grid = array.chunk_grid();
             let chunk_indices: Vec<u64> = vec![i, 0];
-            if let Some(chunk_subset) = chunk_grid.subset(&chunk_indices, array.shape())? {
+            if let Some(chunk_subset) = chunk_grid.subset(&chunk_indices)? {
                 array.store_chunk_elements(
                     &chunk_indices,
                     &vec![i as f32; chunk_subset.num_elements() as usize],

--- a/zarrs/src/array/array_async_readable.rs
+++ b/zarrs/src/array/array_async_readable.rs
@@ -425,7 +425,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         // validate_element_size::<T>(self.data_type())?; in // async_retrieve_chunk_elements_if_exists
         let shape = self
             .chunk_grid()
-            .chunk_shape_u64(chunk_indices, self.shape())?
+            .chunk_shape_u64(chunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
         let elements = self
             .async_retrieve_chunk_elements_if_exists_opt(chunk_indices, options)
@@ -448,7 +448,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         // validate_element_size::<T>(self.data_type())?; // in async_retrieve_chunk_elements
         let shape = self
             .chunk_grid()
-            .chunk_shape_u64(chunk_indices, self.shape())?
+            .chunk_shape_u64(chunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
         let elements = self
             .async_retrieve_chunk_elements_opt(chunk_indices, options)

--- a/zarrs/src/array/array_async_readable_writable.rs
+++ b/zarrs/src/array/array_async_readable_writable.rs
@@ -125,7 +125,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> Array<TSto
     ) -> Result<(), ArrayError> {
         let chunk_shape = self
             .chunk_grid()
-            .chunk_shape_u64(chunk_indices, self.shape())?
+            .chunk_shape_u64(chunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
         if std::iter::zip(chunk_subset.end_exc(), &chunk_shape)
             .any(|(end_exc, shape)| end_exc > *shape)

--- a/zarrs/src/array/array_builder.rs
+++ b/zarrs/src/array/array_builder.rs
@@ -573,6 +573,13 @@ mod tests {
     fn array_builder() {
         let mut builder = ArrayBuilder::new(vec![8, 8], [2, 2], DataType::Int8, 0i8);
 
+        // Coverage
+        builder.shape(vec![8, 8]);
+        builder.data_type(DataType::Int8);
+        // builder.chunk_grid(vec![2, 2].try_into().unwrap());
+        builder.chunk_grid_metadata([2, 2]);
+        builder.fill_value(0i8);
+
         builder.dimension_names(["y", "x"].into());
 
         let mut attributes = serde_json::Map::new();

--- a/zarrs/src/array/array_builder/array_builder_chunk_grid.rs
+++ b/zarrs/src/array/array_builder/array_builder_chunk_grid.rs
@@ -1,166 +1,31 @@
-use std::{num::NonZeroU64, sync::Arc};
+use std::sync::Arc;
 
-use derive_more::From;
-use serde::Serialize;
-use zarrs_metadata::{v3::MetadataV3, ArrayShape, ChunkShape};
-use zarrs_plugin::PluginMetadataInvalidError;
-
-use crate::array::{
-    chunk_grid::{ChunkGridTraits, RegularChunkGrid},
-    ArrayCreateError, ChunkGrid,
-};
+use crate::array::{chunk_grid::ChunkGridTraits, ChunkGrid};
 
 /// An input that can be mapped to a chunk grid.
-#[derive(Debug, From)]
-pub struct ArrayBuilderChunkGrid(ArrayBuilderChunkGridImpl);
-
-#[derive(Debug, From)]
-enum ArrayBuilderChunkGridImpl {
-    ChunkGrid(ChunkGrid),
-    Metadata(MetadataV3),
-    MetadataString(String),
-    ArrayShape(ArrayShape),
-    ChunkShape(ChunkShape),
-}
+#[derive(Debug)]
+pub struct ArrayBuilderChunkGrid(ChunkGrid);
 
 impl ArrayBuilderChunkGrid {
-    pub(crate) fn to_chunk_grid(&self, shape: &ArrayShape) -> Result<ChunkGrid, ArrayCreateError> {
-        match &self.0 {
-            ArrayBuilderChunkGridImpl::ChunkGrid(chunk_grid) => Ok(chunk_grid.clone()),
-            ArrayBuilderChunkGridImpl::Metadata(metadata) => {
-                let chunk_grid = ChunkGrid::from_metadata(metadata)
-                    .map_err(ArrayCreateError::ChunkGridCreateError)?;
-                debug_assert_eq!(chunk_grid.dimensionality(), shape.len());
-                Ok(chunk_grid)
-            }
-            ArrayBuilderChunkGridImpl::MetadataString(metadata) => {
-                let metadata = MetadataV3::try_from(metadata.as_str()).map_err(|_| {
-                    ArrayCreateError::ChunkGridCreateError(zarrs_plugin::PluginCreateError::from(
-                        "chunk grid string cannot be parsed as metadata",
-                    ))
-                })?;
-                let chunk_grid = ChunkGrid::from_metadata(&metadata)
-                    .map_err(ArrayCreateError::ChunkGridCreateError)?;
-                debug_assert_eq!(chunk_grid.dimensionality(), shape.len());
-                Ok(chunk_grid)
-            }
-            ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape) => {
-                let chunk_shape: ChunkShape = chunk_shape.clone().try_into().map_err(|_| {
-                    #[derive(Serialize)]
-                    struct RegularChunkGridConfigurationInvalid {
-                        chunk_shape: ArrayShape,
-                    }
-                    let metadata = MetadataV3::new_with_serializable_configuration(
-                        "regular".to_string(),
-                        &RegularChunkGridConfigurationInvalid {
-                            chunk_shape: chunk_shape.clone(),
-                        },
-                    )
-                    .expect("RegularChunkGridConfigurationInvalid is serialisable");
-                    ArrayCreateError::ChunkGridCreateError(
-                        PluginMetadataInvalidError::new(
-                            "regular",
-                            "chunk_grid",
-                            metadata.to_string(),
-                        )
-                        .into(),
-                    )
-                })?;
-                Ok(ChunkGrid::new(RegularChunkGrid::new(chunk_shape)))
-            }
-            ArrayBuilderChunkGridImpl::ChunkShape(chunk_shape) => {
-                Ok(ChunkGrid::new(RegularChunkGrid::new(chunk_shape.clone())))
-            }
-        }
+    pub(crate) fn as_chunk_grid(&self) -> &ChunkGrid {
+        &self.0
     }
 }
 
 impl From<ChunkGrid> for ArrayBuilderChunkGrid {
     fn from(value: ChunkGrid) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ChunkGrid(value))
+        Self(value)
     }
 }
 
 impl<T: ChunkGridTraits + 'static> From<T> for ArrayBuilderChunkGrid {
     fn from(value: T) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ChunkGrid(ChunkGrid::new(value)))
+        Self(ChunkGrid::new(value))
     }
 }
 
 impl From<Arc<dyn ChunkGridTraits>> for ArrayBuilderChunkGrid {
     fn from(value: Arc<dyn ChunkGridTraits>) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ChunkGrid(value.into()))
-    }
-}
-
-impl From<MetadataV3> for ArrayBuilderChunkGrid {
-    fn from(value: MetadataV3) -> Self {
-        Self(ArrayBuilderChunkGridImpl::Metadata(value))
-    }
-}
-
-impl From<String> for ArrayBuilderChunkGrid {
-    fn from(value: String) -> Self {
-        Self(ArrayBuilderChunkGridImpl::MetadataString(value))
-    }
-}
-
-impl From<&str> for ArrayBuilderChunkGrid {
-    fn from(value: &str) -> Self {
-        Self(ArrayBuilderChunkGridImpl::MetadataString(value.to_string()))
-    }
-}
-
-impl<const N: usize> From<[u64; N]> for ArrayBuilderChunkGrid {
-    fn from(chunk_shape: [u64; N]) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape.to_vec()))
-    }
-}
-
-impl<const N: usize> From<&[u64; N]> for ArrayBuilderChunkGrid {
-    fn from(chunk_shape: &[u64; N]) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape.to_vec()))
-    }
-}
-
-impl From<&[u64]> for ArrayBuilderChunkGrid {
-    fn from(chunk_shape: &[u64]) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape.to_vec()))
-    }
-}
-
-impl<const N: usize> From<[NonZeroU64; N]> for ArrayBuilderChunkGrid {
-    fn from(chunk_shape: [NonZeroU64; N]) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ChunkShape(
-            chunk_shape.to_vec().into(),
-        ))
-    }
-}
-
-impl<const N: usize> From<&[NonZeroU64; N]> for ArrayBuilderChunkGrid {
-    fn from(chunk_shape: &[NonZeroU64; N]) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ChunkShape(
-            chunk_shape.to_vec().into(),
-        ))
-    }
-}
-
-impl From<&[NonZeroU64]> for ArrayBuilderChunkGrid {
-    fn from(chunk_shape: &[NonZeroU64]) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ChunkShape(
-            chunk_shape.to_vec().into(),
-        ))
-    }
-}
-
-impl From<Vec<NonZeroU64>> for ArrayBuilderChunkGrid {
-    fn from(chunk_shape: Vec<NonZeroU64>) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ChunkShape(chunk_shape.into()))
-    }
-}
-
-impl From<Vec<u64>> for ArrayBuilderChunkGrid {
-    fn from(chunk_shape: Vec<u64>) -> Self {
-        Self(ArrayBuilderChunkGridImpl::ArrayShape(chunk_shape))
+        Self(value.into())
     }
 }

--- a/zarrs/src/array/array_builder/array_builder_chunk_grid_metadata.rs
+++ b/zarrs/src/array/array_builder/array_builder_chunk_grid_metadata.rs
@@ -1,0 +1,142 @@
+use std::num::NonZeroU64;
+
+use derive_more::From;
+use serde::Serialize;
+use zarrs_metadata::{v3::MetadataV3, ArrayShape, ChunkShape};
+use zarrs_metadata_ext::chunk_grid::regular::RegularChunkGridConfiguration;
+
+use crate::array::ArrayCreateError;
+
+/// An input that can be mapped to a chunk grid.
+#[derive(Debug, Clone, From)]
+pub struct ArrayBuilderChunkGridMetadata(ArrayBuilderChunkGridMetadataImpl);
+
+#[derive(Debug, Clone, From)]
+enum ArrayBuilderChunkGridMetadataImpl {
+    Metadata(MetadataV3),
+    MetadataString(String),
+    ArrayShape(ArrayShape),
+    ChunkShape(ChunkShape),
+}
+
+impl ArrayBuilderChunkGridMetadata {
+    pub(crate) fn to_metadata(&self) -> Result<MetadataV3, ArrayCreateError> {
+        match &self.0 {
+            ArrayBuilderChunkGridMetadataImpl::Metadata(metadata) => Ok(metadata.clone()),
+            ArrayBuilderChunkGridMetadataImpl::MetadataString(metadata) => {
+                let metadata = MetadataV3::try_from(metadata.as_str()).map_err(|_| {
+                    ArrayCreateError::ChunkGridCreateError(zarrs_plugin::PluginCreateError::from(
+                        "chunk grid string cannot be parsed as metadata",
+                    ))
+                })?;
+                Ok(metadata)
+            }
+            ArrayBuilderChunkGridMetadataImpl::ArrayShape(chunk_shape) => {
+                #[derive(Serialize)]
+                struct RegularChunkGridConfiguration {
+                    chunk_shape: ArrayShape,
+                }
+                let metadata = MetadataV3::new_with_serializable_configuration(
+                    "regular".to_string(),
+                    &RegularChunkGridConfiguration {
+                        chunk_shape: chunk_shape.clone(),
+                    },
+                )
+                .expect("RegularChunkGridConfigurationInvalid is serialisable");
+                Ok(metadata)
+            }
+            ArrayBuilderChunkGridMetadataImpl::ChunkShape(chunk_shape) => {
+                let metadata = MetadataV3::new_with_serializable_configuration(
+                    "regular".to_string(),
+                    &RegularChunkGridConfiguration {
+                        chunk_shape: chunk_shape.clone(),
+                    },
+                )
+                .expect("RegularChunkGridConfigurationInvalid is serialisable");
+                Ok(metadata)
+            }
+        }
+    }
+}
+
+impl From<MetadataV3> for ArrayBuilderChunkGridMetadata {
+    fn from(value: MetadataV3) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::Metadata(value))
+    }
+}
+
+impl From<String> for ArrayBuilderChunkGridMetadata {
+    fn from(value: String) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::MetadataString(value))
+    }
+}
+
+impl From<&str> for ArrayBuilderChunkGridMetadata {
+    fn from(value: &str) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::MetadataString(
+            value.to_string(),
+        ))
+    }
+}
+
+impl<const N: usize> From<[u64; N]> for ArrayBuilderChunkGridMetadata {
+    fn from(chunk_shape: [u64; N]) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::ArrayShape(
+            chunk_shape.to_vec(),
+        ))
+    }
+}
+
+impl<const N: usize> From<&[u64; N]> for ArrayBuilderChunkGridMetadata {
+    fn from(chunk_shape: &[u64; N]) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::ArrayShape(
+            chunk_shape.to_vec(),
+        ))
+    }
+}
+
+impl From<&[u64]> for ArrayBuilderChunkGridMetadata {
+    fn from(chunk_shape: &[u64]) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::ArrayShape(
+            chunk_shape.to_vec(),
+        ))
+    }
+}
+
+impl<const N: usize> From<[NonZeroU64; N]> for ArrayBuilderChunkGridMetadata {
+    fn from(chunk_shape: [NonZeroU64; N]) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::ChunkShape(
+            chunk_shape.to_vec().into(),
+        ))
+    }
+}
+
+impl<const N: usize> From<&[NonZeroU64; N]> for ArrayBuilderChunkGridMetadata {
+    fn from(chunk_shape: &[NonZeroU64; N]) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::ChunkShape(
+            chunk_shape.to_vec().into(),
+        ))
+    }
+}
+
+impl From<&[NonZeroU64]> for ArrayBuilderChunkGridMetadata {
+    fn from(chunk_shape: &[NonZeroU64]) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::ChunkShape(
+            chunk_shape.to_vec().into(),
+        ))
+    }
+}
+
+impl From<Vec<NonZeroU64>> for ArrayBuilderChunkGridMetadata {
+    fn from(chunk_shape: Vec<NonZeroU64>) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::ChunkShape(
+            chunk_shape.into(),
+        ))
+    }
+}
+
+impl From<Vec<u64>> for ArrayBuilderChunkGridMetadata {
+    fn from(chunk_shape: Vec<u64>) -> Self {
+        Self(ArrayBuilderChunkGridMetadataImpl::ArrayShape(chunk_shape))
+    }
+}

--- a/zarrs/src/array/array_dlpack_ext.rs
+++ b/zarrs/src/array/array_dlpack_ext.rs
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn array_dlpack_ext_sync() {
         let store = MemoryStore::new();
-        let array = ArrayBuilder::new(vec![4, 4], DataType::Float32, vec![2, 2], -1.0f32)
+        let array = ArrayBuilder::new(vec![4, 4], vec![2, 2], DataType::Float32, -1.0f32)
             .build(store.into(), "/")
             .unwrap();
         array

--- a/zarrs/src/array/array_sync_readable.rs
+++ b/zarrs/src/array/array_sync_readable.rs
@@ -540,7 +540,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
     ) -> Result<Option<ndarray::ArrayD<T>>, ArrayError> {
         let shape = self
             .chunk_grid()
-            .chunk_shape_u64(chunk_indices, self.shape())?
+            .chunk_shape_u64(chunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
         let elements = self.retrieve_chunk_elements_if_exists_opt::<T>(chunk_indices, options)?;
         if let Some(elements) = elements {
@@ -560,7 +560,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
     ) -> Result<ndarray::ArrayD<T>, ArrayError> {
         let shape = self
             .chunk_grid()
-            .chunk_shape_u64(chunk_indices, self.shape())?
+            .chunk_shape_u64(chunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
         elements_to_ndarray(
             &shape,

--- a/zarrs/src/array/array_sync_readable_writable.rs
+++ b/zarrs/src/array/array_sync_readable_writable.rs
@@ -166,7 +166,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> Array<TStorage>
     ) -> Result<(), ArrayError> {
         let chunk_shape = self
             .chunk_grid()
-            .chunk_shape_u64(chunk_indices, self.shape())?
+            .chunk_shape_u64(chunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
         if std::iter::zip(chunk_subset.end_exc(), &chunk_shape)
             .any(|(end_exc, shape)| end_exc > *shape)

--- a/zarrs/src/array/chunk_cache/array_chunk_cache_ext_sync.rs
+++ b/zarrs/src/array/chunk_cache/array_chunk_cache_ext_sync.rs
@@ -173,7 +173,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayChunkCacheExt<TSto
     ) -> Result<ndarray::ArrayD<T>, ArrayError> {
         let shape = self
             .chunk_grid()
-            .chunk_shape_u64(chunk_indices, self.shape())?
+            .chunk_shape_u64(chunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(chunk_indices.to_vec()))?;
         crate::array::elements_to_ndarray(
             &shape,

--- a/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_lru.rs
@@ -382,8 +382,8 @@ mod tests {
         let store = Arc::new(PerformanceMetricsStorageAdapter::new(store));
         let builder = ArrayBuilder::new(
             vec![8, 8], // array shape
-            DataType::UInt8,
             vec![4, 4], // regular chunk shape
+            DataType::UInt8,
             0u8,
         );
         let array = builder.build(store.clone(), "/").unwrap();

--- a/zarrs/src/array/chunk_grid/rectangular.rs
+++ b/zarrs/src/array/chunk_grid/rectangular.rs
@@ -340,6 +340,11 @@ mod tests {
         //     chunk_grid.chunk_element_indices(&array_index, &array_shape)?,
         //     &[0, 1, 2]
         // );
+
+        assert!(RectangularChunkGrid::new(vec![100; 3], &chunk_shapes).is_err()); // incompatible dimensionality
+        assert!(RectangularChunkGrid::new(vec![123, 100], &chunk_shapes).is_err());
+        // incompatible chunk shapes
+        // incompatible dimensionality
     }
 
     #[test]

--- a/zarrs/src/array/chunk_grid/regular.rs
+++ b/zarrs/src/array/chunk_grid/regular.rs
@@ -4,6 +4,7 @@
 
 use std::num::NonZeroU64;
 
+use thiserror::Error;
 use zarrs_registry::chunk_grid::REGULAR;
 
 use crate::{
@@ -29,27 +30,60 @@ fn is_name_regular(name: &str) -> bool {
 /// # Errors
 /// Returns a [`PluginCreateError`] if the metadata is invalid for a regular chunk grid.
 pub(crate) fn create_chunk_grid_regular(
-    metadata: &MetadataV3,
+    metadata_and_array_shape: &(MetadataV3, ArrayShape),
 ) -> Result<ChunkGrid, PluginCreateError> {
+    let (metadata, array_shape) = metadata_and_array_shape;
     let configuration: RegularChunkGridConfiguration =
         metadata.to_configuration().map_err(|_| {
             PluginMetadataInvalidError::new(REGULAR, "chunk grid", metadata.to_string())
         })?;
-    let chunk_grid = RegularChunkGrid::new(configuration.chunk_shape);
+    let chunk_grid = RegularChunkGrid::new(array_shape.clone(), configuration.chunk_shape)
+        .map_err(|_| {
+            PluginCreateError::from(
+                "regular chunk shape and array shape have inconsistent dimensionality",
+            )
+        })?;
     Ok(ChunkGrid::new(chunk_grid))
 }
 
 /// A `regular` chunk grid.
+#[allow(clippy::struct_field_names)]
 #[derive(Debug, Clone)]
 pub struct RegularChunkGrid {
+    array_shape: ArrayShape,
+    grid_shape: ArrayShape,
     chunk_shape: ChunkShape,
 }
 
+/// A [`RegularChunkGrid`] creation error.
+#[derive(Debug, Clone, Error)]
+#[error("regular chunk shape: {_1:?} not compatible with array shape {_0:?}")]
+pub struct RegularChunkGridCreateError(ArrayShape, ChunkShape);
+
 impl RegularChunkGrid {
     /// Create a new `regular` chunk grid with chunk shape `chunk_shape`.
-    #[must_use]
-    pub fn new(chunk_shape: ChunkShape) -> Self {
-        Self { chunk_shape }
+    ///
+    /// # Errors
+    /// Returns a [`RegularChunkGridCreateError`] if `chunk_shape` is not compatible with the `array_shape`.
+    pub fn new(
+        array_shape: ArrayShape,
+        chunk_shape: ChunkShape,
+    ) -> Result<Self, RegularChunkGridCreateError> {
+        if array_shape.len() != chunk_shape.len() {
+            return Err(RegularChunkGridCreateError(array_shape, chunk_shape));
+        }
+
+        let grid_shape = std::iter::zip(&array_shape, chunk_shape.iter())
+            .map(|(a, s)| {
+                let s = s.get();
+                a.div_ceil(s)
+            })
+            .collect();
+        Ok(Self {
+            array_shape,
+            grid_shape,
+            chunk_shape,
+        })
     }
 
     /// Return the chunk shape.
@@ -82,34 +116,22 @@ impl ChunkGridTraits for RegularChunkGrid {
         self.chunk_shape.len()
     }
 
-    unsafe fn grid_shape_unchecked(&self, array_shape: &[u64]) -> Option<ArrayShape> {
-        assert_eq!(array_shape.len(), self.dimensionality());
-        Some(
-            std::iter::zip(array_shape, self.chunk_shape.as_slice())
-                .map(|(a, s)| {
-                    let s = s.get();
-                    a.div_ceil(s)
-                })
-                .collect(),
-        )
+    fn array_shape(&self) -> &ArrayShape {
+        &self.array_shape
+    }
+
+    fn grid_shape(&self) -> &ArrayShape {
+        &self.grid_shape
     }
 
     /// The chunk shape. Fixed for a `regular` grid.
-    unsafe fn chunk_shape_unchecked(
-        &self,
-        chunk_indices: &[u64],
-        _array_shape: &[u64],
-    ) -> Option<ChunkShape> {
+    unsafe fn chunk_shape_unchecked(&self, chunk_indices: &[u64]) -> Option<ChunkShape> {
         debug_assert_eq!(self.dimensionality(), chunk_indices.len());
         Some(self.chunk_shape.clone())
     }
 
     /// The chunk shape as an [`ArrayShape`] ([`Vec<u64>`]). Fixed for a `regular` grid.
-    unsafe fn chunk_shape_u64_unchecked(
-        &self,
-        chunk_indices: &[u64],
-        _array_shape: &[u64],
-    ) -> Option<ArrayShape> {
+    unsafe fn chunk_shape_u64_unchecked(&self, chunk_indices: &[u64]) -> Option<ArrayShape> {
         debug_assert_eq!(self.dimensionality(), chunk_indices.len());
         Some(
             self.chunk_shape
@@ -120,11 +142,7 @@ impl ChunkGridTraits for RegularChunkGrid {
         )
     }
 
-    unsafe fn chunk_origin_unchecked(
-        &self,
-        chunk_indices: &[u64],
-        _array_shape: &[u64],
-    ) -> Option<ArrayIndices> {
+    unsafe fn chunk_origin_unchecked(&self, chunk_indices: &[u64]) -> Option<ArrayIndices> {
         debug_assert_eq!(self.dimensionality(), chunk_indices.len());
         Some(
             std::iter::zip(chunk_indices, self.chunk_shape.as_slice())
@@ -133,11 +151,7 @@ impl ChunkGridTraits for RegularChunkGrid {
         )
     }
 
-    unsafe fn chunk_indices_unchecked(
-        &self,
-        array_indices: &[u64],
-        _array_shape: &[u64],
-    ) -> Option<ArrayIndices> {
+    unsafe fn chunk_indices_unchecked(&self, array_indices: &[u64]) -> Option<ArrayIndices> {
         debug_assert_eq!(self.dimensionality(), array_indices.len());
         Some(
             std::iter::zip(array_indices, self.chunk_shape.as_slice())
@@ -149,7 +163,6 @@ impl ChunkGridTraits for RegularChunkGrid {
     unsafe fn chunk_element_indices_unchecked(
         &self,
         array_indices: &[u64],
-        _array_shape: &[u64],
     ) -> Option<ArrayIndices> {
         debug_assert_eq!(self.dimensionality(), array_indices.len());
         Some(
@@ -182,7 +195,7 @@ mod tests {
         let metadata: MetadataV3 =
             serde_json::from_str(r#"{"name":"regular","configuration":{"chunk_shape":[1,2,3]}}"#)
                 .unwrap();
-        assert!(create_chunk_grid_regular(&metadata).is_ok());
+        assert!(create_chunk_grid_regular(&(metadata, vec![3, 3, 3])).is_ok());
     }
 
     #[test]
@@ -190,9 +203,9 @@ mod tests {
         let metadata: MetadataV3 =
             serde_json::from_str(r#"{"name":"regular","configuration":{"invalid":[1,2,3]}}"#)
                 .unwrap();
-        assert!(create_chunk_grid_regular(&metadata).is_err());
+        assert!(create_chunk_grid_regular(&(metadata.clone(), vec![3, 3, 3])).is_err());
         assert_eq!(
-            create_chunk_grid_regular(&metadata)
+            create_chunk_grid_regular(&(metadata, vec![3, 3, 3]))
                 .unwrap_err()
                 .to_string(),
             r#"chunk grid regular is unsupported with metadata: regular {"invalid":[1,2,3]}"#
@@ -203,85 +216,65 @@ mod tests {
     fn chunk_grid_regular() {
         let array_shape: ArrayShape = vec![5, 7, 52];
         let chunk_shape: ChunkShape = vec![1, 2, 3].try_into().unwrap();
-        let chunk_grid = RegularChunkGrid::new(chunk_shape.clone());
 
-        assert_eq!(chunk_grid.dimensionality(), 3);
+        {
+            let chunk_grid =
+                RegularChunkGrid::new(array_shape.clone(), chunk_shape.clone()).unwrap();
+            assert_eq!(chunk_grid.dimensionality(), 3);
+            assert_eq!(
+                chunk_grid.chunk_origin(&[1, 1, 1]).unwrap(),
+                Some(vec![1, 2, 3])
+            );
+            assert_eq!(chunk_grid.chunk_shape(), chunk_shape.as_slice());
+            let chunk_grid_shape = chunk_grid.grid_shape();
+            assert_eq!(chunk_grid_shape, &[5, 4, 18]);
+            let array_index: ArrayIndices = vec![3, 5, 50];
+            assert_eq!(
+                chunk_grid.chunk_indices(&array_index).unwrap(),
+                Some(vec![3, 2, 16])
+            );
+            assert_eq!(
+                chunk_grid.chunk_element_indices(&array_index).unwrap(),
+                Some(vec![0, 1, 2])
+            );
 
-        assert_eq!(
-            chunk_grid.chunk_origin(&[1, 1, 1], &array_shape).unwrap(),
-            Some(vec![1, 2, 3])
-        );
+            assert_eq!(
+                chunk_grid
+                    .chunks_subset(&ArraySubset::new_with_ranges(&[1..3, 1..2, 5..8]),)
+                    .unwrap(),
+                Some(ArraySubset::new_with_ranges(&[1..3, 2..4, 15..24]))
+            );
 
-        assert_eq!(chunk_grid.chunk_shape(), chunk_shape.as_slice());
+            assert!(chunk_grid
+                .chunks_subset(&ArraySubset::new_with_ranges(&[1..3]))
+                .is_err());
 
-        let chunk_grid_shape = chunk_grid.grid_shape(&array_shape).unwrap();
-        assert_eq!(chunk_grid_shape, Some(vec![5, 4, 18]));
+            assert!(chunk_grid
+                .chunks_subset(&ArraySubset::new_with_ranges(&[0..0, 0..0, 0..0]),)
+                .unwrap()
+                .unwrap()
+                .is_empty());
+        }
 
-        let array_index: ArrayIndices = vec![3, 5, 50];
-        assert_eq!(
-            chunk_grid
-                .chunk_indices(&array_index, &array_shape)
-                .unwrap(),
-            Some(vec![3, 2, 16])
-        );
-        assert_eq!(
-            chunk_grid
-                .chunk_element_indices(&array_index, &array_shape)
-                .unwrap(),
-            Some(vec![0, 1, 2])
-        );
-
-        assert_eq!(
-            chunk_grid
-                .chunks_subset(
-                    &ArraySubset::new_with_ranges(&[1..3, 1..2, 5..8]),
-                    &array_shape
-                )
-                .unwrap(),
-            Some(ArraySubset::new_with_ranges(&[1..3, 2..4, 15..24]))
-        );
-
-        assert!(chunk_grid
-            .chunks_subset(&ArraySubset::new_with_ranges(&[1..3]), &array_shape)
-            .is_err());
-
-        assert!(chunk_grid
-            .chunks_subset(
-                &ArraySubset::new_with_ranges(&[1..3, 1..2, 5..8]),
-                &vec![0; 1]
-            )
-            .is_err());
-
-        assert!(chunk_grid
-            .chunks_subset(
-                &ArraySubset::new_with_ranges(&[0..0, 0..0, 0..0]),
-                &array_shape
-            )
-            .unwrap()
-            .unwrap()
-            .is_empty());
+        assert!(RegularChunkGrid::new(vec![0; 1], chunk_shape.clone()).is_err());
     }
 
     #[test]
     fn chunk_grid_regular_out_of_bounds() {
         let array_shape: ArrayShape = vec![5, 7, 52];
         let chunk_shape: ChunkShape = vec![1, 2, 3].try_into().unwrap();
-        let chunk_grid = RegularChunkGrid::new(chunk_shape);
+        let chunk_grid = RegularChunkGrid::new(array_shape, chunk_shape).unwrap();
 
         let array_indices: ArrayIndices = vec![3, 5, 53];
         assert_eq!(
-            chunk_grid
-                .chunk_indices(&array_indices, &array_shape)
-                .unwrap(),
+            chunk_grid.chunk_indices(&array_indices).unwrap(),
             Some(vec![3, 2, 17])
         );
 
         let chunk_indices: ArrayShape = vec![6, 1, 1];
-        assert!(!chunk_grid.chunk_indices_inbounds(&chunk_indices, &array_shape));
+        assert!(!chunk_grid.chunk_indices_inbounds(&chunk_indices));
         assert_eq!(
-            chunk_grid
-                .chunk_origin(&chunk_indices, &array_shape)
-                .unwrap(),
+            chunk_grid.chunk_origin(&chunk_indices).unwrap(),
             Some(vec![6, 2, 3])
         );
     }
@@ -290,24 +283,15 @@ mod tests {
     fn chunk_grid_regular_unlimited() {
         let array_shape: ArrayShape = vec![5, 7, 0];
         let chunk_shape: ChunkShape = vec![1, 2, 3].try_into().unwrap();
-        let chunk_grid = RegularChunkGrid::new(chunk_shape);
+        let chunk_grid = RegularChunkGrid::new(array_shape, chunk_shape).unwrap();
 
         let array_indices: ArrayIndices = vec![3, 5, 1000];
-        assert!(chunk_grid
-            .chunk_indices(&array_indices, &array_shape)
-            .unwrap()
-            .is_some());
+        assert!(chunk_grid.chunk_indices(&array_indices).unwrap().is_some());
 
-        assert_eq!(
-            chunk_grid.grid_shape(&array_shape).unwrap(),
-            Some(vec![5, 4, 0])
-        );
+        assert_eq!(chunk_grid.grid_shape(), &[5, 4, 0]);
 
         let chunk_indices: ArrayShape = vec![3, 1, 1000];
-        assert!(chunk_grid.chunk_indices_inbounds(&chunk_indices, &array_shape));
-        assert!(chunk_grid
-            .chunk_origin(&chunk_indices, &array_shape)
-            .unwrap()
-            .is_some());
+        assert!(chunk_grid.chunk_indices_inbounds(&chunk_indices));
+        assert!(chunk_grid.chunk_origin(&chunk_indices).unwrap().is_some());
     }
 }

--- a/zarrs/src/lib.rs
+++ b/zarrs/src/lib.rs
@@ -111,8 +111,8 @@
 //! // Create a new sharded V3 array using the array builder
 //! let array = zarrs::array::ArrayBuilder::new(
 //!     vec![3, 4], // array shape
-//!     zarrs::array::DataType::Float32,
 //!     vec![2, 2], // regular chunk (shard) shape
+//!     zarrs::array::DataType::Float32,
 //!     0.0f32, // fill value
 //! )
 //! .array_to_bytes_codec(Arc::new(

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -553,8 +553,8 @@ mod tests {
         let node_path = "/node";
         let array = ArrayBuilder::new(
             vec![1, 2, 3],
-            crate::array::DataType::Float32,
             vec![1, 1, 1],
+            crate::array::DataType::Float32,
             0.0f32,
         )
         .build(store.clone(), node_path)

--- a/zarrs/tests/array_async.rs
+++ b/zarrs/tests/array_async.rs
@@ -19,8 +19,8 @@ async fn array_async_read(shard: bool) -> Result<(), Box<dyn std::error::Error>>
     let array_path = "/array";
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::UInt8,
         vec![2, 2], // regular chunk shape
+        DataType::UInt8,
         0u8,
     );
     builder.bytes_to_bytes_codecs(vec![]);
@@ -42,7 +42,7 @@ async fn array_async_read(shard: bool) -> Result<(), Box<dyn std::error::Error>>
     assert_eq!(array.fill_value().as_ne_bytes(), &[0u8]);
     assert_eq!(array.shape(), &[4, 4]);
     assert_eq!(array.chunk_shape(&[0, 0]).unwrap(), [2, 2].try_into().unwrap());
-    assert_eq!(array.chunk_grid_shape().unwrap(), &[2, 2]);
+    assert_eq!(array.chunk_grid_shape(), &[2, 2]);
 
     let options = CodecOptions::default();
 
@@ -278,8 +278,8 @@ async fn array_str_async_simple() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/array";
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::String,
         vec![2, 2], // regular chunk shape
+        DataType::String,
         "",
     );
     builder.bytes_to_bytes_codecs(vec![
@@ -298,8 +298,8 @@ async fn array_str_async_sharded_transpose() -> Result<(), Box<dyn std::error::E
         let array_path = "/array";
         let mut builder = ArrayBuilder::new(
             vec![4, 4], // array shape
-            DataType::String,
             vec![2, 2], // regular chunk shape
+            DataType::String,
             "",
         );
         builder.array_to_array_codecs(vec![Arc::new(TransposeCodec::new(

--- a/zarrs/tests/array_async_to_sync.rs
+++ b/zarrs/tests/array_async_to_sync.rs
@@ -48,7 +48,7 @@ fn array_read_and_write_async_storage_adapter() {
 
     // Create an array
     let array =
-        zarrs::array::ArrayBuilder::new(vec![8, 8], DataType::Float32, vec![4, 4], ZARR_NAN_F32)
+        zarrs::array::ArrayBuilder::new(vec![8, 8], vec![4, 4], DataType::Float32, ZARR_NAN_F32)
             .dimension_names(["y", "x"].into())
             .build(store.clone(), ARRAY_PATH)
             .unwrap();

--- a/zarrs/tests/array_partial_encode.rs
+++ b/zarrs/tests/array_partial_encode.rs
@@ -45,8 +45,8 @@ fn array_partial_encode_sharding(
     let array_path = "/";
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::UInt16,
         vec![2, 2], // regular chunk shape
+        DataType::UInt16,
         0u16,
     );
     builder

--- a/zarrs/tests/array_sync.rs
+++ b/zarrs/tests/array_sync.rs
@@ -14,7 +14,7 @@ fn array_sync_read(array: Array<MemoryStore>) -> Result<(), Box<dyn std::error::
     assert_eq!(array.fill_value().as_ne_bytes(), &[0u8]);
     assert_eq!(array.shape(), &[4, 4]);
     assert_eq!(array.chunk_shape(&[0, 0]).unwrap(), [2, 2].try_into().unwrap());
-    assert_eq!(array.chunk_grid_shape().unwrap(), &[2, 2]);
+    assert_eq!(array.chunk_grid_shape(), &[2, 2]);
 
     let options = CodecOptions::default();
 
@@ -106,8 +106,8 @@ fn array_sync_read_uncompressed() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/array";
     let array = ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::UInt8,
         vec![2, 2], // regular chunk shape
+        DataType::UInt8,
         0u8,
     )
     .bytes_to_bytes_codecs(vec![])
@@ -135,8 +135,8 @@ fn array_sync_read_shard_compress() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/array";
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::UInt8,
         vec![2, 2], // regular chunk shape
+        DataType::UInt8,
         0u8,
     );
     builder.array_to_bytes_codec(Arc::new(
@@ -267,8 +267,8 @@ fn array_str_sync_simple() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/array";
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::String,
         vec![2, 2], // regular chunk shape
+        DataType::String,
         "",
     );
     builder.bytes_to_bytes_codecs(vec![
@@ -290,8 +290,8 @@ fn array_str_sync_sharded_transpose() -> Result<(), Box<dyn std::error::Error>> 
     let array_path = "/array";
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::String,
         vec![2, 2], // regular chunk shape
+        DataType::String,
         "",
     );
     builder.array_to_array_codecs(vec![Arc::new(TransposeCodec::new(
@@ -321,8 +321,8 @@ fn array_binary() -> Result<(), Box<dyn std::error::Error>> {
     let array_path = "/array";
     let mut builder = ArrayBuilder::new(
         vec![4, 4], // array shape
-        DataType::Bytes,
         vec![2, 2], // regular chunk shape
+        DataType::Bytes,
         [],
     );
     builder.bytes_to_bytes_codecs(vec![

--- a/zarrs/tests/cities.rs
+++ b/zarrs/tests/cities.rs
@@ -48,8 +48,8 @@ fn cities_impl(
 
     let mut builder = ArrayBuilder::new(
         vec![cities.len() as u64], // array shape
+        vec![chunk_size],          // regular chunk shape
         DataType::String,
-        vec![chunk_size], // regular chunk shape
         "",
     );
     if let Some(shard_size) = shard_size {

--- a/zarrs/tests/zarr_python_numpy_time.rs
+++ b/zarrs/tests/zarr_python_numpy_time.rs
@@ -180,11 +180,11 @@ fn zarr_python_v3_numpy_datetime_write() -> Result<(), Box<dyn Error>> {
         let store = Arc::new(MemoryStore::new());
         let array = ArrayBuilder::new(
             vec![6],
+            vec![5],
             zarrs::array::DataType::NumpyDateTime64 {
                 unit,
                 scale_factor: 1.try_into().unwrap(),
             },
-            vec![5],
             i64::MIN,
         )
         .build(store.clone(), "/")?;
@@ -380,11 +380,11 @@ fn zarr_python_v3_numpy_timedelta_write() -> Result<(), Box<dyn Error>> {
             let store = Arc::new(MemoryStore::new());
             let array = ArrayBuilder::new(
                 vec![11],
+                vec![5],
                 zarrs::array::DataType::NumpyTimeDelta64 {
                     unit,
                     scale_factor: scale_factor.try_into().unwrap(),
                 },
-                vec![5],
                 i64::MIN,
             )
             .build(store.clone(), "/")?;


### PR DESCRIPTION
This simplifies chunk grid usage and enables chunk grid validation on initialisation.

**The order of arguments for `ArrayBuilder` has swapped**. A long overdue change and worth doing while `ArrayBuilder` is breaking anyway.

Closes #215.