### PR TITLE
feat!: Add upcasting methods to storage traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ ArrayBuilder::new(
 - **Breaking**: Add `size()` method to `{Array,Bytes}PartialDecoderTraits`
 - **Breaking**: Add `retrieve_chunk_subset` method to the `ChunkCache` trait
 - Bump `zarrs_metadata_ext` to 0.2.0
+- Bump `zarrs_storage` to 0.4.0
 - Bump `blosc-src` to 0.3.6
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,27 +52,27 @@ version = "0.1.4"
 path = "zarrs_registry"
 
 [workspace.dependencies.zarrs_storage]
-version = "0.3.4"
+version = "0.4.0"
 path = "zarrs_storage"
 
 [workspace.dependencies.zarrs_filesystem]
-version = "0.2.3"
+version = "0.3.0"
 path = "zarrs_filesystem"
 
 [workspace.dependencies.zarrs_http]
-version = "0.2.2"
+version = "0.3.0"
 path = "zarrs_http"
 
 [workspace.dependencies.zarrs_object_store]
-version = "0.4.3"
+version = "0.5.0"
 path = "zarrs_object_store"
 
 [workspace.dependencies.zarrs_opendal]
-version = "0.7.2"
+version = "0.8.0"
 path = "zarrs_opendal"
 
 [workspace.dependencies.zarrs_zip]
-version = "0.2.3"
+version = "0.3.0"
 path = "zarrs_zip"
 
 [workspace.dependencies.object_store]

--- a/zarrs_filesystem/CHANGELOG.md
+++ b/zarrs_filesystem/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- Bump `zarrs_storage` to 0.4.0
+
 ## [0.2.3] - 2025-06-16
 
 ## Changed

--- a/zarrs_filesystem/Cargo.toml
+++ b/zarrs_filesystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_filesystem"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.77"

--- a/zarrs_http/CHANGELOG.md
+++ b/zarrs_http/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- Bump `zarrs_storage` to 0.4.0
+
 ## [0.2.2] - 2025-05-16
 
 ## Changed

--- a/zarrs_http/Cargo.toml
+++ b/zarrs_http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_http"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.77"

--- a/zarrs_object_store/CHANGELOG.md
+++ b/zarrs_object_store/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- Bump `zarrs_storage` to 0.4.0
+
 ## [0.4.3] - 2025-06-20
 
 ### Added

--- a/zarrs_object_store/Cargo.toml
+++ b/zarrs_object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_object_store"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.77"

--- a/zarrs_opendal/CHANGELOG.md
+++ b/zarrs_opendal/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- Bump `zarrs_storage` to 0.4.0
+
 ## [0.7.2] - 2025-05-16
 
 ## Changed

--- a/zarrs_opendal/Cargo.toml
+++ b/zarrs_opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_opendal"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.80"

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking**: Add upcasting methods to storage traits (`readable()`, `writable()`, etc.)
+
 ## [0.3.4] - 2025-05-16
 
 ### Changed

--- a/zarrs_storage/Cargo.toml
+++ b/zarrs_storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_storage"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.77"

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -328,12 +328,6 @@ pub trait AsyncReadableWritableListableStorageTraits:
     /// Return a readable and writable version of the store.
     fn readable_writable(self: Arc<Self>) -> Arc<dyn AsyncReadableWritableStorageTraits>;
 
-    /// Return a readable version of the store.
-    fn readable(self: Arc<Self>) -> Arc<dyn AsyncReadableStorageTraits>;
-
-    /// Return a writable version of the store.
-    fn writable(self: Arc<Self>) -> Arc<dyn AsyncWritableStorageTraits>;
-
     /// Return a listable version of the store.
     fn listable(self: Arc<Self>) -> Arc<dyn AsyncListableStorageTraits>;
 }
@@ -343,14 +337,6 @@ where
     T: AsyncReadableWritableStorageTraits + AsyncListableStorageTraits + 'static,
 {
     fn readable_writable(self: Arc<Self>) -> Arc<dyn AsyncReadableWritableStorageTraits> {
-        self.clone()
-    }
-
-    fn readable(self: Arc<Self>) -> Arc<dyn AsyncReadableStorageTraits> {
-        self.clone()
-    }
-
-    fn writable(self: Arc<Self>) -> Arc<dyn AsyncWritableStorageTraits> {
         self.clone()
     }
 

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -328,6 +328,9 @@ pub trait AsyncReadableWritableListableStorageTraits:
     /// Return a readable and writable version of the store.
     fn readable_writable(self: Arc<Self>) -> Arc<dyn AsyncReadableWritableStorageTraits>;
 
+    /// Return a readable and listable version of the store.
+    fn readable_listable(self: Arc<Self>) -> Arc<dyn AsyncReadableListableStorageTraits>;
+
     /// Return a listable version of the store.
     fn listable(self: Arc<Self>) -> Arc<dyn AsyncListableStorageTraits>;
 }
@@ -337,6 +340,10 @@ where
     T: AsyncReadableWritableStorageTraits + AsyncListableStorageTraits + 'static,
 {
     fn readable_writable(self: Arc<Self>) -> Arc<dyn AsyncReadableWritableStorageTraits> {
+        self.clone()
+    }
+
+    fn readable_listable(self: Arc<Self>) -> Arc<dyn AsyncReadableListableStorageTraits> {
         self.clone()
     }
 

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -277,33 +277,86 @@ pub trait AsyncWritableStorageTraits: Send + Sync {
 pub trait AsyncReadableWritableStorageTraits:
     AsyncReadableStorageTraits + AsyncWritableStorageTraits
 {
+    /// Return a readable version of the store.
+    fn readable(self: Arc<Self>) -> Arc<dyn AsyncReadableStorageTraits>;
+
+    /// Return a writable version of the store.
+    fn writable(self: Arc<Self>) -> Arc<dyn AsyncWritableStorageTraits>;
 }
 
-impl<T> AsyncReadableWritableStorageTraits for T where
-    T: AsyncReadableStorageTraits + AsyncWritableStorageTraits
+impl<T> AsyncReadableWritableStorageTraits for T
+where
+    T: AsyncReadableStorageTraits + AsyncWritableStorageTraits + 'static,
 {
+    fn readable(self: Arc<Self>) -> Arc<dyn AsyncReadableStorageTraits> {
+        self.clone()
+    }
+
+    fn writable(self: Arc<Self>) -> Arc<dyn AsyncWritableStorageTraits> {
+        self.clone()
+    }
 }
 
 /// A supertrait of [`AsyncReadableStorageTraits`] and [`AsyncListableStorageTraits`].
 pub trait AsyncReadableListableStorageTraits:
     AsyncReadableStorageTraits + AsyncListableStorageTraits
 {
+    /// Return a readable version of the store.
+    fn readable(self: Arc<Self>) -> Arc<dyn AsyncReadableStorageTraits>;
+
+    /// Return a listable version of the store.
+    fn listable(self: Arc<Self>) -> Arc<dyn AsyncListableStorageTraits>;
 }
 
-impl<T> AsyncReadableListableStorageTraits for T where
-    T: AsyncReadableStorageTraits + AsyncListableStorageTraits
+impl<T> AsyncReadableListableStorageTraits for T
+where
+    T: AsyncReadableStorageTraits + AsyncListableStorageTraits + 'static,
 {
+    fn readable(self: Arc<Self>) -> Arc<dyn AsyncReadableStorageTraits> {
+        self.clone()
+    }
+
+    fn listable(self: Arc<Self>) -> Arc<dyn AsyncListableStorageTraits> {
+        self.clone()
+    }
 }
 
 /// A supertrait of [`AsyncReadableWritableStorageTraits`] and [`AsyncListableStorageTraits`].
 pub trait AsyncReadableWritableListableStorageTraits:
     AsyncReadableWritableStorageTraits + AsyncListableStorageTraits
 {
+    /// Return a readable and writable version of the store.
+    fn readable_writable(self: Arc<Self>) -> Arc<dyn AsyncReadableWritableStorageTraits>;
+
+    /// Return a readable version of the store.
+    fn readable(self: Arc<Self>) -> Arc<dyn AsyncReadableStorageTraits>;
+
+    /// Return a writable version of the store.
+    fn writable(self: Arc<Self>) -> Arc<dyn AsyncWritableStorageTraits>;
+
+    /// Return a listable version of the store.
+    fn listable(self: Arc<Self>) -> Arc<dyn AsyncListableStorageTraits>;
 }
 
-impl<T> AsyncReadableWritableListableStorageTraits for T where
-    T: AsyncReadableWritableStorageTraits + AsyncListableStorageTraits
+impl<T> AsyncReadableWritableListableStorageTraits for T
+where
+    T: AsyncReadableWritableStorageTraits + AsyncListableStorageTraits + 'static,
 {
+    fn readable_writable(self: Arc<Self>) -> Arc<dyn AsyncReadableWritableStorageTraits> {
+        self.clone()
+    }
+
+    fn readable(self: Arc<Self>) -> Arc<dyn AsyncReadableStorageTraits> {
+        self.clone()
+    }
+
+    fn writable(self: Arc<Self>) -> Arc<dyn AsyncWritableStorageTraits> {
+        self.clone()
+    }
+
+    fn listable(self: Arc<Self>) -> Arc<dyn AsyncListableStorageTraits> {
+        self.clone()
+    }
 }
 
 /// Asynchronously discover the children of a store prefix.

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -248,29 +248,84 @@ pub trait WritableStorageTraits: Send + Sync {
 
 /// A supertrait of [`ReadableStorageTraits`] and [`WritableStorageTraits`].
 pub trait ReadableWritableStorageTraits: ReadableStorageTraits + WritableStorageTraits {
-    // /// Returns the mutex for the store value at `key`.
-    // ///
-    // /// # Errors
-    // /// Returns a [`StorageError`] if the mutex cannot be retrieved.
-    // fn mutex(&self, key: &StoreKey) -> Result<StoreKeyMutex, StorageError>;
+    /// Return a readable version of the store.
+    fn readable(self: Arc<Self>) -> Arc<dyn ReadableStorageTraits>;
+
+    /// Return a writable version of the store.
+    fn writable(self: Arc<Self>) -> Arc<dyn WritableStorageTraits>;
 }
 
-impl<T> ReadableWritableStorageTraits for T where T: ReadableStorageTraits + WritableStorageTraits {}
+impl<T> ReadableWritableStorageTraits for T
+where
+    T: ReadableStorageTraits + WritableStorageTraits + 'static,
+{
+    fn readable(self: Arc<Self>) -> Arc<dyn ReadableStorageTraits> {
+        self.clone()
+    }
+
+    fn writable(self: Arc<Self>) -> Arc<dyn WritableStorageTraits> {
+        self.clone()
+    }
+}
 
 /// A supertrait of [`ReadableStorageTraits`] and [`ListableStorageTraits`].
-pub trait ReadableListableStorageTraits: ReadableStorageTraits + ListableStorageTraits {}
+pub trait ReadableListableStorageTraits: ReadableStorageTraits + ListableStorageTraits {
+    /// Return a readable version of the store.
+    fn readable(self: Arc<Self>) -> Arc<dyn ReadableStorageTraits>;
 
-impl<T> ReadableListableStorageTraits for T where T: ReadableStorageTraits + ListableStorageTraits {}
+    /// Return a listable version of the store.
+    fn listable(self: Arc<Self>) -> Arc<dyn ListableStorageTraits>;
+}
+
+impl<T> ReadableListableStorageTraits for T
+where
+    T: ReadableStorageTraits + ListableStorageTraits + 'static,
+{
+    fn readable(self: Arc<Self>) -> Arc<dyn ReadableStorageTraits> {
+        self.clone()
+    }
+
+    fn listable(self: Arc<Self>) -> Arc<dyn ListableStorageTraits> {
+        self.clone()
+    }
+}
 
 /// A supertrait of [`ReadableWritableStorageTraits`] and [`ListableStorageTraits`].
 pub trait ReadableWritableListableStorageTraits:
     ReadableWritableStorageTraits + ListableStorageTraits
 {
+    /// Return a readable and writable version of the store.
+    fn readable_writable(self: Arc<Self>) -> Arc<dyn ReadableWritableStorageTraits>;
+
+    /// Return a readable version of the store.
+    fn readable(self: Arc<Self>) -> Arc<dyn ReadableStorageTraits>;
+
+    /// Return a writable version of the store.
+    fn writable(self: Arc<Self>) -> Arc<dyn WritableStorageTraits>;
+
+    /// Return a listable version of the store.
+    fn listable(self: Arc<Self>) -> Arc<dyn ListableStorageTraits>;
 }
 
-impl<T> ReadableWritableListableStorageTraits for T where
-    T: ReadableWritableStorageTraits + ListableStorageTraits
+impl<T> ReadableWritableListableStorageTraits for T
+where
+    T: ReadableWritableStorageTraits + ListableStorageTraits + 'static,
 {
+    fn readable_writable(self: Arc<Self>) -> Arc<dyn ReadableWritableStorageTraits> {
+        self.clone()
+    }
+
+    fn readable(self: Arc<Self>) -> Arc<dyn ReadableStorageTraits> {
+        self.clone()
+    }
+
+    fn writable(self: Arc<Self>) -> Arc<dyn WritableStorageTraits> {
+        self.clone()
+    }
+
+    fn listable(self: Arc<Self>) -> Arc<dyn ListableStorageTraits> {
+        self.clone()
+    }
 }
 
 /// Discover the children of a store prefix.

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -297,12 +297,6 @@ pub trait ReadableWritableListableStorageTraits:
     /// Return a readable and writable version of the store.
     fn readable_writable(self: Arc<Self>) -> Arc<dyn ReadableWritableStorageTraits>;
 
-    /// Return a readable version of the store.
-    fn readable(self: Arc<Self>) -> Arc<dyn ReadableStorageTraits>;
-
-    /// Return a writable version of the store.
-    fn writable(self: Arc<Self>) -> Arc<dyn WritableStorageTraits>;
-
     /// Return a listable version of the store.
     fn listable(self: Arc<Self>) -> Arc<dyn ListableStorageTraits>;
 }
@@ -312,14 +306,6 @@ where
     T: ReadableWritableStorageTraits + ListableStorageTraits + 'static,
 {
     fn readable_writable(self: Arc<Self>) -> Arc<dyn ReadableWritableStorageTraits> {
-        self.clone()
-    }
-
-    fn readable(self: Arc<Self>) -> Arc<dyn ReadableStorageTraits> {
-        self.clone()
-    }
-
-    fn writable(self: Arc<Self>) -> Arc<dyn WritableStorageTraits> {
         self.clone()
     }
 

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -297,6 +297,9 @@ pub trait ReadableWritableListableStorageTraits:
     /// Return a readable and writable version of the store.
     fn readable_writable(self: Arc<Self>) -> Arc<dyn ReadableWritableStorageTraits>;
 
+    /// Return a readable and listable version of the store.
+    fn readable_listable(self: Arc<Self>) -> Arc<dyn ReadableListableStorageTraits>;
+
     /// Return a listable version of the store.
     fn listable(self: Arc<Self>) -> Arc<dyn ListableStorageTraits>;
 }
@@ -306,6 +309,10 @@ where
     T: ReadableWritableStorageTraits + ListableStorageTraits + 'static,
 {
     fn readable_writable(self: Arc<Self>) -> Arc<dyn ReadableWritableStorageTraits> {
+        self.clone()
+    }
+
+    fn readable_listable(self: Arc<Self>) -> Arc<dyn ReadableListableStorageTraits> {
         self.clone()
     }
 

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -228,13 +228,28 @@ mod tests {
     }
 
     #[test]
-    fn memory_generic() -> Result<(), Box<dyn Error>> {
+    fn memory_upcast1() -> Result<(), Box<dyn Error>> {
         let store: Arc<dyn ReadableWritableListableStorageTraits> = Arc::new(MemoryStore::new());
-        crate::store_test::store_write(&store.clone().readable_writable().writable())?;
         crate::store_test::store_write(&store.clone().writable())?;
-        crate::store_test::store_read(&store.clone().readable_writable().readable())?;
         crate::store_test::store_read(&store.clone().readable())?;
         crate::store_test::store_list(&store.clone().listable())?;
+        Ok(())
+    }
+
+    #[test]
+    fn memory_upcast2() -> Result<(), Box<dyn Error>> {
+        let store: Arc<dyn ReadableWritableListableStorageTraits> = Arc::new(MemoryStore::new());
+        crate::store_test::store_write(&store.clone().readable_writable().writable())?;
+        crate::store_test::store_read(&store.clone().readable_writable().readable())?;
+        Ok(())
+    }
+
+    #[test]
+    fn memory_upcast3() -> Result<(), Box<dyn Error>> {
+        let store: Arc<dyn ReadableWritableListableStorageTraits> = Arc::new(MemoryStore::new());
+        crate::store_test::store_write(&store.clone().writable())?;
+        crate::store_test::store_read(&store.clone().readable_listable().readable())?;
+        crate::store_test::store_list(&store.clone().readable_listable().listable())?;
         Ok(())
     }
 }

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -213,6 +213,8 @@ impl ListableStorageTraits for MemoryStore {
 
 #[cfg(test)]
 mod tests {
+    use crate::ReadableWritableListableStorageTraits;
+
     use super::*;
     use std::error::Error;
 
@@ -222,6 +224,17 @@ mod tests {
         crate::store_test::store_write(&store)?;
         crate::store_test::store_read(&store)?;
         crate::store_test::store_list(&store)?;
+        Ok(())
+    }
+
+    #[test]
+    fn memory_generic() -> Result<(), Box<dyn Error>> {
+        let store: Arc<dyn ReadableWritableListableStorageTraits> = Arc::new(MemoryStore::new());
+        crate::store_test::store_write(&store.clone().readable_writable().writable())?;
+        crate::store_test::store_write(&store.clone().writable())?;
+        crate::store_test::store_read(&store.clone().readable_writable().readable())?;
+        crate::store_test::store_read(&store.clone().readable())?;
+        crate::store_test::store_list(&store.clone().listable())?;
         Ok(())
     }
 }

--- a/zarrs_zip/CHANGELOG.md
+++ b/zarrs_zip/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- Bump `zarrs_storage` to 0.4.0
+
 ## [0.2.3] - 2025-06-19
 
 ## Changed

--- a/zarrs_zip/Cargo.toml
+++ b/zarrs_zip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_zip"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.77"


### PR DESCRIPTION
This is technically a breaking API change for `zarrs_storage`, but stores/user code do not require any changes.