### PR TITLE
refactor: revert contiguous iterator outputs to `(_, u64)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: Change `byte_range::extract_byte_ranges_read_seek` to take `T` instead of `&mut T`
 - **Breaking**: Auto implement `[Async]BytesPartialDecoderTraits` for `T: AsRef<[u8]> + ...`
 - **Breaking**: `Arc` the `ChunkCache` types
+- **Breaking**: Change `Contiguous[Linearised]Indices` iterators to include the number of contiguous indices in their `Item`
 - Bump `zarrs_metadata_ext` to 0.2.0
 - Bump `zarrs_storage` to 0.4.0
 - Bump `blosc-src` to 0.3.6

--- a/zarrs/src/array_subset/iterators.rs
+++ b/zarrs/src/array_subset/iterators.rs
@@ -103,7 +103,7 @@ mod tests {
         let mut iter = indices.into_iter();
         assert_eq!(iter.size_hint(), (1, Some(1)));
         assert_eq!(iter.contiguous_elements(), 4);
-        assert_eq!(iter.next(), Some(vec![0, 0]));
+        assert_eq!(iter.next(), Some((vec![0, 0], 4)));
         assert_eq!(iter.next(), None);
     }
 
@@ -118,11 +118,11 @@ mod tests {
         let mut iter = indices.iter();
         assert_eq!(iter.size_hint(), (2, Some(2)));
         assert_eq!(iter.contiguous_elements(), 2);
-        assert_eq!(iter.next_back(), Some(vec![2, 1]));
-        assert_eq!(iter.next(), Some(vec![1, 1]));
+        assert_eq!(iter.next_back(), Some((vec![2, 1], 2)));
+        assert_eq!(iter.next(), Some((vec![1, 1], 2)));
         assert_eq!(iter.next(), None);
 
-        let expected = vec![vec![1, 1], vec![2, 1]];
+        let expected = vec![(vec![1, 1], 2), (vec![2, 1], 2)];
         assert_eq!(indices.iter().collect::<Vec<_>>(), expected);
         // assert_eq!(indices.par_iter().collect::<Vec<_>>(), expected);
         assert_eq!(indices.clone().into_iter().collect::<Vec<_>>(), expected);
@@ -134,7 +134,7 @@ mod tests {
         let subset = ArraySubset::new_with_ranges(&[1..3, 0..1, 0..2, 0..2]);
         let indices = subset.contiguous_indices(&[3, 1, 2, 2]).unwrap();
 
-        let expected = vec![vec![1, 0, 0, 0]];
+        let expected = vec![(vec![1, 0, 0, 0], 8)];
         assert_eq!(indices.iter().collect::<Vec<_>>(), expected);
         // assert_eq!(indices.par_iter().collect::<Vec<_>>(), expected);
         assert_eq!(indices.clone().into_iter().collect::<Vec<_>>(), expected);
@@ -156,11 +156,11 @@ mod tests {
         // 12 13 14 15
         assert_eq!(iter.size_hint(), (2, Some(2)));
         assert_eq!(iter.contiguous_elements(), 2);
-        assert_eq!(iter.next_back(), Some(9));
-        assert_eq!(iter.next(), Some(5));
+        assert_eq!(iter.next_back(), Some((9, 2)));
+        assert_eq!(iter.next(), Some((5, 2)));
         assert_eq!(iter.next(), None);
 
-        let expected = vec![5, 9];
+        let expected = vec![(5, 2), (9, 2)];
         assert_eq!(indices.iter().collect::<Vec<_>>(), expected);
         // assert_eq!(indices.par_iter().collect::<Vec<_>>(), expected);
         assert_eq!(indices.clone().into_iter().collect::<Vec<_>>(), expected);

--- a/zarrs/src/array_subset/iterators/contiguous_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/contiguous_indices_iterator.rs
@@ -122,7 +122,7 @@ impl ContiguousIndices {
 }
 
 impl<'a> IntoIterator for &'a ContiguousIndices {
-    type Item = ArrayIndices;
+    type Item = (ArrayIndices, u64);
     type IntoIter = ContiguousIndicesIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -138,7 +138,7 @@ impl<'a> IntoIterator for &'a ContiguousIndices {
 }
 
 impl IntoIterator for ContiguousIndices {
-    type Item = ArrayIndices;
+    type Item = (ArrayIndices, u64);
     type IntoIter = ContiguousIndicesIntoIterator;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -189,10 +189,10 @@ macro_rules! impl_contiguous_indices_iterator {
         }
 
         impl Iterator for $iterator_type {
-            type Item = ArrayIndices;
+            type Item = (ArrayIndices, u64);
 
             fn next(&mut self) -> Option<Self::Item> {
-                self.inner.next()
+                self.inner.next().map(|i| (i, self.contiguous_elements()))
             }
 
             fn size_hint(&self) -> (usize, Option<usize>) {
@@ -202,7 +202,9 @@ macro_rules! impl_contiguous_indices_iterator {
 
         impl DoubleEndedIterator for $iterator_type {
             fn next_back(&mut self) -> Option<Self::Item> {
-                self.inner.next_back()
+                self.inner
+                    .next_back()
+                    .map(|i| (i, self.contiguous_elements()))
             }
         }
 

--- a/zarrs/src/array_subset/iterators/contiguous_linearised_indices_iterator.rs
+++ b/zarrs/src/array_subset/iterators/contiguous_linearised_indices_iterator.rs
@@ -87,7 +87,7 @@ impl ContiguousLinearisedIndices {
 }
 
 impl<'a> IntoIterator for &'a ContiguousLinearisedIndices {
-    type Item = u64;
+    type Item = (u64, u64);
     type IntoIter = ContiguousLinearisedIndicesIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -99,7 +99,7 @@ impl<'a> IntoIterator for &'a ContiguousLinearisedIndices {
 }
 
 impl IntoIterator for ContiguousLinearisedIndices {
-    type Item = u64;
+    type Item = (u64, u64);
     type IntoIter = ContiguousLinearisedIndicesIntoIterator;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -146,12 +146,15 @@ macro_rules! impl_contiguous_linearised_indices_iterator {
         }
 
         impl Iterator for $iterator_type {
-            type Item = u64;
+            type Item = (u64, u64);
 
             fn next(&mut self) -> Option<Self::Item> {
-                self.inner
-                    .next()
-                    .map(|indices| ravel_indices(&indices, $qualifier!(self.array_shape)))
+                self.inner.next().map(|indices| {
+                    (
+                        ravel_indices(indices.0.as_slice(), $qualifier!(self.array_shape)),
+                        indices.1,
+                    )
+                })
             }
 
             fn size_hint(&self) -> (usize, Option<usize>) {
@@ -161,9 +164,12 @@ macro_rules! impl_contiguous_linearised_indices_iterator {
 
         impl DoubleEndedIterator for $iterator_type {
             fn next_back(&mut self) -> Option<Self::Item> {
-                self.inner
-                    .next_back()
-                    .map(|indices| ravel_indices(&indices, $qualifier!(self.array_shape)))
+                self.inner.next_back().map(|indices| {
+                    (
+                        ravel_indices(indices.0.as_slice(), $qualifier!(self.array_shape)),
+                        indices.1,
+                    )
+                })
             }
         }
 


### PR DESCRIPTION
Reverts a trivial optimisation added in 65542ccb0ac5727930a7687c5bd6c2e84e5b5f5e. The original form is required for generic indexers (#52).