### PR TITLE
feat: flexible indexing

### DIFF
--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -89,6 +89,7 @@ jiff = { version = "0.2.15", optional = true }
 chrono = { version = "0.4.39", optional = true }
 float8 = { version = "0.1.3", optional = true, features = ["bytemuck"] }
 simd-adler32 = { version = "0.3.7", optional = true }
+enum_dispatch = "0.3.13"
 
 [dependencies.num-complex]
 version = "0.4.3"

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -8,8 +8,8 @@
 //! This module also provides convenience functions for:
 //!  - computing the byte ranges of array subsets within an array with a fixed element size.
 
-pub mod iterators;
 pub mod indexers;
+pub mod iterators;
 use serde_json::value::Index;
 use thiserror::Error;
 
@@ -19,22 +19,24 @@ use std::{
     ops::Range,
 };
 
+use indexers::{IndexerEnum, RangeSubset};
 use iterators::{
     Chunks, ContiguousIndices, ContiguousLinearisedIndices, Indices, LinearisedIndices,
 };
-use indexers::{RangeSubset, IndexerEnum};
 
 use derive_more::From;
 use itertools::izip;
 
 use crate::{
-    array::{ArrayError, ArrayIndices, ArrayShape}, array_subset::indexers::Indexer, storage::byte_range::ByteRange
+    array::{ArrayError, ArrayIndices, ArrayShape},
+    array_subset::indexers::Indexer,
+    storage::byte_range::ByteRange,
 };
 
 /// An array subset.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct ArraySubset {
-    indexer: IndexerEnum
+    indexer: IndexerEnum,
 }
 impl From<IndexerEnum> for ArraySubset {
     fn from(indexer: IndexerEnum) -> Self {
@@ -50,7 +52,9 @@ impl Display for ArraySubset {
 
 impl<T: IntoIterator<Item = Range<u64>>> From<T> for ArraySubset {
     fn from(ranges: T) -> Self {
-        Self { indexer: IndexerEnum::RangeSubset(ranges.into()) }
+        Self {
+            indexer: IndexerEnum::RangeSubset(ranges.into()),
+        }
     }
 }
 
@@ -58,19 +62,25 @@ impl ArraySubset {
     /// Create a new empty array subset.
     #[must_use]
     pub fn new_empty(dimensionality: usize) -> Self {
-        Self { indexer: IndexerEnum::RangeSubset(RangeSubset::new_empty(dimensionality)) }
+        Self {
+            indexer: IndexerEnum::RangeSubset(RangeSubset::new_empty(dimensionality)),
+        }
     }
 
     /// Create a new array subset from a list of [`Range`]s.
     #[must_use]
     pub fn new_with_ranges(ranges: &[Range<u64>]) -> Self {
-        Self { indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_ranges(ranges)) }
+        Self {
+            indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_ranges(ranges)),
+        }
     }
 
     /// Create a new array subset with `size` starting at the origin.
     #[must_use]
     pub fn new_with_shape(shape: ArrayShape) -> Self {
-        Self { indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_shape(shape)) }
+        Self {
+            indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_shape(shape)),
+        }
     }
 
     /// Create a new array subset.
@@ -82,7 +92,9 @@ impl ArraySubset {
         start: ArrayIndices,
         shape: ArrayShape,
     ) -> Result<Self, IncompatibleDimensionalityError> {
-        Ok(Self { indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_start_shape(start, shape)?) })
+        Ok(Self {
+            indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_start_shape(start, shape)?),
+        })
     }
 
     /// Create a new array subset from a start and end (inclusive).
@@ -93,7 +105,9 @@ impl ArraySubset {
         start: ArrayIndices,
         end: ArrayIndices,
     ) -> Result<Self, IncompatibleStartEndIndicesError> {
-        Ok(Self { indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_start_end_inc(start, end)?) })
+        Ok(Self {
+            indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_start_end_inc(start, end)?),
+        })
     }
 
     /// Create a new array subset from a start and end (exclusive).
@@ -104,7 +118,9 @@ impl ArraySubset {
         start: ArrayIndices,
         end: ArrayIndices,
     ) -> Result<Self, IncompatibleStartEndIndicesError> {
-        Ok(Self { indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_start_end_exc(start, end)?) })
+        Ok(Self {
+            indexer: IndexerEnum::RangeSubset(RangeSubset::new_with_start_end_exc(start, end)?),
+        })
     }
 
     /// Return the array subset as a vec of ranges.

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -319,6 +319,14 @@ impl ArraySubset {
     pub fn inbounds_shape(&self, array_shape: &[u64]) -> bool {
         self.indexer.inbounds_shape(array_shape)
     }
+
+    pub fn is_compatible_shape(&self, array_shape: &[u64]) -> bool {
+        self.indexer.is_compatible_shape(array_shape)
+    }
+
+    pub fn find_linearised_index(&self, index: usize) -> ArrayIndices {
+        self.indexer.find_linearised_index(index)
+    }
 }
 
 /// An incompatible dimensionality error.

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -276,7 +276,7 @@ impl ArraySubset {
         &self,
         array_shape: &[u64],
     ) -> Result<ContiguousIndices, IncompatibleArraySubsetAndShapeError> {
-        ContiguousIndices::new(self, array_shape)
+        self.indexer.contiguous_indices(array_shape)
     }
 
     /// Returns an iterator over the linearised indices of contiguous elements within the subset.

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -302,7 +302,7 @@ impl ArraySubset {
         &self,
         chunk_shape: &[NonZeroU64],
     ) -> Result<Chunks, IncompatibleDimensionalityError> {
-        Chunks::new(self, chunk_shape)
+        self.indexer.chunks(chunk_shape)
     }
 
     /// Return the overlapping subset between this array subset and `subset_other`.

--- a/zarrs/src/array_subset/indexers.rs
+++ b/zarrs/src/array_subset/indexers.rs
@@ -1,5 +1,7 @@
 mod indexer;
 mod range_subset;
+mod vindex;
 
 pub use indexer::{IndexerEnum, Indexer};
 pub use range_subset::RangeSubset;
+pub use vindex::VIndex;

--- a/zarrs/src/array_subset/indexers.rs
+++ b/zarrs/src/array_subset/indexers.rs
@@ -1,0 +1,5 @@
+mod indexer;
+mod range_subset;
+
+pub use indexer::{IndexerEnum, Indexer};
+pub use range_subset::RangeSubset;

--- a/zarrs/src/array_subset/indexers.rs
+++ b/zarrs/src/array_subset/indexers.rs
@@ -2,6 +2,6 @@ mod indexer;
 mod range_subset;
 mod vindex;
 
-pub use indexer::{IndexerEnum, Indexer};
+pub use indexer::{Indexer, IndexerEnum};
 pub use range_subset::RangeSubset;
 pub use vindex::VIndex;

--- a/zarrs/src/array_subset/indexers/indexer.rs
+++ b/zarrs/src/array_subset/indexers/indexer.rs
@@ -7,7 +7,7 @@ use zarrs_metadata::ArrayShape;
 use zarrs_storage::byte_range::ByteRange;
 use thiserror::Error;
 
-use crate::{array::ArrayIndices, array_subset::{indexers::RangeSubset, iterators::{ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices}, ArraySubset, IncompatibleArraySubsetAndShapeError, IncompatibleDimensionalityError}};
+use crate::{array::ArrayIndices, array_subset::{indexers::{RangeSubset, VIndex}, iterators::{ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices}, ArraySubset, IncompatibleArraySubsetAndShapeError, IncompatibleDimensionalityError}};
 
 
 #[enum_dispatch]
@@ -132,7 +132,8 @@ pub trait Indexer: Send + Sync + Clone {
 #[enum_dispatch(Indexer)]
 #[derive(Clone, Error, Debug, Eq, PartialEq, Display, PartialOrd, Ord, Hash)]
 pub enum IndexerEnum {
-    RangeSubset
+    RangeSubset,
+    VIndex
 }
 
 impl Default for IndexerEnum {

--- a/zarrs/src/array_subset/indexers/indexer.rs
+++ b/zarrs/src/array_subset/indexers/indexer.rs
@@ -1,4 +1,6 @@
 //! Indexer trait with common functionality
+use std::num::NonZeroU64;
+
 use derive_more::{Display, From};
 use enum_dispatch::enum_dispatch;
 use itertools::izip;
@@ -11,7 +13,7 @@ use crate::{
     array::ArrayIndices,
     array_subset::{
         indexers::{RangeSubset, VIndex},
-        iterators::{ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices},
+        iterators::{Chunks, ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices},
         ArraySubset, IncompatibleArraySubsetAndShapeError, IncompatibleDimensionalityError,
     },
 };
@@ -145,6 +147,11 @@ pub trait Indexer: Send + Sync + Clone {
     ) -> Result<ContiguousIndices, IncompatibleArraySubsetAndShapeError>;
 
     fn to_enum(&self) -> IndexerEnum;
+
+    fn chunks(
+        &self,
+        chunk_shape: &[NonZeroU64],
+    ) -> Result<Chunks, IncompatibleDimensionalityError>;
 }
 
 #[enum_dispatch(Indexer)]

--- a/zarrs/src/array_subset/indexers/indexer.rs
+++ b/zarrs/src/array_subset/indexers/indexer.rs
@@ -138,6 +138,13 @@ pub trait Indexer: Send + Sync + Clone {
     }
 
     fn end_inc(&self) -> Option<ArrayIndices>;
+
+    fn contiguous_indices(
+        &self,
+        array_shape: &[u64],
+    ) -> Result<ContiguousIndices, IncompatibleArraySubsetAndShapeError>;
+
+    fn to_enum(&self) -> IndexerEnum;
 }
 
 #[enum_dispatch(Indexer)]
@@ -152,3 +159,4 @@ impl Default for IndexerEnum {
         IndexerEnum::RangeSubset(Default::default())
     }
 }
+

--- a/zarrs/src/array_subset/indexers/indexer.rs
+++ b/zarrs/src/array_subset/indexers/indexer.rs
@@ -3,12 +3,18 @@ use derive_more::{Display, From};
 use enum_dispatch::enum_dispatch;
 use itertools::izip;
 use serde_json::value::Index;
+use thiserror::Error;
 use zarrs_metadata::ArrayShape;
 use zarrs_storage::byte_range::ByteRange;
-use thiserror::Error;
 
-use crate::{array::ArrayIndices, array_subset::{indexers::{RangeSubset, VIndex}, iterators::{ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices}, ArraySubset, IncompatibleArraySubsetAndShapeError, IncompatibleDimensionalityError}};
-
+use crate::{
+    array::ArrayIndices,
+    array_subset::{
+        indexers::{RangeSubset, VIndex},
+        iterators::{ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices},
+        ArraySubset, IncompatibleArraySubsetAndShapeError, IncompatibleDimensionalityError,
+    },
+};
 
 #[enum_dispatch]
 pub trait Indexer: Send + Sync + Clone {
@@ -57,9 +63,12 @@ pub trait Indexer: Send + Sync + Clone {
             return false;
         }
 
-        for (self_start, self_end, other_start, other_end) in
-            izip!(self.start(), self.end_exc(), subset.start(), subset.end_exc())
-        {
+        for (self_start, self_end, other_start, other_end) in izip!(
+            self.start(),
+            self.end_exc(),
+            subset.start(),
+            subset.end_exc()
+        ) {
             if self_start < other_start || self_end > other_end {
                 return false;
             }
@@ -88,7 +97,6 @@ pub trait Indexer: Send + Sync + Clone {
         element_size: usize,
     ) -> Result<Vec<ByteRange>, IncompatibleArraySubsetAndShapeError>;
 
-
     /// Returns [`true`] if the array subset contains `indices`.
     #[must_use]
     fn contains(&self, indices: &[u64]) -> bool;
@@ -98,8 +106,11 @@ pub trait Indexer: Send + Sync + Clone {
     /// # Errors
     ///
     /// Returns [`IncompatibleDimensionalityError`] if the dimensionality of `subset_other` does not match the dimensionality of this array subset.
-    fn overlap(&self, subset_other: &ArraySubset) -> Result<ArraySubset, IncompatibleDimensionalityError>;
-    
+    fn overlap(
+        &self,
+        subset_other: &ArraySubset,
+    ) -> Result<ArraySubset, IncompatibleDimensionalityError>;
+
     /// Return the subset relative to `start`.
     ///
     /// Creates an array subset starting at [`ArraySubset::start()`] - `start`.
@@ -133,9 +144,11 @@ pub trait Indexer: Send + Sync + Clone {
 #[derive(Clone, Error, Debug, Eq, PartialEq, Display, PartialOrd, Ord, Hash)]
 pub enum IndexerEnum {
     RangeSubset,
-    VIndex
+    VIndex,
 }
 
 impl Default for IndexerEnum {
-    fn default() -> Self { IndexerEnum::RangeSubset(Default::default()) }
+    fn default() -> Self {
+        IndexerEnum::RangeSubset(Default::default())
+    }
 }

--- a/zarrs/src/array_subset/indexers/indexer.rs
+++ b/zarrs/src/array_subset/indexers/indexer.rs
@@ -88,19 +88,6 @@ pub trait Indexer: Send + Sync + Clone {
         element_size: usize,
     ) -> Result<Vec<ByteRange>, IncompatibleArraySubsetAndShapeError>;
 
-    fn to_enum(&self) -> IndexerEnum;
-
-    /// Returns an iterator over the linearised indices of elements within the subset.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the `array_shape` does not encapsulate this array subset.
-    fn linearised_indices(
-        &self,
-        array_shape: &[u64],
-    ) -> Result<LinearisedIndices, IncompatibleArraySubsetAndShapeError> {
-        LinearisedIndices::new(self.to_enum().into(), array_shape.to_vec())
-    }
 
     /// Returns [`true`] if the array subset contains `indices`.
     #[must_use]
@@ -120,27 +107,6 @@ pub trait Indexer: Send + Sync + Clone {
     /// # Errors
     /// Returns [`IncompatibleDimensionalityError`] if the length of `start` does not match the dimensionality of this array subset.
     fn relative_to(&self, start: &[u64]) -> Result<ArraySubset, IncompatibleDimensionalityError>;
-
-        /// Returns an iterator over the indices of contiguous elements within the subset.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the `array_shape` does not encapsulate this array subset.
-    fn contiguous_indices(
-        &self,
-        array_shape: &[u64],
-    ) -> Result<ContiguousIndices, IncompatibleArraySubsetAndShapeError>;
-
-    /// Returns an iterator over the linearised indices of contiguous elements within the subset.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the `array_shape` does not encapsulate this array subset.
-    fn contiguous_linearised_indices(
-        &self,
-        array_shape: &[u64],
-    ) -> Result<ContiguousLinearisedIndices, IncompatibleArraySubsetAndShapeError>;
-
 
     /// Return the shape of the array subset.
     ///

--- a/zarrs/src/array_subset/indexers/range_subset.rs
+++ b/zarrs/src/array_subset/indexers/range_subset.rs
@@ -172,6 +172,13 @@ impl Indexer for RangeSubset {
     fn contiguous_indices(&self,array_shape: &[u64],) -> Result<ContiguousIndices,IncompatibleArraySubsetAndShapeError> {
         ContiguousIndices::new_from_range_subset(self, array_shape)
     }
+
+    fn chunks(
+        &self,
+        chunk_shape: &[NonZeroU64],
+    ) -> Result<Chunks, IncompatibleDimensionalityError> {
+        Chunks::new_from_range_subset(self, chunk_shape)
+    }
 }
 
 impl RangeSubset {

--- a/zarrs/src/array_subset/indexers/range_subset.rs
+++ b/zarrs/src/array_subset/indexers/range_subset.rs
@@ -52,6 +52,11 @@ impl<T: IntoIterator<Item = Range<u64>>> From<T> for RangeSubset {
 }
 
 impl Indexer for RangeSubset {
+
+    fn to_enum(&self) -> IndexerEnum {
+        IndexerEnum::RangeSubset(self.clone())
+    }
+
     fn num_elements(&self) -> u64 {
         self.shape().iter().product()
     }
@@ -162,6 +167,10 @@ impl Indexer for RangeSubset {
                     .collect(),
             )
         }
+    }
+
+    fn contiguous_indices(&self,array_shape: &[u64],) -> Result<ContiguousIndices,IncompatibleArraySubsetAndShapeError> {
+        ContiguousIndices::new_from_range_subset(self, array_shape)
     }
 }
 

--- a/zarrs/src/array_subset/indexers/range_subset.rs
+++ b/zarrs/src/array_subset/indexers/range_subset.rs
@@ -1,0 +1,275 @@
+
+use thiserror::Error;
+
+use std::{
+    fmt::{Debug, Display},
+    num::NonZeroU64,
+    ops::Range,
+};
+
+use crate::array_subset::{iterators::{
+    Chunks, ContiguousIndices, ContiguousLinearisedIndices, Indices, LinearisedIndices,
+}, ArraySubset, ArraySubsetError, IncompatibleStartEndIndicesError};
+
+use derive_more::From;
+use itertools::izip;
+
+use crate::{
+    array::{unravel_index, ArrayError, ArrayIndices, ArrayShape}, array_subset::{IncompatibleDimensionalityError,IncompatibleArraySubsetAndShapeError}, storage::byte_range::ByteRange
+};
+
+use crate::array_subset::indexers::{Indexer, IndexerEnum};
+
+/// An array subset.
+///
+/// The unsafe `_unchecked methods` are mostly intended for internal use to avoid redundant input validation.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct RangeSubset {
+    /// The start of the array subset.
+    start: ArrayIndices,
+    /// The shape of the array subset.
+    shape: ArrayShape,
+}
+
+impl Display for RangeSubset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_ranges().fmt(f)
+    }
+}
+
+impl<T: IntoIterator<Item = Range<u64>>> From<T> for RangeSubset {
+    fn from(ranges: T) -> Self {
+        let (start, shape) = ranges
+        .into_iter()
+        .map(|range| (range.start, range.end.saturating_sub(range.start)))
+        .unzip();
+        Self { start, shape }
+    }
+}
+
+impl Indexer for RangeSubset {
+
+    fn num_elements(&self) -> u64 {
+        todo!()
+    }
+
+    fn is_compatible_shape(&self,array_shape: &[u64]) -> bool {
+        todo!()
+    }
+
+    fn find_linearised_index(&self,index:usize) -> ArrayIndices {
+        todo!()
+    }
+
+ 
+    fn shape(&self) ->  &[u64] {
+        todo!()
+    }
+
+
+    fn start(&self) ->  &[u64] {
+        todo!()
+    }
+
+
+    fn dimensionality(&self) -> usize {
+        todo!()
+    }
+
+    fn end_exc(&self) -> ArrayIndices {
+        todo!()
+    }
+
+    fn byte_ranges(&self,array_shape: &[u64],element_size:usize,) -> Result<Vec<ByteRange>,IncompatibleArraySubsetAndShapeError> {
+        todo!()
+    }
+
+    fn to_enum(&self) -> IndexerEnum {
+        todo!()
+    }
+
+    fn contains(&self,indices: &[u64]) -> bool {
+        todo!()
+    }
+
+    fn overlap(&self,subset_other: &ArraySubset) -> Result<ArraySubset,IncompatibleDimensionalityError> {
+        todo!()
+    }
+
+    fn relative_to(&self,start: &[u64]) -> Result<ArraySubset,IncompatibleDimensionalityError> {
+        todo!()
+    }
+
+    fn contiguous_indices(&self,array_shape: &[u64],) -> Result<ContiguousIndices,IncompatibleArraySubsetAndShapeError> {
+        todo!()
+    }
+
+    fn contiguous_linearised_indices(&self,array_shape: &[u64],) -> Result<ContiguousLinearisedIndices,IncompatibleArraySubsetAndShapeError> {
+        todo!()
+    }
+
+    fn end_inc(&self) -> Option<ArrayIndices> {
+        todo!()
+    }
+}
+
+impl RangeSubset {
+ 
+    /// Create a new array subset from a list of [`Range`]s.
+    #[must_use]
+    pub fn new_with_ranges(ranges: &[Range<u64>]) -> Self {
+        let start = ranges.iter().map(|range| range.start).collect();
+        let shape = ranges.iter().map(|range| range.end - range.start).collect();
+        Self { start, shape }
+    }
+
+    /// Create a new array subset with `size` starting at the origin.
+    #[must_use]
+    pub fn new_with_shape(shape: ArrayShape) -> Self {
+        Self {
+            start: vec![0; shape.len()],
+            shape,
+        }
+    }
+
+    /// Create a new array subset.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IncompatibleDimensionalityError`] if the size of `start` and `size` do not match.
+    pub fn new_with_start_shape(
+        start: ArrayIndices,
+        shape: ArrayShape,
+    ) -> Result<Self, IncompatibleDimensionalityError> {
+        if start.len() == shape.len() {
+            Ok(Self { start, shape })
+        } else {
+            Err(IncompatibleDimensionalityError::new(
+                start.len(),
+                shape.len(),
+            ))
+        }
+    }
+
+    /// Create a new array subset from a start and end (inclusive).
+    ///
+    /// # Errors
+    /// Returns [`IncompatibleStartEndIndicesError`] if `start` and `end` are incompatible, such as if any element of `end` is less than `start` or they differ in length.
+    pub fn new_with_start_end_inc(
+        start: ArrayIndices,
+        end: ArrayIndices,
+    ) -> Result<Self, IncompatibleStartEndIndicesError> {
+        if start.len() != end.len() || std::iter::zip(&start, &end).any(|(start, end)| end < start)
+        {
+            Err(IncompatibleStartEndIndicesError::from((start, end)))
+        } else {
+            let shape = std::iter::zip(&start, end)
+                .map(|(&start, end)| end.saturating_sub(start) + 1)
+                .collect();
+            Ok(Self { start, shape })
+        }
+    }
+
+    /// Create a new array subset from a start and end (exclusive).
+    ///
+    /// # Errors
+    /// Returns [`IncompatibleStartEndIndicesError`] if `start` and `end` are incompatible, such as if any element of `end` is less than `start` or they differ in length.
+    pub fn new_with_start_end_exc(
+        start: ArrayIndices,
+        end: ArrayIndices,
+    ) -> Result<Self, IncompatibleStartEndIndicesError> {
+        if start.len() != end.len() || std::iter::zip(&start, &end).any(|(start, end)| end < start)
+        {
+            Err(IncompatibleStartEndIndicesError::from((start, end)))
+        } else {
+            let shape = std::iter::zip(&start, end)
+                .map(|(&start, end)| end.saturating_sub(start))
+                .collect();
+            Ok(Self { start, shape })
+        }
+    }
+
+    /// Return the array subset as a vec of ranges.
+    #[must_use]
+    pub fn to_ranges(&self) -> Vec<Range<u64>> {
+        std::iter::zip(&self.start, &self.shape)
+            .map(|(&start, &size)| start..start + size)
+            .collect()
+    }
+
+    /// Bound the array subset to the domain within `end` (exclusive).
+    ///
+    /// # Errors
+    /// Returns an error if `end` does not match the array subset dimensionality.
+    pub fn bound(&self, end: &[u64]) -> Result<Self, ArraySubsetError> {
+        if end.len() == self.dimensionality() {
+            let start = std::iter::zip(self.start(), end)
+                .map(|(&a, &b)| std::cmp::min(a, b))
+                .collect();
+            let end = std::iter::zip(self.end_exc(), end)
+                .map(|(a, &b)| std::cmp::min(a, b))
+                .collect();
+            Ok(Self::new_with_start_end_exc(start, end)?)
+        } else {
+            Err(IncompatibleDimensionalityError::new(end.len(), self.dimensionality()).into())
+        }
+    }
+
+    /// Return the elements in this array subset from an array with shape `array_shape`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IncompatibleArraySubsetAndShapeError`] if the length of `array_shape` does not match the array subset dimensionality or the array subset is outside of the bounds of `array_shape`.
+    ///
+    /// # Panics
+    /// Panics if attempting to access a byte index beyond [`usize::MAX`].
+    pub fn extract_elements<T: std::marker::Copy>(
+        &self,
+        elements: &[T],
+        array_shape: &[u64],
+    ) -> Result<Vec<T>, IncompatibleArraySubsetAndShapeError> {
+        let is_same_shape = elements.len() as u64 == array_shape.iter().product::<u64>();
+        let is_correct_dimensionality = array_shape.len() == self.dimensionality();
+        let is_in_bounds = self
+            .end_exc()
+            .iter()
+            .zip(array_shape)
+            .all(|(end, shape)| end <= shape);
+        if !(is_correct_dimensionality && is_in_bounds && is_same_shape) {
+            return Err(IncompatibleArraySubsetAndShapeError::new(
+self.to_enum().into(),
+                array_shape.to_vec(),
+            ));
+        }
+        let num_elements = usize::try_from(self.num_elements()).unwrap();
+        let mut elements_subset = Vec::with_capacity(num_elements);
+        let elements_subset_slice = crate::vec_spare_capacity_to_mut_slice(&mut elements_subset);
+        let mut subset_offset = 0;
+        // SAFETY: `array_shape` is encapsulated by an array with `array_shape`.
+        let contiguous_elements = self.contiguous_linearised_indices(array_shape)?;
+        let element_length = contiguous_elements.contiguous_elements_usize();
+        for array_index in &contiguous_elements {
+            let element_offset = usize::try_from(array_index).unwrap();
+            debug_assert!(element_offset + element_length <= elements.len());
+            debug_assert!(subset_offset + element_length <= num_elements);
+            elements_subset_slice[subset_offset..subset_offset + element_length]
+                .copy_from_slice(&elements[element_offset..element_offset + element_length]);
+            subset_offset += element_length;
+        }
+        unsafe { elements_subset.set_len(num_elements) };
+        Ok(elements_subset)
+    }
+
+    fn find_on_axis(&self, index: &u64, axis: usize) -> u64 {
+        let shape = self.start();
+        shape[axis] + index
+    }
+    /// Create a new empty array subset.
+    #[must_use]
+    pub fn new_empty(dimensionality: usize) -> Self {
+        Self {
+            start: vec![0; dimensionality],
+            shape: vec![0; dimensionality],
+        }
+    }
+}

--- a/zarrs/src/array_subset/indexers/vindex.rs
+++ b/zarrs/src/array_subset/indexers/vindex.rs
@@ -42,6 +42,11 @@ impl Display for VIndex {
 }
 
 impl Indexer for VIndex {
+
+    fn to_enum(&self) -> IndexerEnum {
+        IndexerEnum::VIndex(self.clone())
+    }
+
     fn num_elements(&self) -> u64 {
         if self.are_dimension_first_indices {
             return self.indices[0].len() as u64;
@@ -188,6 +193,10 @@ impl Indexer for VIndex {
                 self.dimensionality(),
             ))
         }
+    }
+
+    fn contiguous_indices(&self,array_shape: &[u64],) -> Result<ContiguousIndices,IncompatibleArraySubsetAndShapeError> {
+        ContiguousIndices::new_from_discontinuous( self, array_shape)
     }
 }
 

--- a/zarrs/src/array_subset/indexers/vindex.rs
+++ b/zarrs/src/array_subset/indexers/vindex.rs
@@ -1,0 +1,298 @@
+use std::fmt::{Debug, Display};
+
+use crate::array::{ArrayIndices, ArrayShape};
+
+use crate::array_subset::iterators::{ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices};
+use crate::array_subset::{ArraySubset, IncompatibleArraySubsetAndShapeError, IncompatibleDimensionalityError};
+use crate::array_subset::indexers::{Indexer, IndexerEnum};
+use itertools::{izip, Itertools};
+use derive_more::From;
+use thiserror::Error;
+use zarrs_storage::byte_range::ByteRange;
+
+// TODO: sorted for now assumed
+
+/// A vindex array subset
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct VIndex {
+    /// The start of the array subset.
+    start: ArrayIndices,
+    /// The shape of the array subset.
+    shape: ArrayShape,
+    /// The indices themselves
+    indices: Vec<Vec<u64>>,
+    /// How to interpret the indices
+    are_dimension_first_indices: bool,
+}
+
+fn transpose(v: &Vec<Vec<u64>>) -> Vec<Vec<u64>>
+{
+    (0..v[0].len())
+        .map(|i| v.iter().map(|inner| inner[i].clone()).collect::<Vec<_>>())
+        .collect()
+}
+
+impl Display for VIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.indices.fmt(f)
+    }
+}
+
+impl Indexer for VIndex {
+
+    fn num_elements(&self) -> u64 {
+        if self.are_dimension_first_indices {
+            return self.indices[0].len() as u64;
+        }
+        return self.indices.len() as u64;
+    }
+
+    fn is_compatible_shape(&self, array_shape: &[u64]) -> bool {
+        let is_compat_array_shape = array_shape.iter().skip(1).all_equal_value() != Ok(&1);
+        if self.are_dimension_first_indices {
+            return self.indices[0].len() <= (array_shape[0] as usize) && is_compat_array_shape;
+        }
+        self.indices.len() <= (array_shape[0] as usize) && is_compat_array_shape
+    }
+
+    fn shape(&self) -> &[u64] {
+        &self.shape
+    }
+
+    fn find_linearised_index(&self, index: usize) -> ArrayIndices {
+        if self.are_dimension_first_indices {
+            return self.indices.iter().map(|i| i[index]).collect::<Vec<_>>();
+        }
+        self.indices[index].clone()
+    }
+
+    fn end_exc(&self) -> ArrayIndices {
+        if self.are_dimension_first_indices {
+            return self.indices.iter().map(|i| i[i.len() - 1] + 1).collect::<Vec<_>>();
+        }
+        self.indices[self.indices.len() - 1].clone()
+    }
+
+    fn end_inc(&self) -> Option<ArrayIndices> {
+        if self.is_empty() {
+            None
+        } else {
+            if self.are_dimension_first_indices {
+                return Some(self.indices.iter().map(|i| i[i.len() - 1]).collect::<Vec<_>>());
+            }
+            Some(self.indices[self.indices.len() - 1].clone())
+        }
+    }
+
+    fn start(&self) -> &[u64] {
+        &self.start
+    }
+
+    fn dimensionality(&self) -> usize {
+        if self.are_dimension_first_indices {
+            return self.indices.len();
+        }
+        return self.indices[0].len();
+    }
+
+    fn byte_ranges(
+        &self,
+        array_shape: &[u64],
+        element_size: usize,
+    ) -> Result<Vec<ByteRange>, IncompatibleArraySubsetAndShapeError> {
+        let mut byte_ranges: Vec<ByteRange> = Vec::new();
+        let linearised_indices = self.linearised_indices(&array_shape)?;
+        for array_index in &linearised_indices {
+            let byte_index = array_index * element_size as u64;
+            byte_ranges.push(ByteRange::FromStart(byte_index, Some(element_size as u64)));
+        }
+        Ok(byte_ranges)
+    }
+
+    fn contains(&self, indices: &[u64]) -> bool {
+        if self.are_dimension_first_indices {
+            return indices.iter().zip(&self.indices).all(|(index, vindex)| vindex.contains(index) );
+        }
+        self.indices.contains(&indices.to_vec())
+    }
+
+    fn overlap(&self, subset_other: &ArraySubset) -> Result<ArraySubset, IncompatibleDimensionalityError> {
+        if let IndexerEnum::RangeSubset(range_subset) = &subset_other.indexer {
+            if range_subset.dimensionality() == self.dimensionality() {
+                let indices: Vec<Vec<u64>>;
+                if self.are_dimension_first_indices{
+                    indices = transpose(&self.indices).into_iter().filter(|row| izip!(row.iter(), subset_other.start(), subset_other.end_exc()).all(|(i, s, e)| i >= s && i < &e)).collect::<Vec<Vec<u64>>>();
+                } else {
+                    indices = self.indices.clone();
+                }
+                return Ok(IndexerEnum::VIndex(Self::new_from_selection_first_indices(indices).unwrap()).into()); // TODO: handle error better
+            } else {
+                return Err(IncompatibleDimensionalityError::new(
+                    range_subset.dimensionality(),
+                    self.dimensionality(),
+                ));
+            }
+        } else {
+            todo!("Intersect other types or handle error more gracefully (ugh)")
+        }
+    }
+
+    fn relative_to(&self, start: &[u64]) -> Result<ArraySubset, IncompatibleDimensionalityError> {
+        if start.len() == self.dimensionality() {
+            let iter: std::vec::IntoIter<Vec<u64>>;
+            if self.are_dimension_first_indices {
+                iter = transpose(&self.indices).into_iter();
+            } else {
+                iter = self.indices.clone().into_iter();
+            }
+            let indices = iter.filter(|row| row.iter().zip(start).all(|(i, s)| i >= s)).collect::<Vec<Vec<u64>>>();
+            let shape = vec![indices[0].len() as u64];
+            Ok(IndexerEnum::VIndex(Self {
+                indices,
+                start: start.to_vec(),
+                shape,
+                are_dimension_first_indices: false
+            }).into())
+            
+        } else {
+            Err(IncompatibleDimensionalityError::new(
+                start.len(),
+                self.dimensionality(),
+            ))
+        }
+    }
+}
+
+impl VIndex {
+
+    fn linearised_indices(
+        &self,
+        array_shape: &[u64],
+    ) -> Result<LinearisedIndices, IncompatibleArraySubsetAndShapeError> {
+        LinearisedIndices::new(IndexerEnum::VIndex(self.clone()).into(), array_shape.to_vec()) // TODO: better handling of these iterators
+    }
+}
+
+/// An incompatible array and array shape error.
+#[derive(Clone, Debug, Error, From)]
+#[error("At least one of the indices was not equal to the others in length: {0:?}")]
+pub struct UnequalVIndexLengthsError(Vec<usize>);
+
+impl UnequalVIndexLengthsError {
+    /// Create a new incompatible array subset and shape error.
+    #[must_use]
+    pub fn new(indices_lengths: Vec<usize>) -> Self {
+        Self(indices_lengths)
+    }
+}
+
+/// An incompatible array and array shape error.
+#[derive(Clone, Debug, Error, From, Default)]
+#[error("Empty indices")]
+pub struct EmptyVIndexError;
+
+/// An incompatible VIndex argument
+#[derive(Debug, Error)]
+pub enum VIndexError{
+    /// An incompatible array and array shape error.
+    #[error("At least one of the indices was not equal to the others in length: {0}")]
+    UnequalVIndexLengths(#[from] UnequalVIndexLengthsError),
+    /// An incompatible array and array shape error.
+    #[error("Empty indices")]
+    EmptyVIndex(#[from] EmptyVIndexError),
+}
+fn check_indices(indices: &[Vec<u64>]) -> Result<(), VIndexError> {
+    if indices.len() == 0 || indices[0].len() == 0 {
+        return Err(EmptyVIndexError.into());
+    }
+    if !indices.iter().map(|x: &Vec<u64>| x.len()).all_equal() {
+        return Err(UnequalVIndexLengthsError::new(indices.iter().map(|x| x.len()).collect()).into());
+    }
+    Ok(())
+}
+
+
+impl VIndex {
+
+    pub fn new_from_dimension_first_indices(indices: Vec<ArrayIndices>) -> Result<Self, VIndexError> {
+        check_indices(&indices)?;
+        let shape = vec![indices[0].len() as u64];
+        let start = indices.iter().map(|i| i[0]).collect::<Vec<_>>();
+        Ok(
+            Self {
+                shape,
+                start,
+                indices,
+                are_dimension_first_indices: true
+            }
+        )
+    }
+
+    pub fn new_from_selection_first_indices(indices: Vec<ArrayIndices>) -> Result<Self, VIndexError> {
+        check_indices(&indices)?;
+        let shape = vec![indices.len() as u64];
+        let start = indices[0].clone();
+        Ok(
+            Self {
+                shape,
+                start,
+                indices,
+                are_dimension_first_indices: false
+            }
+        )
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    use crate::{array_subset::indexers::Indexer, array_subset::indexers::vindex::VIndexError};
+
+    use super::VIndex;
+
+
+    #[test]
+    fn vindex_new_ok() {
+        assert!(VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2, 5]]).is_ok())
+    }
+    #[test]
+    fn vindex_new_unequal() {
+        assert!(VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2]]).is_err_and(|x|
+            matches!(x, VIndexError::UnequalVIndexLengths(_))
+        ))
+    }
+
+    #[test]
+    fn vindex_new_empty() {
+        assert!(VIndex::new_from_dimension_first_indices(vec![]).is_err_and(|x|
+            matches!(x, VIndexError::EmptyVIndex(_))
+        ))
+    }
+
+    #[test]
+    fn vindex_byte_ranges_dimension_first() {
+        let indexer = VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2, 5]]).unwrap();
+        indexer.byte_ranges(vec![10, 10].as_slice(), 4)
+            .unwrap()
+            .iter()
+            .zip(vec![4, 40, 88, 220])
+            .for_each(|(byte_range, expected)| {
+                assert_eq!(byte_range.start(0), expected);
+                assert_eq!(byte_range.end(0), expected + 4);
+            });
+    }
+
+    #[test]
+    fn vindex_byte_ranges_selection_first() {
+        let indexer = VIndex::new_from_selection_first_indices(vec![vec![0, 1],  vec![1, 0], vec![2, 2], vec![5, 5]]).unwrap();
+        indexer.byte_ranges(vec![10, 10].as_slice(), 4)
+            .unwrap()
+            .iter()
+            .zip(vec![4, 40, 88, 220])
+            .for_each(|(byte_range, expected)| {
+                assert_eq!(byte_range.start(0), expected);
+                assert_eq!(byte_range.end(0), expected + 4);
+            });
+    }
+}

--- a/zarrs/src/array_subset/indexers/vindex.rs
+++ b/zarrs/src/array_subset/indexers/vindex.rs
@@ -1,10 +1,11 @@
 use std::fmt::{Debug, Display};
+use std::num::NonZeroU64;
 
 use crate::array::{ArrayIndices, ArrayShape};
 
 use crate::array_subset::indexers::{Indexer, IndexerEnum};
 use crate::array_subset::iterators::{
-    ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices,
+    Chunks, ContiguousIndices, ContiguousLinearisedIndices, LinearisedIndices
 };
 use crate::array_subset::{
     ArraySubset, IncompatibleArraySubsetAndShapeError, IncompatibleDimensionalityError,
@@ -198,6 +199,14 @@ impl Indexer for VIndex {
     fn contiguous_indices(&self,array_shape: &[u64],) -> Result<ContiguousIndices,IncompatibleArraySubsetAndShapeError> {
         ContiguousIndices::new_from_discontinuous( self, array_shape)
     }
+
+
+    fn chunks(
+        &self,
+        chunk_shape: &[NonZeroU64],
+    ) -> Result<Chunks, IncompatibleDimensionalityError> {
+        todo!("Implement")
+    }
 }
 
 impl VIndex {
@@ -253,6 +262,8 @@ fn check_indices(indices: &[Vec<u64>]) -> Result<(), VIndexError> {
 }
 
 impl VIndex {
+    /// Create a new VIndex where the indices look like [[0, 0, 1, ...], [0, 1, 2, ...], ...] i.e., make the selection (0, 0, ..) and then (0, 1, ...)
+    /// Here the dimension of the VIndex object i.e., its size is the first shape dimension.
     pub fn new_from_dimension_first_indices(
         indices: Vec<ArrayIndices>,
     ) -> Result<Self, VIndexError> {
@@ -267,6 +278,8 @@ impl VIndex {
         })
     }
 
+    /// Create a new VIndex where the indices look like [[0, 0], [0, 1], ...] i.e., make the selections (0, 0), then (0, 1)...
+    /// Here the first dimension shape is the number of selections and the start is indices[0].
     pub fn new_from_selection_first_indices(
         indices: Vec<ArrayIndices>,
     ) -> Result<Self, VIndexError> {

--- a/zarrs/src/array_subset/iterators/contiguous_linearised_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/contiguous_linearised_indices_iterator.rs
@@ -19,14 +19,17 @@ use super::{contiguous_indices_iterator::ContiguousIndices, ContiguousIndicesIte
 /// 6   7   8
 /// 9  10  11
 /// ```
+/// with a `contiguous_elements{_usize}` of `9`.
+/// 
 /// An iterator with an array subset covering the entire array will produce
 /// ```rust,ignore
-/// [(0, 9)]
+/// [0]
 /// ```
 /// An iterator with an array subset corresponding to the lower right 2x2 region will produce
 /// ```rust,ignore
-/// [(7, 2), (10, 2)]
+/// [7, 10]
 /// ```
+/// with a `contiguous_elements{_usize}` of `2`.
 pub struct ContiguousLinearisedIndices {
     inner: ContiguousIndices,
     array_shape: Vec<u64>,

--- a/zarrs/src/array_subset/iterators/contiguous_linearised_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/contiguous_linearised_indices_iterator.rs
@@ -20,7 +20,7 @@ use super::{contiguous_indices_iterator::ContiguousIndices, ContiguousIndicesIte
 /// 9  10  11
 /// ```
 /// with a `contiguous_elements{_usize}` of `9`.
-/// 
+///
 /// An iterator with an array subset covering the entire array will produce
 /// ```rust,ignore
 /// [0]

--- a/zarrs/src/array_subset/iterators/indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/indices_iterator.rs
@@ -139,11 +139,8 @@ impl Iterator for IndicesIterator<'_> {
     type Item = ArrayIndices;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut indices = unravel_index(self.range.start as u64, self.subset.shape());
-        std::iter::zip(indices.iter_mut(), self.subset.start())
-            .for_each(|(index, start)| *index += start);
-
-        if self.range.start < self.range.end {
+        if self.range.start < self.range.end && self.range.start < self.subset.num_elements_usize() {
+            let indices = self.subset.find_linearised_index(self.range.start);
             self.range.start += 1;
             Some(indices)
         } else {
@@ -161,9 +158,7 @@ impl DoubleEndedIterator for IndicesIterator<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.range.end > self.range.start {
             self.range.end -= 1;
-            let mut indices = unravel_index(self.range.end as u64, self.subset.shape());
-            std::iter::zip(indices.iter_mut(), self.subset.start())
-                .for_each(|(index, start)| *index += start);
+            let indices = self.subset.find_linearised_index(self.range.end);
             Some(indices)
         } else {
             None

--- a/zarrs/src/array_subset/iterators/indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/indices_iterator.rs
@@ -246,6 +246,8 @@ impl<'a> From<&'a ParIndicesIterator<'_>> for ParIndicesIteratorProducer<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::array_subset::indexers::{IndexerEnum, VIndex};
+
     use super::*;
 
     #[test]
@@ -273,15 +275,14 @@ mod tests {
     }
 
     #[test]
-    fn indices_iterator_empty() {
+    fn indices_iterator_from_vindex_full() {
         let indices =
-            Indices::new_with_start_end(ArraySubset::new_with_ranges(&[1..3, 5..7]), 5..5);
-        assert_eq!(indices.len(), 0);
-        assert!(indices.is_empty());
-
-        let indices =
-            Indices::new_with_start_end(ArraySubset::new_with_ranges(&[1..3, 5..7]), 5..1);
-        assert_eq!(indices.len(), 0);
-        assert!(indices.is_empty());
+            Indices::new_with_start_end(IndexerEnum::VIndex(VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2, 5]]).unwrap()).into(), 0..3);
+        assert_eq!(indices.len(), 3);
+        let mut iter = indices.iter();
+        assert_eq!(iter.next(), Some(vec![0, 1]));
+        assert_eq!(iter.next_back(), Some(vec![2, 2]));
+        assert_eq!(iter.next(), Some(vec![1, 0]));
+        assert_eq!(iter.next(), None);
     }
 }

--- a/zarrs/src/array_subset/iterators/indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/indices_iterator.rs
@@ -139,7 +139,8 @@ impl Iterator for IndicesIterator<'_> {
     type Item = ArrayIndices;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.range.start < self.range.end && self.range.start < self.subset.num_elements_usize() {
+        if self.range.start < self.range.end && self.range.start < self.subset.num_elements_usize()
+        {
             let indices = self.subset.find_linearised_index(self.range.start);
             self.range.start += 1;
             Some(indices)
@@ -276,8 +277,14 @@ mod tests {
 
     #[test]
     fn indices_iterator_from_vindex_full() {
-        let indices =
-            Indices::new_with_start_end(IndexerEnum::VIndex(VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2, 5]]).unwrap()).into(), 0..3);
+        let indices = Indices::new_with_start_end(
+            IndexerEnum::VIndex(
+                VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2, 5]])
+                    .unwrap(),
+            )
+            .into(),
+            0..3,
+        );
         assert_eq!(indices.len(), 3);
         let mut iter = indices.iter();
         assert_eq!(iter.next(), Some(vec![0, 1]));

--- a/zarrs/src/array_subset/iterators/linearised_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/linearised_indices_iterator.rs
@@ -34,7 +34,10 @@ impl LinearisedIndices {
     ) -> Result<Self, IncompatibleArraySubsetAndShapeError> {
         if !subset.is_compatible_shape(&array_shape) {
             // TODO: Resolve error behavior
-            return Err(IncompatibleArraySubsetAndShapeError::new(subset, array_shape));
+            return Err(IncompatibleArraySubsetAndShapeError::new(
+                subset,
+                array_shape,
+            ));
         };
         return Ok(Self {
             subset,
@@ -160,12 +163,17 @@ mod tests {
         assert!(indices.is_empty());
     }
 
-
     #[test]
     fn linearised_vindices_iterator_partial() {
-        let indices =
-            LinearisedIndices::new(IndexerEnum::VIndex(VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2, 5]]).unwrap()).into(), vec![8, 8])
-                .unwrap();
+        let indices = LinearisedIndices::new(
+            IndexerEnum::VIndex(
+                VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2, 5]])
+                    .unwrap(),
+            )
+            .into(),
+            vec![8, 8],
+        )
+        .unwrap();
         assert_eq!(indices.len(), 4);
         let mut iter = indices.iter();
         assert_eq!(iter.next(), Some(1)); // [0,1]

--- a/zarrs/src/array_subset/iterators/linearised_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/linearised_indices_iterator.rs
@@ -125,6 +125,8 @@ impl FusedIterator for LinearisedIndicesIterator<'_> {}
 
 #[cfg(test)]
 mod tests {
+    use crate::array_subset::indexers::{IndexerEnum, VIndex};
+
     use super::*;
 
     #[test]
@@ -156,5 +158,20 @@ mod tests {
                 .unwrap();
         assert_eq!(indices.len(), 0);
         assert!(indices.is_empty());
+    }
+
+
+    #[test]
+    fn linearised_vindices_iterator_partial() {
+        let indices =
+            LinearisedIndices::new(IndexerEnum::VIndex(VIndex::new_from_dimension_first_indices(vec![vec![0, 1, 2, 5], vec![1, 0, 2, 5]]).unwrap()).into(), vec![8, 8])
+                .unwrap();
+        assert_eq!(indices.len(), 4);
+        let mut iter = indices.iter();
+        assert_eq!(iter.next(), Some(1)); // [0,1]
+        assert_eq!(iter.next(), Some(8)); // [1,0]
+        assert_eq!(iter.next_back(), Some(45)); // [5,5]
+        assert_eq!(iter.next(), Some(18)); // [2,2]
+        assert_eq!(iter.next(), None);
     }
 }

--- a/zarrs/src/array_subset/iterators/linearised_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/linearised_indices_iterator.rs
@@ -32,16 +32,14 @@ impl LinearisedIndices {
         subset: ArraySubset,
         array_shape: ArrayShape,
     ) -> Result<Self, IncompatibleArraySubsetAndShapeError> {
-        if subset.dimensionality() == array_shape.len()
-            && std::iter::zip(subset.end_exc(), &array_shape).all(|(end, shape)| end <= *shape)
-        {
-            Ok(Self {
-                subset,
-                array_shape,
-            })
-        } else {
-            Err(IncompatibleArraySubsetAndShapeError(subset, array_shape))
-        }
+        if !subset.is_compatible_shape(&array_shape) {
+            // TODO: Resolve error behavior
+            return Err(IncompatibleArraySubsetAndShapeError::new(subset, array_shape));
+        };
+        return Ok(Self {
+            subset,
+            array_shape,
+        });
     }
 
     /// Create a new linearised indices iterator.


### PR DESCRIPTION
Fixes #52

This is in a rough state but I think the first two commits contain the basic structure of how I went about this:

1. Create a `trait Indexer` and `enum_dispatch` it.
2. Make `ArraySubset` a wrapper around the `enum_dispatch`-ed `IndexerEnum`
3. Implement `RangeSubset` which is basically all the old methods from `ArraySubset` that intersected the new trait.  

At this point, everything compiled and tests passed.

Then I started adding more methods to the `trait` and implementing a new indexer, `VIndex` (vectorized indexing).

I landed on this route for a few reasons:

1. Using the raw trait in any meaningful way through the codebase is problematic because
      a.  It would require a massive refactor, going one-by-one and figuring out what is actually using `ArraySusbet` for its range capability and what is "generic" to the underlying indexing method.  This would also be a total breaking change.
      b. Using the trait directly (`impl` or `dyn`) is not `dyn` compatible and we have a lot of things that are `dyn` compatible and would break
      c. A non-trivial amount of generic code might start to appear if we can't rely in `impl Indexer`
2. I think there is some issue making `ArraySubset` actually the `IndexerEnum` i.e., `ArraySusbet` is itself `enum_dispatch`-ed and not a wrapper.  I can't remember what it is off-hand, but it's something nasty.  In any case, if that isn't a problem, it would be easy to swap it out, I think.

I think the main downside is that end-users might somehow lose sight of what a given `ArraySubset` represents.  I actually don't think this is really an issue at the moment given that all the methods/iterators generalize pretty well so it probably shouldn't matter, but I could see this monolithic approach being bad (i.e., hiding everything behind `ArraySubset`).

Please be kind! I really enjoyed implementing this feature and would be excited to learn more!

Some TODOs:

- [ ] **Add higher level array tests for `VIndex`**.  I think at this point, all the plumbing is in-place to try out actually subsetting an array using this type of indexing
- [ ] **Add more indexing methods** So outer indexing and mixed indexing
- [ ] **Documentation, linting etc** This has slipped...apologies if it's bad dev practice.
- [ ] **API cleanup** I think there are a number of methods that can be removed/cleaned up/tested.  I found a number of things that seem to be unused throughout the code base but are public (If I remember correctly). 

And if there is an architecture for this feature that is simpler, I'm all ears! I think the plumbing here of having the trait is good, so we can maybe pivot.  And it's also now clear what methods are really "necessary."