### PR TITLE
feat: use `Iterator<Item = ByteRange>`

### DIFF
--- a/zarrs/src/array/array_bytes.rs
+++ b/zarrs/src/array/array_bytes.rs
@@ -259,7 +259,7 @@ impl<'a> ArrayBytes<'a> {
             ArrayBytes::Fixed(bytes) => {
                 let byte_ranges =
                     indexer.byte_ranges(array_shape, data_type.fixed_size().unwrap())?;
-                let bytes = extract_byte_ranges_concat(bytes, byte_ranges).unwrap(); // FIXME: remove unwrap
+                let bytes = extract_byte_ranges_concat(bytes, byte_ranges)?;
                 Ok(ArrayBytes::new_flen(bytes))
             }
         }

--- a/zarrs/src/array/array_bytes.rs
+++ b/zarrs/src/array/array_bytes.rs
@@ -7,7 +7,7 @@ use unsafe_cell_slice::UnsafeCellSlice;
 
 use crate::{
     array_subset::{ArraySubset, IncompatibleIndexerAndShapeError},
-    byte_range::extract_byte_ranges_concat_unchecked,
+    byte_range::extract_byte_ranges_concat,
     indexer::Indexer,
     metadata::DataTypeSize,
 };
@@ -259,7 +259,7 @@ impl<'a> ArrayBytes<'a> {
             ArrayBytes::Fixed(bytes) => {
                 let byte_ranges =
                     indexer.byte_ranges(array_shape, data_type.fixed_size().unwrap())?;
-                let bytes = unsafe { extract_byte_ranges_concat_unchecked(bytes, &byte_ranges) };
+                let bytes = extract_byte_ranges_concat(bytes, byte_ranges).unwrap(); // FIXME: remove unwrap
                 Ok(ArrayBytes::new_flen(bytes))
             }
         }

--- a/zarrs/src/array/array_bytes.rs
+++ b/zarrs/src/array/array_bytes.rs
@@ -259,7 +259,7 @@ impl<'a> ArrayBytes<'a> {
             ArrayBytes::Fixed(bytes) => {
                 let byte_ranges =
                     indexer.byte_ranges(array_shape, data_type.fixed_size().unwrap())?;
-                let bytes = extract_byte_ranges_concat(bytes, &*byte_ranges).unwrap(); // FIXME: remove unwrap
+                let bytes = extract_byte_ranges_concat(bytes, byte_ranges).unwrap(); // FIXME: remove unwrap
                 Ok(ArrayBytes::new_flen(bytes))
             }
         }
@@ -551,7 +551,7 @@ pub fn update_array_bytes<'a>(
             let byte_ranges = update_indexer.byte_ranges(shape, data_type_size)?; // FIXME: Prefer not to collect here, and go parallel
             let mut offset: usize = 0;
             // TODO: Add `is_disjoint()` to indexer, so that this could go parallel
-            for byte_range in byte_ranges.iter() {
+            for byte_range in byte_ranges {
                 let byte_range_len =
                     usize::try_from(byte_range.length(bytes.len() as u64)).unwrap();
                 bytes

--- a/zarrs/src/array/array_bytes.rs
+++ b/zarrs/src/array/array_bytes.rs
@@ -259,7 +259,7 @@ impl<'a> ArrayBytes<'a> {
             ArrayBytes::Fixed(bytes) => {
                 let byte_ranges =
                     indexer.byte_ranges(array_shape, data_type.fixed_size().unwrap())?;
-                let bytes = extract_byte_ranges_concat(bytes, byte_ranges).unwrap(); // FIXME: remove unwrap
+                let bytes = extract_byte_ranges_concat(bytes, &*byte_ranges).unwrap(); // FIXME: remove unwrap
                 Ok(ArrayBytes::new_flen(bytes))
             }
         }
@@ -551,7 +551,7 @@ pub fn update_array_bytes<'a>(
             let byte_ranges = update_indexer.byte_ranges(shape, data_type_size)?; // FIXME: Prefer not to collect here, and go parallel
             let mut offset: usize = 0;
             // TODO: Add `is_disjoint()` to indexer, so that this could go parallel
-            for byte_range in byte_ranges {
+            for byte_range in byte_ranges.iter() {
                 let byte_range_len =
                     usize::try_from(byte_range.length(bytes.len() as u64)).unwrap();
                 bytes

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -88,6 +88,7 @@ pub use array_to_bytes_partial_encoder_default::ArrayToBytesPartialEncoderDefaul
 #[cfg(feature = "async")]
 pub use array_to_bytes_partial_encoder_default::AsyncArrayToBytesPartialEncoderDefault;
 use zarrs_metadata::Configuration;
+use zarrs_storage::byte_range::ByteRangeIndexer;
 
 use crate::array_subset::IncompatibleDimensionalityError;
 mod array_to_array_partial_decoder_default;
@@ -325,7 +326,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     fn partial_decode(
         &self,
-        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions:&dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError>;
 
@@ -339,7 +340,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     fn partial_decode_concat(
         &self,
-        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions:&dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
@@ -355,7 +356,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails.
     fn decode(&self, options: &CodecOptions) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
-            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)?
+            .partial_decode(&[ByteRange::FromStart(0, None)], options)?
             .map(|mut v| v.remove(0)))
     }
 }
@@ -372,7 +373,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     async fn partial_decode(
         &self,
-        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions:&dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError>;
 
@@ -384,7 +385,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     async fn partial_decode_concat(
         &self,
-        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions:&dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
@@ -401,7 +402,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails.
     async fn decode(&self, options: &CodecOptions) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
-            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)
+            .partial_decode(&[ByteRange::FromStart(0, None)], options)
             .await?
             .map(|mut v| v.remove(0)))
     }
@@ -605,7 +606,7 @@ impl BytesPartialDecoderTraits for StoragePartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions:&dyn ByteRangeIndexer,
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(self
@@ -640,7 +641,7 @@ impl AsyncStoragePartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions:&dyn ByteRangeIndexer,
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(self
@@ -1186,7 +1187,7 @@ where
 
     fn partial_decode(
         &self,
-        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions:&dyn ByteRangeIndexer,
         _parallel: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(Some(
@@ -1206,7 +1207,7 @@ where
 {
     async fn partial_decode(
         &self,
-        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions:&dyn ByteRangeIndexer,
         _parallel: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(Some(

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -325,7 +325,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError>;
 
@@ -339,7 +339,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     fn partial_decode_concat(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
@@ -355,7 +355,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails.
     fn decode(&self, options: &CodecOptions) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
-            .partial_decode(&[ByteRange::FromStart(0, None)], options)?
+            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)?
             .map(|mut v| v.remove(0)))
     }
 }
@@ -372,7 +372,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     async fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError>;
 
@@ -384,7 +384,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     async fn partial_decode_concat(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
@@ -401,7 +401,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails.
     async fn decode(&self, options: &CodecOptions) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
-            .partial_decode(&[ByteRange::FromStart(0, None)], options)
+            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)
             .await?
             .map(|mut v| v.remove(0)))
     }
@@ -605,7 +605,7 @@ impl BytesPartialDecoderTraits for StoragePartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(self
@@ -640,7 +640,7 @@ impl AsyncStoragePartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(self
@@ -1186,7 +1186,7 @@ where
 
     fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         _parallel: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(Some(
@@ -1206,7 +1206,7 @@ where
 {
     async fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         _parallel: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(Some(

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -88,7 +88,6 @@ pub use array_to_bytes_partial_encoder_default::ArrayToBytesPartialEncoderDefaul
 #[cfg(feature = "async")]
 pub use array_to_bytes_partial_encoder_default::AsyncArrayToBytesPartialEncoderDefault;
 use zarrs_metadata::Configuration;
-use zarrs_storage::byte_range::ByteRangeIndexer;
 
 use crate::array_subset::IncompatibleDimensionalityError;
 mod array_to_array_partial_decoder_default;
@@ -326,7 +325,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     fn partial_decode(
         &self,
-        decoded_regions:&dyn ByteRangeIndexer,
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError>;
 
@@ -340,7 +339,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     fn partial_decode_concat(
         &self,
-        decoded_regions:&dyn ByteRangeIndexer,
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
@@ -356,7 +355,7 @@ pub trait BytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails.
     fn decode(&self, options: &CodecOptions) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
-            .partial_decode(&[ByteRange::FromStart(0, None)], options)?
+            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)?
             .map(|mut v| v.remove(0)))
     }
 }
@@ -373,7 +372,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     async fn partial_decode(
         &self,
-        decoded_regions:&dyn ByteRangeIndexer,
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError>;
 
@@ -385,7 +384,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails or a byte range is invalid.
     async fn partial_decode_concat(
         &self,
-        decoded_regions:&dyn ByteRangeIndexer,
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
@@ -402,7 +401,7 @@ pub trait AsyncBytesPartialDecoderTraits: Any + Send + Sync {
     /// Returns [`CodecError`] if a codec fails.
     async fn decode(&self, options: &CodecOptions) -> Result<Option<RawBytes<'_>>, CodecError> {
         Ok(self
-            .partial_decode(&[ByteRange::FromStart(0, None)], options)
+            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)
             .await?
             .map(|mut v| v.remove(0)))
     }
@@ -606,7 +605,7 @@ impl BytesPartialDecoderTraits for StoragePartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions:&dyn ByteRangeIndexer,
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(self
@@ -641,7 +640,7 @@ impl AsyncStoragePartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions:&dyn ByteRangeIndexer,
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(self
@@ -1187,7 +1186,7 @@ where
 
     fn partial_decode(
         &self,
-        decoded_regions:&dyn ByteRangeIndexer,
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         _parallel: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(Some(
@@ -1207,7 +1206,7 @@ where
 {
     async fn partial_decode(
         &self,
-        decoded_regions:&dyn ByteRangeIndexer,
+        decoded_regions:&mut (dyn Iterator<Item = ByteRange> + Send),
         _parallel: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(Some(

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
@@ -61,7 +61,7 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder {
 
         let chunk_shape = self.decoded_representation.shape_u64();
         // Get byte ranges
-        let byte_ranges = indexer
+        let mut byte_ranges = indexer
             .byte_ranges(&chunk_shape, data_type_size)
             .map_err(|_| {
                 IncompatibleIndexerAndShapeError::new(self.decoded_representation.shape_u64())
@@ -70,7 +70,7 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder {
         // Decode
         let decoded = self
             .input_handle
-            .partial_decode_concat(&*byte_ranges, options)?
+            .partial_decode_concat(&mut byte_ranges, options)?
             .map_or_else(
                 || {
                     let array_size = ArraySize::new(
@@ -149,7 +149,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
         let chunk_shape = self.decoded_representation.shape_u64();
 
         // Get byte ranges
-        let byte_ranges = indexer
+        let mut byte_ranges = indexer
             .byte_ranges(&chunk_shape, data_type_size)
             .map_err(|_| {
                 IncompatibleIndexerAndShapeError::new(self.decoded_representation.shape_u64())
@@ -158,7 +158,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
         // Decode
         let decoded = self
             .input_handle
-            .partial_decode_concat(&*byte_ranges, options)
+            .partial_decode_concat(&mut byte_ranges, options)
             .await?
             .map_or_else(
                 || {

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use zarrs_registry::codec::BYTES;
+use zarrs_storage::byte_range::ByteRange;
 
 use crate::{
     array::{
@@ -60,7 +61,7 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder {
 
         let chunk_shape = self.decoded_representation.shape_u64();
         // Get byte ranges
-        let byte_ranges = indexer
+        let mut byte_ranges = indexer
             .byte_ranges(&chunk_shape, data_type_size)
             .map_err(|_| {
                 IncompatibleIndexerAndShapeError::new(self.decoded_representation.shape_u64())
@@ -69,7 +70,7 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder {
         // Decode
         let decoded = self
             .input_handle
-            .partial_decode_concat(&byte_ranges, options)?
+            .partial_decode_concat(&mut byte_ranges, options)?
             .map_or_else(
                 || {
                     let array_size = ArraySize::new(
@@ -148,7 +149,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
         let chunk_shape = self.decoded_representation.shape_u64();
 
         // Get byte ranges
-        let byte_ranges = indexer
+        let mut byte_ranges = indexer
             .byte_ranges(&chunk_shape, data_type_size)
             .map_err(|_| {
                 IncompatibleIndexerAndShapeError::new(self.decoded_representation.shape_u64())
@@ -157,7 +158,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
         // Decode
         let decoded = self
             .input_handle
-            .partial_decode_concat(&byte_ranges, options)
+            .partial_decode_concat(&mut byte_ranges, options)
             .await?
             .map_or_else(
                 || {

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
@@ -61,7 +61,7 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder {
 
         let chunk_shape = self.decoded_representation.shape_u64();
         // Get byte ranges
-        let mut byte_ranges = indexer
+        let byte_ranges = indexer
             .byte_ranges(&chunk_shape, data_type_size)
             .map_err(|_| {
                 IncompatibleIndexerAndShapeError::new(self.decoded_representation.shape_u64())
@@ -70,7 +70,7 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder {
         // Decode
         let decoded = self
             .input_handle
-            .partial_decode_concat(&mut byte_ranges, options)?
+            .partial_decode_concat(&*byte_ranges, options)?
             .map_or_else(
                 || {
                     let array_size = ArraySize::new(
@@ -149,7 +149,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
         let chunk_shape = self.decoded_representation.shape_u64();
 
         // Get byte ranges
-        let mut byte_ranges = indexer
+        let byte_ranges = indexer
             .byte_ranges(&chunk_shape, data_type_size)
             .map_err(|_| {
                 IncompatibleIndexerAndShapeError::new(self.decoded_representation.shape_u64())
@@ -158,7 +158,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
         // Decode
         let decoded = self
             .input_handle
-            .partial_decode_concat(&mut byte_ranges, options)
+            .partial_decode_concat(&*byte_ranges, options)
             .await?
             .map_or_else(
                 || {

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use zarrs_registry::codec::BYTES;
-use zarrs_storage::byte_range::ByteRange;
 
 use crate::{
     array::{

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
@@ -80,24 +80,24 @@ fn partial_decode<'a>(
     // Get the bit ranges that map to the elements
     let bit_ranges = indexer
         .byte_ranges(&chunk_shape, element_size_bits_usize)
-        .map_err(|_| IncompatibleIndexerAndShapeError::new(chunk_shape.clone()))?;
+        .map_err(|_| IncompatibleIndexerAndShapeError::new(chunk_shape.clone()))?
+        .collect::<Vec<_>>();
 
     // Convert to byte ranges, skipping the padding encoding byte
-    let byte_ranges = bit_ranges
+    let mut byte_ranges = bit_ranges
         .iter()
         .map(|bit_range| {
             let byte_start = offset + bit_range.start(encoded_length_bits).div(8);
             let byte_end = offset + bit_range.end(encoded_length_bits).div_ceil(8);
             ByteRange::new(byte_start..byte_end)
-        })
-        .collect::<Vec<_>>();
+        });
 
     // Retrieve those bytes
     #[cfg(feature = "async")]
     let encoded_bytes = if _async {
-        input_handle.partial_decode(&byte_ranges, options).await
+        input_handle.partial_decode(&mut byte_ranges, options).await
     } else {
-        input_handle.partial_decode(&byte_ranges, options)
+        input_handle.partial_decode(&mut byte_ranges, options)
     }?;
     #[cfg(not(feature = "async"))]
     let encoded_bytes = input_handle.partial_decode(&mut byte_ranges, options)?;
@@ -107,7 +107,7 @@ fn partial_decode<'a>(
         let mut bytes_dec: Vec<u8> =
             vec![0; usize::try_from(indexer.len() * data_type_size_dec as u64).unwrap()];
         let mut component_idx_outer = 0;
-        for (packed_elements, bit_range) in encoded_bytes.into_iter().zip(bit_ranges.iter()) {
+        for (packed_elements, bit_range) in encoded_bytes.into_iter().zip(bit_ranges) {
             // Get the bit range within the entire chunk
             let bit_start = bit_range.start(encoded_length_bits);
             let bit_end = bit_range.end(encoded_length_bits);

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -267,7 +267,7 @@ fn decode_shard_index_partial_decoder(
     let index_byte_range =
         get_index_byte_range(&index_array_representation, index_codecs, index_location)?;
     let encoded_shard_index = input_handle
-        .partial_decode(&mut [index_byte_range].into_iter(), options)?
+        .partial_decode(&[index_byte_range], options)?
         .map(|mut v| v.remove(0));
     Ok(match encoded_shard_index {
         Some(encoded_shard_index) => Some(decode_shard_index(
@@ -295,7 +295,7 @@ async fn decode_shard_index_async_partial_decoder(
     let index_byte_range =
         get_index_byte_range(&index_array_representation, index_codecs, index_location)?;
     let encoded_shard_index = input_handle
-        .partial_decode(&mut [index_byte_range].into_iter(), options)
+        .partial_decode(&[index_byte_range], options)
         .await?
         .map(|mut v| v.remove(0));
     Ok(match encoded_shard_index {

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -267,7 +267,7 @@ fn decode_shard_index_partial_decoder(
     let index_byte_range =
         get_index_byte_range(&index_array_representation, index_codecs, index_location)?;
     let encoded_shard_index = input_handle
-        .partial_decode(&[index_byte_range], options)?
+        .partial_decode(&mut [index_byte_range].into_iter(), options)?
         .map(|mut v| v.remove(0));
     Ok(match encoded_shard_index {
         Some(encoded_shard_index) => Some(decode_shard_index(
@@ -295,7 +295,7 @@ async fn decode_shard_index_async_partial_decoder(
     let index_byte_range =
         get_index_byte_range(&index_array_representation, index_codecs, index_location)?;
     let encoded_shard_index = input_handle
-        .partial_decode(&[index_byte_range], options)
+        .partial_decode(&mut [index_byte_range].into_iter(), options)
         .await?
         .map(|mut v| v.remove(0));
     Ok(match encoded_shard_index {

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -91,7 +91,7 @@ impl AsyncShardingPartialDecoder {
         let byte_range = self.inner_chunk_byte_range(chunk_indices)?;
         if let Some(byte_range) = byte_range {
             self.input_handle
-                .partial_decode_concat(&[byte_range], &CodecOptions::default())
+                .partial_decode_concat(&mut [byte_range].into_iter(), &CodecOptions::default())
                 .await
         } else {
             Ok(None)

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -91,7 +91,7 @@ impl AsyncShardingPartialDecoder {
         let byte_range = self.inner_chunk_byte_range(chunk_indices)?;
         if let Some(byte_range) = byte_range {
             self.input_handle
-                .partial_decode_concat(&mut [byte_range].into_iter(), &CodecOptions::default())
+                .partial_decode_concat(&[byte_range], &CodecOptions::default())
                 .await
         } else {
             Ok(None)

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -90,7 +90,7 @@ impl ShardingPartialDecoder {
         let byte_range = self.inner_chunk_byte_range(chunk_indices)?;
         if let Some(byte_range) = byte_range {
             self.input_handle
-                .partial_decode_concat(&[byte_range], &CodecOptions::default())
+                .partial_decode_concat(&mut [byte_range].into_iter(), &CodecOptions::default())
         } else {
             Ok(None)
         }

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -90,7 +90,7 @@ impl ShardingPartialDecoder {
         let byte_range = self.inner_chunk_byte_range(chunk_indices)?;
         if let Some(byte_range) = byte_range {
             self.input_handle
-                .partial_decode_concat(&mut [byte_range].into_iter(), &CodecOptions::default())
+                .partial_decode_concat(&[byte_range], &CodecOptions::default())
         } else {
             Ok(None)
         }

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -234,7 +234,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
         // Read the straddling inner chunks
         let inner_chunks_encoded = self
             .input_handle
-            .partial_decode(&byte_ranges, options)?
+            .partial_decode(&mut byte_ranges.into_iter(), options)?
             .map(|bytes| bytes.into_iter().map(Cow::into_owned).collect::<Vec<_>>());
 
         // Decode the straddling inner chunks

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -234,7 +234,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
         // Read the straddling inner chunks
         let inner_chunks_encoded = self
             .input_handle
-            .partial_decode(&mut byte_ranges.into_iter(), options)?
+            .partial_decode(&byte_ranges, options)?
             .map(|bytes| bytes.into_iter().map(Cow::into_owned).collect::<Vec<_>>());
 
         // Decode the straddling inner chunks

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
@@ -86,7 +86,7 @@ impl ArrayPartialDecoderTraits for ZfpPartialDecoder {
             let byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
             Ok(ArrayBytes::from(extract_byte_ranges_concat(
                 &decoded_value,
-                byte_ranges,
+                &*byte_ranges,
             )?))
         } else {
             let array_size = ArraySize::new(
@@ -169,7 +169,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder {
             let byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
             Ok(ArrayBytes::from(extract_byte_ranges_concat(
                 &decoded_value,
-                byte_ranges,
+                &*byte_ranges,
             )?))
         } else {
             let array_size = ArraySize::new(

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
@@ -86,7 +86,7 @@ impl ArrayPartialDecoderTraits for ZfpPartialDecoder {
             let byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
             Ok(ArrayBytes::from(extract_byte_ranges_concat(
                 &decoded_value,
-                &byte_ranges,
+                byte_ranges,
             )?))
         } else {
             let array_size = ArraySize::new(
@@ -169,7 +169,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder {
             let byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
             Ok(ArrayBytes::from(extract_byte_ranges_concat(
                 &decoded_value,
-                &byte_ranges,
+                byte_ranges,
             )?))
         } else {
             let array_size = ArraySize::new(

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
@@ -86,7 +86,7 @@ impl ArrayPartialDecoderTraits for ZfpPartialDecoder {
             let byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
             Ok(ArrayBytes::from(extract_byte_ranges_concat(
                 &decoded_value,
-                &*byte_ranges,
+                byte_ranges,
             )?))
         } else {
             let array_size = ArraySize::new(
@@ -169,7 +169,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder {
             let byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
             Ok(ArrayBytes::from(extract_byte_ranges_concat(
                 &decoded_value,
-                &*byte_ranges,
+                byte_ranges,
             )?))
         } else {
             let array_size = ArraySize::new(

--- a/zarrs/src/array/codec/byte_interval_partial_decoder.rs
+++ b/zarrs/src/array/codec/byte_interval_partial_decoder.rs
@@ -41,25 +41,23 @@ impl BytesPartialDecoderTraits for ByteIntervalPartialDecoder {
 
     fn partial_decode(
         &self,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let byte_ranges: Vec<ByteRange> = byte_ranges
-            .iter()
+        let mut byte_ranges = byte_ranges
             .map(|byte_range| match byte_range {
                 ByteRange::FromStart(offset, None) => {
                     ByteRange::FromStart(self.byte_offset + offset, Some(self.byte_length))
                 }
                 ByteRange::FromStart(offset, Some(length)) => {
-                    ByteRange::FromStart(self.byte_offset + offset, Some(*length))
+                    ByteRange::FromStart(self.byte_offset + offset, Some(length))
                 }
                 ByteRange::Suffix(length) => ByteRange::FromStart(
-                    self.byte_offset + self.byte_length - *length,
-                    Some(*length),
+                    self.byte_offset + self.byte_length - length,
+                    Some(length),
                 ),
-            })
-            .collect();
-        self.inner.partial_decode(&byte_ranges, options)
+            });
+        self.inner.partial_decode(&mut byte_ranges, options)
     }
 }
 
@@ -94,24 +92,22 @@ impl AsyncByteIntervalPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder {
     async fn partial_decode(
         &self,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let byte_ranges: Vec<ByteRange> = byte_ranges
-            .iter()
+        let mut byte_ranges = byte_ranges
             .map(|byte_range| match byte_range {
                 ByteRange::FromStart(offset, None) => {
                     ByteRange::FromStart(self.byte_offset + offset, Some(self.byte_length))
                 }
                 ByteRange::FromStart(offset, Some(length)) => {
-                    ByteRange::FromStart(self.byte_offset + offset, Some(*length))
+                    ByteRange::FromStart(self.byte_offset + offset, Some(length))
                 }
                 ByteRange::Suffix(length) => ByteRange::FromStart(
-                    self.byte_offset + self.byte_length - *length,
-                    Some(*length),
+                    self.byte_offset + self.byte_length - length,
+                    Some(length),
                 ),
-            })
-            .collect();
-        self.inner.partial_decode(&byte_ranges, options).await
+            });
+        self.inner.partial_decode(&mut byte_ranges, options).await
     }
 }

--- a/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
+++ b/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
@@ -27,7 +27,7 @@ impl BytesPartialDecoderCache {
         options: &CodecOptions,
     ) -> Result<Self, CodecError> {
         let cache = input_handle
-            .partial_decode(&[ByteRange::FromStart(0, None)], options)?
+            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)?
             .map(|mut bytes| bytes.remove(0).into_owned());
         Ok(Self { cache })
     }
@@ -42,7 +42,7 @@ impl BytesPartialDecoderCache {
         options: &CodecOptions,
     ) -> Result<BytesPartialDecoderCache, CodecError> {
         let cache = input_handle
-            .partial_decode(&[ByteRange::FromStart(0, None)], options)
+            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)
             .await?
             .map(|mut bytes| bytes.remove(0).into_owned());
         Ok(Self { cache })
@@ -56,7 +56,7 @@ impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
 
     fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(match &self.cache {
@@ -77,7 +77,7 @@ impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
 impl AsyncBytesPartialDecoderTraits for BytesPartialDecoderCache {
     async fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         BytesPartialDecoderTraits::partial_decode(self, decoded_regions, options)

--- a/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
+++ b/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
@@ -2,8 +2,6 @@
 
 use std::borrow::Cow;
 
-use zarrs_storage::byte_range::ByteRangeIndexer;
-
 use crate::{
     array::RawBytes,
     byte_range::{extract_byte_ranges, ByteRange},
@@ -29,7 +27,7 @@ impl BytesPartialDecoderCache {
         options: &CodecOptions,
     ) -> Result<Self, CodecError> {
         let cache = input_handle
-            .partial_decode(&[ByteRange::FromStart(0, None)], options)?
+            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)?
             .map(|mut bytes| bytes.remove(0).into_owned());
         Ok(Self { cache })
     }
@@ -44,7 +42,7 @@ impl BytesPartialDecoderCache {
         options: &CodecOptions,
     ) -> Result<BytesPartialDecoderCache, CodecError> {
         let cache = input_handle
-            .partial_decode(&[ByteRange::FromStart(0, None)], options)
+            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)
             .await?
             .map(|mut bytes| bytes.remove(0).into_owned());
         Ok(Self { cache })
@@ -58,7 +56,7 @@ impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
 
     fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(match &self.cache {
@@ -79,7 +77,7 @@ impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
 impl AsyncBytesPartialDecoderTraits for BytesPartialDecoderCache {
     async fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         BytesPartialDecoderTraits::partial_decode(self, decoded_regions, options)

--- a/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
@@ -154,7 +154,7 @@ mod tests {
                 .unwrap();
             assert_eq!(partial_decoder.size(), input_handle.size()); // adler32 partial decoder does not hold bytes
             let decoded_partial_chunk = partial_decoder
-                .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+                .partial_decode(&decoded_regions, &CodecOptions::default())
                 .unwrap()
                 .unwrap();
             let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -195,7 +195,7 @@ mod tests {
                 .await
                 .unwrap();
             let decoded_partial_chunk = partial_decoder
-                .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+                .partial_decode(&decoded_regions, &CodecOptions::default())
                 .await
                 .unwrap()
                 .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
@@ -154,7 +154,7 @@ mod tests {
                 .unwrap();
             assert_eq!(partial_decoder.size(), input_handle.size()); // adler32 partial decoder does not hold bytes
             let decoded_partial_chunk = partial_decoder
-                .partial_decode(&decoded_regions, &CodecOptions::default())
+                .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
                 .unwrap()
                 .unwrap();
             let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -195,7 +195,7 @@ mod tests {
                 .await
                 .unwrap();
             let decoded_partial_chunk = partial_decoder
-                .partial_decode(&decoded_regions, &CodecOptions::default())
+                .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
                 .await
                 .unwrap()
                 .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
@@ -268,8 +268,7 @@ mod tests {
             codec::{BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecOptions},
             ArrayRepresentation, BytesRepresentation, DataType,
         },
-        array_subset::ArraySubset,
-        byte_range::ByteRange, indexer::Indexer,
+        array_subset::ArraySubset, indexer::Indexer,
     };
 
     use super::*;

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
@@ -269,7 +269,7 @@ mod tests {
             ArrayRepresentation, BytesRepresentation, DataType,
         },
         array_subset::ArraySubset,
-        byte_range::ByteRange,
+        byte_range::ByteRange, indexer::Indexer,
     };
 
     use super::*;
@@ -383,7 +383,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -396,7 +396,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // blosc partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -414,6 +414,8 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn codec_blosc_async_partial_decode() {
+        use crate::indexer::Indexer;
+
         let array_representation =
             ArrayRepresentation::new(vec![2, 2, 2], DataType::UInt16, 0u16).unwrap();
         let data_type_size = array_representation.data_type().fixed_size().unwrap();
@@ -430,7 +432,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -443,7 +445,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
@@ -383,7 +383,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -396,7 +396,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // blosc partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -432,7 +432,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -445,7 +445,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
@@ -383,7 +383,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -396,7 +396,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // blosc partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -432,7 +432,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -445,7 +445,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
@@ -1,7 +1,5 @@
 use std::{borrow::Cow, sync::Arc};
 
-use zarrs_storage::byte_range::ByteRangeIndexer;
-
 use crate::{
     array::{
         codec::{
@@ -36,7 +34,7 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
@@ -48,7 +46,7 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder {
             let nbytes = blosc_nbytes(&encoded_value);
             let typesize = blosc_typesize(&encoded_value);
             if let (Some(nbytes), Some(typesize)) = (nbytes, typesize) {
-                let decoded_byte_ranges = decoded_regions.iter().map(|byte_range| {
+                let decoded_byte_ranges = decoded_regions.map(|byte_range| {
                     let start = usize::try_from(byte_range.start(nbytes as u64)).unwrap();
                     let end = usize::try_from(byte_range.end(nbytes as u64)).unwrap();
                     blosc_decompress_bytes_partial(
@@ -85,7 +83,7 @@ impl AsyncBloscPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;
@@ -97,7 +95,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder {
             let nbytes = blosc_nbytes(&encoded_value);
             let typesize = blosc_typesize(&encoded_value);
             if let (Some(nbytes), Some(typesize)) = (nbytes, typesize) {
-                let decoded_byte_ranges = decoded_regions.iter().map(|byte_range| {
+                let decoded_byte_ranges = decoded_regions.map(|byte_range| {
                     let start = usize::try_from(byte_range.start(nbytes as u64)).unwrap();
                     let end = usize::try_from(byte_range.end(nbytes as u64)).unwrap();
                     blosc_decompress_bytes_partial(

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
@@ -34,7 +34,7 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
@@ -46,21 +46,18 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder {
             let nbytes = blosc_nbytes(&encoded_value);
             let typesize = blosc_typesize(&encoded_value);
             if let (Some(nbytes), Some(typesize)) = (nbytes, typesize) {
-                let mut decoded_byte_ranges = Vec::with_capacity(decoded_regions.len());
-                for byte_range in decoded_regions {
+                let decoded_byte_ranges = decoded_regions.map(|byte_range| {
                     let start = usize::try_from(byte_range.start(nbytes as u64)).unwrap();
                     let end = usize::try_from(byte_range.end(nbytes as u64)).unwrap();
-                    decoded_byte_ranges.push(
-                        blosc_decompress_bytes_partial(
-                            &encoded_value,
-                            start,
-                            end - start,
-                            typesize,
-                        )
-                        .map(Cow::Owned)
-                        .map_err(|err| CodecError::from(err.to_string()))?,
-                    );
-                }
+                    blosc_decompress_bytes_partial(
+                        &encoded_value,
+                        start,
+                        end - start,
+                        typesize,
+                    )
+                    .map(Cow::Owned)
+                    .map_err(|err| CodecError::from(err.to_string()))
+                }).collect::<Result<Vec<_>, CodecError>>()?;
                 return Ok(Some(decoded_byte_ranges));
             }
         }
@@ -86,7 +83,7 @@ impl AsyncBloscPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;
@@ -98,21 +95,18 @@ impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder {
             let nbytes = blosc_nbytes(&encoded_value);
             let typesize = blosc_typesize(&encoded_value);
             if let (Some(nbytes), Some(typesize)) = (nbytes, typesize) {
-                let mut decoded_byte_ranges = Vec::with_capacity(decoded_regions.len());
-                for byte_range in decoded_regions {
+                let decoded_byte_ranges = decoded_regions.map(|byte_range| {
                     let start = usize::try_from(byte_range.start(nbytes as u64)).unwrap();
                     let end = usize::try_from(byte_range.end(nbytes as u64)).unwrap();
-                    decoded_byte_ranges.push(
-                        blosc_decompress_bytes_partial(
-                            &encoded_value,
-                            start,
-                            end - start,
-                            typesize,
-                        )
-                        .map(Cow::Owned)
-                        .map_err(|err| CodecError::from(err.to_string()))?,
-                    );
-                }
+                    blosc_decompress_bytes_partial(
+                        &encoded_value,
+                        start,
+                        end - start,
+                        typesize,
+                    )
+                    .map(Cow::Owned)
+                    .map_err(|err| CodecError::from(err.to_string()))
+                }).collect::<Result<Vec<_>, CodecError>>()?;
                 return Ok(Some(decoded_byte_ranges));
             }
         }

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
@@ -123,7 +123,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -136,7 +136,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // bz2 partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
@@ -75,8 +75,7 @@ mod tests {
             codec::{BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecOptions},
             ArrayRepresentation, BytesRepresentation, DataType,
         },
-        array_subset::ArraySubset,
-        byte_range::ByteRange, indexer::Indexer,
+        array_subset::ArraySubset, indexer::Indexer,
     };
 
     use super::*;

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
@@ -123,7 +123,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -136,7 +136,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // bz2 partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
@@ -135,7 +135,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // crc32c partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
         let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -172,7 +172,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
@@ -135,7 +135,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // crc32c partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .unwrap()
             .unwrap();
         let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -172,7 +172,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
@@ -149,7 +149,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // fletcher32 partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
         let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -189,7 +189,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
@@ -149,7 +149,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // fletcher32 partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .unwrap()
             .unwrap();
         let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -189,7 +189,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&decoded_regions, &CodecOptions::default())
+            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
@@ -351,7 +351,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // gdeflate partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -393,7 +393,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
@@ -351,7 +351,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // gdeflate partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -393,7 +393,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
@@ -143,7 +143,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // gzip partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
@@ -143,7 +143,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // gzip partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
@@ -127,7 +127,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // shuffle partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -168,7 +168,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
@@ -127,7 +127,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // shuffle partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -168,7 +168,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_prefix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_prefix_partial_decoder.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use itertools::Itertools;
 
 use crate::{
     array::{

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_prefix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_prefix_partial_decoder.rs
@@ -39,21 +39,19 @@ impl BytesPartialDecoderTraits for StripPrefixPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let decoded_regions = decoded_regions
-            .iter()
+        let mut decoded_regions = decoded_regions
             .map(|range| match range {
                 ByteRange::FromStart(offset, length) => ByteRange::FromStart(
                     offset.checked_add(self.prefix_size as u64).unwrap(),
-                    *length,
+                    length,
                 ),
-                ByteRange::Suffix(length) => ByteRange::Suffix(*length),
-            })
-            .collect_vec();
+                ByteRange::Suffix(length) => ByteRange::Suffix(length),
+            });
 
-        self.input_handle.partial_decode(&decoded_regions, options)
+        self.input_handle.partial_decode(&mut decoded_regions, options)
     }
 }
 
@@ -83,22 +81,20 @@ impl AsyncStripPrefixPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncStripPrefixPartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let decoded_regions = decoded_regions
-            .iter()
+        let mut decoded_regions = decoded_regions
             .map(|range| match range {
                 ByteRange::FromStart(offset, length) => ByteRange::FromStart(
                     offset.checked_add(self.prefix_size as u64).unwrap(),
-                    *length,
+                    length,
                 ),
-                ByteRange::Suffix(length) => ByteRange::Suffix(*length),
-            })
-            .collect_vec();
+                ByteRange::Suffix(length) => ByteRange::Suffix(length),
+            });
 
         self.input_handle
-            .partial_decode(&decoded_regions, options)
+            .partial_decode(&mut decoded_regions, options)
             .await
     }
 }

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
@@ -5,7 +5,7 @@ use crate::{
         codec::{BytesPartialDecoderTraits, CodecError, CodecOptions},
         RawBytes,
     },
-    byte_range::{ByteRange,ByteRangeIndexer},
+    byte_range::ByteRange,
 };
 
 #[cfg(feature = "async")]
@@ -37,17 +37,18 @@ impl BytesPartialDecoderTraits for StripSuffixPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let bytes = self.input_handle.partial_decode(decoded_regions, options)?;
+        let decoded_regions_collected = decoded_regions.collect::<Vec<ByteRange>>();
+        let bytes = self.input_handle.partial_decode(&mut decoded_regions_collected.clone().into_iter(), options)?;
         let Some(bytes) = bytes else {
             return Ok(None);
         };
 
         // Drop suffix of length `suffix_size`
         let mut output = Vec::with_capacity(bytes.len());
-        for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions.iter()) {
+        for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions_collected) {
             let bytes = match byte_range {
                 ByteRange::FromStart(_, Some(_)) => bytes,
                 ByteRange::FromStart(_, None) => {
@@ -93,12 +94,13 @@ impl AsyncStripSuffixPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncStripSuffixPartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
+        let decoded_regions_collected = decoded_regions.collect::<Vec<ByteRange>>();
         let bytes = self
             .input_handle
-            .partial_decode(decoded_regions, options)
+            .partial_decode(&mut decoded_regions_collected.clone().into_iter(), options)
             .await?;
         let Some(bytes) = bytes else {
             return Ok(None);
@@ -106,7 +108,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncStripSuffixPartialDecoder {
 
         // Drop trailing checksum
         let mut output = Vec::with_capacity(bytes.len());
-        for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions.iter()) {
+        for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions_collected) {
             let bytes = match byte_range {
                 ByteRange::FromStart(_, Some(_)) => bytes,
                 ByteRange::FromStart(_, None) => {

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
@@ -5,7 +5,7 @@ use crate::{
         codec::{BytesPartialDecoderTraits, CodecError, CodecOptions},
         RawBytes,
     },
-    byte_range::ByteRange,
+    byte_range::{ByteRange,ByteRangeIndexer},
 };
 
 #[cfg(feature = "async")]
@@ -37,18 +37,17 @@ impl BytesPartialDecoderTraits for StripSuffixPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions: &dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let decoded_regions_collected = decoded_regions.collect::<Vec<ByteRange>>();
-        let bytes = self.input_handle.partial_decode(&mut decoded_regions_collected.clone().into_iter(), options)?;
+        let bytes = self.input_handle.partial_decode(decoded_regions, options)?;
         let Some(bytes) = bytes else {
             return Ok(None);
         };
 
         // Drop suffix of length `suffix_size`
         let mut output = Vec::with_capacity(bytes.len());
-        for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions_collected) {
+        for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions.iter()) {
             let bytes = match byte_range {
                 ByteRange::FromStart(_, Some(_)) => bytes,
                 ByteRange::FromStart(_, None) => {
@@ -94,13 +93,12 @@ impl AsyncStripSuffixPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncStripSuffixPartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions: &dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let decoded_regions_collected = decoded_regions.collect::<Vec<ByteRange>>();
         let bytes = self
             .input_handle
-            .partial_decode(&mut decoded_regions_collected.clone().into_iter(), options)
+            .partial_decode(decoded_regions, options)
             .await?;
         let Some(bytes) = bytes else {
             return Ok(None);
@@ -108,7 +106,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncStripSuffixPartialDecoder {
 
         // Drop trailing checksum
         let mut output = Vec::with_capacity(bytes.len());
-        for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions_collected) {
+        for (bytes, byte_range) in bytes.into_iter().zip(decoded_regions.iter()) {
             let bytes = match byte_range {
                 ByteRange::FromStart(_, Some(_)) => bytes,
                 ByteRange::FromStart(_, None) => {

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
@@ -64,7 +64,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // test unbounded partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -106,7 +106,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
@@ -64,7 +64,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // test unbounded partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -106,7 +106,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -1,7 +1,5 @@
 use std::{borrow::Cow, sync::Arc};
 
-use zarrs_storage::byte_range::ByteRangeIndexer;
-
 use crate::{
     array::{
         codec::{BytesPartialDecoderTraits, CodecError, CodecOptions},
@@ -32,7 +30,7 @@ impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
@@ -69,7 +67,7 @@ impl AsyncTestUnboundedPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, sync::Arc};
 
+use zarrs_storage::byte_range::ByteRangeIndexer;
+
 use crate::{
     array::{
         codec::{BytesPartialDecoderTraits, CodecError, CodecOptions},
@@ -30,7 +32,7 @@ impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions: &dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
@@ -67,7 +69,7 @@ impl AsyncTestUnboundedPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions: &dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -30,7 +30,7 @@ impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
@@ -67,7 +67,7 @@ impl AsyncTestUnboundedPartialDecoder {
 impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder {
     async fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
@@ -124,7 +124,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -137,7 +137,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // zlib partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
@@ -74,8 +74,7 @@ mod tests {
             codec::{BytesPartialDecoderTraits, BytesToBytesCodecTraits, CodecOptions},
             ArrayRepresentation, BytesRepresentation, DataType,
         },
-        array_subset::ArraySubset,
-        byte_range::ByteRange, indexer::Indexer,
+        array_subset::ArraySubset, indexer::Indexer,
     };
 
     use super::*;

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
@@ -124,7 +124,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -137,7 +137,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // zlib partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&*decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
@@ -75,7 +75,7 @@ mod tests {
             ArrayRepresentation, BytesRepresentation, DataType,
         },
         array_subset::ArraySubset,
-        byte_range::ByteRange,
+        byte_range::ByteRange, indexer::Indexer,
     };
 
     use super::*;
@@ -124,7 +124,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -137,7 +137,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // zlib partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let decoded_regions: Vec<ByteRange> = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
@@ -129,7 +129,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // zstd partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
@@ -129,7 +129,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // zstd partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(&decoded_regions, &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use zarrs_storage::byte_range::{extract_byte_ranges, ByteRangeIndexer};
+use zarrs_storage::byte_range::{extract_byte_ranges, ByteRange};
 
 use crate::array::{BytesRepresentation, RawBytes};
 
@@ -14,14 +14,14 @@ use crate::array::codec::AsyncBytesPartialDecoderTraits;
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
-    decoded_regions: &dyn ByteRangeIndexer,
+    decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
     options: &CodecOptions,
 )))]
 fn partial_decode<'a>(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
-    decoded_regions: &dyn ByteRangeIndexer,
+    decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
     options: &CodecOptions,
 ) -> Result<Option<Vec<RawBytes<'a>>>, CodecError> {
     #[cfg(feature = "async")]
@@ -80,7 +80,7 @@ impl BytesPartialDecoderTraits for BytesToBytesPartialDecoderDefault {
 
     fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode(
@@ -123,7 +123,7 @@ impl AsyncBytesToBytesPartialDecoderDefault {
 impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialDecoderDefault {
     async fn partial_decode(
         &self,
-        decoded_regions: &dyn ByteRangeIndexer,
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode_async(

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
@@ -14,14 +14,14 @@ use crate::array::codec::AsyncBytesPartialDecoderTraits;
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
-    decoded_regions: &[ByteRange],
+    decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
     options: &CodecOptions,
 )))]
 fn partial_decode<'a>(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
-    decoded_regions: &[ByteRange],
+    decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
     options: &CodecOptions,
 ) -> Result<Option<Vec<RawBytes<'a>>>, CodecError> {
     #[cfg(feature = "async")]
@@ -80,7 +80,7 @@ impl BytesPartialDecoderTraits for BytesToBytesPartialDecoderDefault {
 
     fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode(
@@ -123,7 +123,7 @@ impl AsyncBytesToBytesPartialDecoderDefault {
 impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialDecoderDefault {
     async fn partial_decode(
         &self,
-        decoded_regions: &[ByteRange],
+        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode_async(

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use zarrs_storage::byte_range::{extract_byte_ranges, ByteRange};
+use zarrs_storage::byte_range::{extract_byte_ranges, ByteRangeIndexer};
 
 use crate::array::{BytesRepresentation, RawBytes};
 
@@ -14,14 +14,14 @@ use crate::array::codec::AsyncBytesPartialDecoderTraits;
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
-    decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
+    decoded_regions: &dyn ByteRangeIndexer,
     options: &CodecOptions,
 )))]
 fn partial_decode<'a>(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
-    decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
+    decoded_regions: &dyn ByteRangeIndexer,
     options: &CodecOptions,
 ) -> Result<Option<Vec<RawBytes<'a>>>, CodecError> {
     #[cfg(feature = "async")]
@@ -80,7 +80,7 @@ impl BytesPartialDecoderTraits for BytesToBytesPartialDecoderDefault {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions: &dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode(
@@ -123,7 +123,7 @@ impl AsyncBytesToBytesPartialDecoderDefault {
 impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialDecoderDefault {
     async fn partial_decode(
         &self,
-        decoded_regions: &mut (dyn Iterator<Item = ByteRange> + Send),
+        decoded_regions: &dyn ByteRangeIndexer,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode_async(

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -27,7 +27,6 @@ use itertools::izip;
 use crate::{
     array::{ArrayError, ArrayIndices, ArrayShape},
     indexer::Indexer,
-    storage::byte_range::ByteRange,
 };
 
 /// An array subset.
@@ -548,6 +547,8 @@ impl From<ArraySubsetError> for ArrayError {
 
 #[cfg(test)]
 mod tests {
+    use zarrs_storage::byte_range::ByteRange;
+
     use super::*;
 
     #[test]
@@ -608,7 +609,7 @@ mod tests {
         let array_subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
 
         assert!(array_subset.byte_ranges(&[1, 1], 1).is_err());
-        let ranges = array_subset.byte_ranges(&[4, 4], 1).unwrap().collect::<Vec<ByteRange>>();
+        let ranges = array_subset.byte_ranges(&[4, 4], 1).unwrap().iter().map(|e| *e).collect::<Vec<ByteRange>>();
 
         assert_eq!(
             ranges,

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -27,6 +27,7 @@ use itertools::izip;
 use crate::{
     array::{ArrayError, ArrayIndices, ArrayShape},
     indexer::Indexer,
+    storage::byte_range::ByteRange,
 };
 
 /// An array subset.
@@ -547,8 +548,6 @@ impl From<ArraySubsetError> for ArrayError {
 
 #[cfg(test)]
 mod tests {
-    use zarrs_storage::byte_range::ByteRange;
-
     use super::*;
 
     #[test]
@@ -609,7 +608,7 @@ mod tests {
         let array_subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
 
         assert!(array_subset.byte_ranges(&[1, 1], 1).is_err());
-        let ranges = array_subset.byte_ranges(&[4, 4], 1).unwrap().iter().map(|e| *e).collect::<Vec<ByteRange>>();
+        let ranges = array_subset.byte_ranges(&[4, 4], 1).unwrap().collect::<Vec<ByteRange>>();
 
         assert_eq!(
             ranges,

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -27,7 +27,6 @@ use itertools::izip;
 use crate::{
     array::{ArrayError, ArrayIndices, ArrayShape},
     indexer::Indexer,
-    storage::byte_range::ByteRange,
 };
 
 /// An array subset.
@@ -549,6 +548,8 @@ impl From<ArraySubsetError> for ArrayError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::byte_range::ByteRange;
+
 
     #[test]
     fn array_subset() {

--- a/zarrs/src/array_subset.rs
+++ b/zarrs/src/array_subset.rs
@@ -251,26 +251,6 @@ impl ArraySubset {
         izip!(indices, &self.start, &self.shape).all(|(&i, &o, &s)| i >= o && i < o + s)
     }
 
-    /// Return the byte ranges of an array subset in an array with `array_shape` and `element_size`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IncompatibleIndexerAndShapeError`] if the `array_shape` does not encapsulate this array subset.
-    pub fn byte_ranges(
-        &self,
-        array_shape: &[u64],
-        element_size: usize,
-    ) -> Result<Vec<ByteRange>, IncompatibleIndexerAndShapeError> {
-        let mut byte_ranges: Vec<ByteRange> = Vec::new();
-        let element_size = element_size as u64;
-        for (array_index, contiguous_elements) in self.contiguous_linearised_indices(array_shape)? {
-            let byte_index = array_index * element_size;
-            let byte_length = contiguous_elements * element_size;
-            byte_ranges.push(ByteRange::FromStart(byte_index, Some(byte_length)));
-        }
-        Ok(byte_ranges)
-    }
-
     /// Return the elements in this array subset from an array with shape `array_shape`.
     ///
     /// # Errors
@@ -628,17 +608,10 @@ mod tests {
         let array_subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
 
         assert!(array_subset.byte_ranges(&[1, 1], 1).is_err());
+        let ranges = array_subset.byte_ranges(&[4, 4], 1).unwrap().collect::<Vec<ByteRange>>();
 
         assert_eq!(
-            array_subset.byte_ranges(&[4, 4], 1).unwrap(),
-            vec![
-                ByteRange::FromStart(5, Some(2)),
-                ByteRange::FromStart(9, Some(2))
-            ]
-        );
-
-        assert_eq!(
-            array_subset.byte_ranges(&[4, 4], 1).unwrap(),
+            ranges,
             vec![
                 ByteRange::FromStart(5, Some(2)),
                 ByteRange::FromStart(9, Some(2))

--- a/zarrs/src/indexer.rs
+++ b/zarrs/src/indexer.rs
@@ -66,17 +66,18 @@ pub trait Indexer: Send + Sync {
         &self,
         array_shape: &[u64],
         element_size: usize,
-    ) -> Result<Vec<ByteRange>, IncompatibleIndexerAndShapeError> {
-        let mut byte_ranges: Vec<ByteRange> = Vec::new();
-        let contiguous_indices = self.iter_contiguous_linearised_indices(array_shape)?;
-        for (array_index, contiguous_elements) in contiguous_indices {
-            let byte_index = array_index * element_size as u64;
-            byte_ranges.push(ByteRange::FromStart(
-                byte_index,
-                Some(contiguous_elements * element_size as u64),
-            ));
-        }
-        Ok(byte_ranges)
+    ) -> Result<Box<dyn Iterator<Item = ByteRange> + Send + Sync>, IncompatibleIndexerAndShapeError> {
+        let element_size_u64 = element_size as u64;
+        let byte_ranges = self.iter_contiguous_linearised_indices(array_shape)?.map(
+            move |(array_index, contiguous_elements)| {
+                let byte_index = array_index * element_size_u64;
+                ByteRange::FromStart(
+                    byte_index,
+                    Some(contiguous_elements * element_size_u64),
+                )
+            }
+        );
+        Ok(Box::new(byte_ranges))
     }
 
     /// Return the indexer as an [`ArraySubset`].

--- a/zarrs/src/indexer.rs
+++ b/zarrs/src/indexer.rs
@@ -1,6 +1,6 @@
 //! Generic indexer support.
 
-use zarrs_storage::byte_range::{ByteRange, ByteRangeIndexer};
+use zarrs_storage::byte_range::ByteRange;
 
 use crate::{
     array::{ravel_indices, ArrayIndices},
@@ -65,7 +65,7 @@ pub trait Indexer: Send + Sync {
         &self,
         array_shape: &[u64],
         element_size: usize,
-    ) -> Result<Box<dyn ByteRangeIndexer>, IncompatibleIndexerAndShapeError> {
+    ) -> Result<Box<dyn Iterator<Item = ByteRange> + Send + Sync>, IncompatibleIndexerAndShapeError> {
         let element_size_u64 = element_size as u64;
         let byte_ranges = self.iter_contiguous_linearised_indices(array_shape)?.map(
             move |(array_index, contiguous_elements)| {
@@ -76,7 +76,7 @@ pub trait Indexer: Send + Sync {
                 )
             }
         );
-        Ok(Box::new(byte_ranges.collect::<Vec<ByteRange>>())) // TODO: Figure out ByteRangeIndexer for an already-made-iterator?
+        Ok(Box::new(byte_ranges))
     }
 
     /// Return the indexer as an [`ArraySubset`].

--- a/zarrs/src/indexer.rs
+++ b/zarrs/src/indexer.rs
@@ -61,7 +61,6 @@ pub trait Indexer: Send + Sync {
     ///
     /// # Errors
     /// Returns [`IncompatibleIndexerAndShapeError`] if the `array_shape` does not encapsulate this array subset.
-    // FIXME: Prefer to remove this? Or at least return an iterator
     fn byte_ranges(
         &self,
         array_shape: &[u64],

--- a/zarrs/src/indexer.rs
+++ b/zarrs/src/indexer.rs
@@ -1,6 +1,6 @@
 //! Generic indexer support.
 
-use zarrs_storage::byte_range::ByteRange;
+use zarrs_storage::byte_range::{ByteRange, ByteRangeIndexer};
 
 use crate::{
     array::{ravel_indices, ArrayIndices},
@@ -65,7 +65,7 @@ pub trait Indexer: Send + Sync {
         &self,
         array_shape: &[u64],
         element_size: usize,
-    ) -> Result<Box<dyn Iterator<Item = ByteRange> + Send + Sync>, IncompatibleIndexerAndShapeError> {
+    ) -> Result<Box<dyn ByteRangeIndexer>, IncompatibleIndexerAndShapeError> {
         let element_size_u64 = element_size as u64;
         let byte_ranges = self.iter_contiguous_linearised_indices(array_shape)?.map(
             move |(array_index, contiguous_elements)| {
@@ -76,7 +76,7 @@ pub trait Indexer: Send + Sync {
                 )
             }
         );
-        Ok(Box::new(byte_ranges))
+        Ok(Box::new(byte_ranges.collect::<Vec<ByteRange>>())) // TODO: Figure out ByteRangeIndexer for an already-made-iterator?
     }
 
     /// Return the indexer as an [`ArraySubset`].

--- a/zarrs_filesystem/src/lib.rs
+++ b/zarrs_filesystem/src/lib.rs
@@ -8,7 +8,7 @@
 //! - the MIT license [LICENSE-MIT](https://docs.rs/crate/zarrs_filesystem/latest/source/LICENCE-MIT) or <http://opensource.org/licenses/MIT>, at your option.
 
 use zarrs_storage::{
-    byte_range::{ByteOffset, ByteRange},
+    byte_range::{ByteOffset, ByteRange, ByteRangeIndexer},
     store_set_partial_values, Bytes, ListableStorageTraits, ReadableStorageTraits, StorageError,
     StoreKey, StoreKeyError, StoreKeyOffsetValue, StoreKeys, StoreKeysPrefixes, StorePrefix,
     StorePrefixes, WritableStorageTraits,
@@ -253,7 +253,7 @@ impl ReadableStorageTraits for FilesystemStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges: &dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let file = self.get_file_mutex(key);
         let _lock = file.read();
@@ -268,13 +268,13 @@ impl ReadableStorageTraits for FilesystemStore {
             }
         };
         
-        let out = byte_ranges.map(|byte_range| {
+        let out = byte_ranges.iter().map(|byte_range| {
             let bytes = {
                 // Seek
                 match byte_range {
-                    ByteRange::FromStart(offset, _) => file.seek(SeekFrom::Start(offset)),
+                    ByteRange::FromStart(offset, _) => file.seek(SeekFrom::Start(*offset)),
                     ByteRange::Suffix(length) => {
-                        file.seek(SeekFrom::End(-(i64::try_from(length).unwrap())))
+                        file.seek(SeekFrom::End(-(i64::try_from(*length).unwrap())))
                     }
                 }?;
 
@@ -286,7 +286,7 @@ impl ReadableStorageTraits for FilesystemStore {
                         buffer
                     }
                     ByteRange::FromStart(_, Some(length)) | ByteRange::Suffix(length) => {
-                        let length = usize::try_from(length).unwrap();
+                        let length = usize::try_from(*length).unwrap();
                         let mut buffer = vec![0; length];
                         file.read_exact(&mut buffer)?;
                         buffer

--- a/zarrs_filesystem/src/lib.rs
+++ b/zarrs_filesystem/src/lib.rs
@@ -8,7 +8,7 @@
 //! - the MIT license [LICENSE-MIT](https://docs.rs/crate/zarrs_filesystem/latest/source/LICENCE-MIT) or <http://opensource.org/licenses/MIT>, at your option.
 
 use zarrs_storage::{
-    byte_range::{ByteOffset, ByteRange, ByteRangeIndexer},
+    byte_range::{ByteOffset, ByteRange},
     store_set_partial_values, Bytes, ListableStorageTraits, ReadableStorageTraits, StorageError,
     StoreKey, StoreKeyError, StoreKeyOffsetValue, StoreKeys, StoreKeysPrefixes, StorePrefix,
     StorePrefixes, WritableStorageTraits,
@@ -253,7 +253,7 @@ impl ReadableStorageTraits for FilesystemStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &dyn ByteRangeIndexer,
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let file = self.get_file_mutex(key);
         let _lock = file.read();
@@ -268,13 +268,13 @@ impl ReadableStorageTraits for FilesystemStore {
             }
         };
         
-        let out = byte_ranges.iter().map(|byte_range| {
+        let out = byte_ranges.map(|byte_range| {
             let bytes = {
                 // Seek
                 match byte_range {
-                    ByteRange::FromStart(offset, _) => file.seek(SeekFrom::Start(*offset)),
+                    ByteRange::FromStart(offset, _) => file.seek(SeekFrom::Start(offset)),
                     ByteRange::Suffix(length) => {
-                        file.seek(SeekFrom::End(-(i64::try_from(*length).unwrap())))
+                        file.seek(SeekFrom::End(-(i64::try_from(length).unwrap())))
                     }
                 }?;
 
@@ -286,7 +286,7 @@ impl ReadableStorageTraits for FilesystemStore {
                         buffer
                     }
                     ByteRange::FromStart(_, Some(length)) | ByteRange::Suffix(length) => {
-                        let length = usize::try_from(*length).unwrap();
+                        let length = usize::try_from(length).unwrap();
                         let mut buffer = vec![0; length];
                         file.read_exact(&mut buffer)?;
                         buffer

--- a/zarrs_http/src/lib.rs
+++ b/zarrs_http/src/lib.rs
@@ -15,10 +15,10 @@
 //! - the MIT license [LICENSE-MIT](https://docs.rs/crate/zarrs_http/latest/source/LICENCE-MIT) or <http://opensource.org/licenses/MIT>, at your option.
 
 use zarrs_storage::{
-    byte_range::{ByteRange, ByteRangeIndexer}, Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
+    byte_range::ByteRangeIndexer, Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
 };
 
-use itertools::{multiunzip, Itertools};
+use itertools::multiunzip;
 use reqwest::{
     header::{HeaderValue, CONTENT_LENGTH, RANGE},
     StatusCode, Url,

--- a/zarrs_http/src/lib.rs
+++ b/zarrs_http/src/lib.rs
@@ -18,7 +18,7 @@ use zarrs_storage::{
     byte_range::ByteRange, Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
 };
 
-use itertools::{multiunzip, Itertools};
+use itertools::multiunzip;
 use reqwest::{
     header::{HeaderValue, CONTENT_LENGTH, RANGE},
     StatusCode, Url,

--- a/zarrs_http/src/lib.rs
+++ b/zarrs_http/src/lib.rs
@@ -15,10 +15,10 @@
 //! - the MIT license [LICENSE-MIT](https://docs.rs/crate/zarrs_http/latest/source/LICENCE-MIT) or <http://opensource.org/licenses/MIT>, at your option.
 
 use zarrs_storage::{
-    byte_range::ByteRangeIndexer, Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
+    byte_range::{ByteRange, ByteRangeIndexer}, Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
 };
 
-use itertools::multiunzip;
+use itertools::{multiunzip, Itertools};
 use reqwest::{
     header::{HeaderValue, CONTENT_LENGTH, RANGE},
     StatusCode, Url,

--- a/zarrs_http/src/lib.rs
+++ b/zarrs_http/src/lib.rs
@@ -15,7 +15,7 @@
 //! - the MIT license [LICENSE-MIT](https://docs.rs/crate/zarrs_http/latest/source/LICENCE-MIT) or <http://opensource.org/licenses/MIT>, at your option.
 
 use zarrs_storage::{
-    byte_range::{ByteRange, ByteRangeIndexer}, Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
+    byte_range::ByteRange, Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
 };
 
 use itertools::{multiunzip, Itertools};
@@ -101,14 +101,14 @@ impl ReadableStorageTraits for HTTPStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &dyn ByteRangeIndexer,
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let url = self.key_to_url(key).map_err(handle_url_error)?;
         let Some(size) = self.size_key(key)? else {
             return Ok(None);
         };
         let (bytes_strs, bytes_lengths, bytes_start_end): (Vec<String>, Vec<usize>, Vec<(usize, usize)>) = multiunzip(byte_ranges
-            .iter().map(|byte_range| (format!("{}-{}", byte_range.start(size), byte_range.end(size) - 1), usize::try_from(byte_range.length(size)).unwrap(), (usize::try_from(byte_range.start(size)).unwrap(), usize::try_from(byte_range.end(size)).unwrap()))));
+            .map(|byte_range| (format!("{}-{}", byte_range.start(size), byte_range.end(size) - 1), usize::try_from(byte_range.length(size)).unwrap(), (usize::try_from(byte_range.start(size)).unwrap(), usize::try_from(byte_range.end(size)).unwrap()))));
         let bytes_strs = bytes_strs.join(", ");
 
         let range = HeaderValue::from_str(&format!("bytes={bytes_strs}")).unwrap();
@@ -226,7 +226,7 @@ mod tests {
         assert!(store
             .get_partial_values_key(
                 &"zarr.json".try_into().unwrap(),
-                &[ByteRange::FromStart(0, None)]
+                &mut [ByteRange::FromStart(0, None)].into_iter()
             )
             .is_err());
         assert!(store.size_key(&"zarr.json".try_into().unwrap()).is_err());

--- a/zarrs_http/src/lib.rs
+++ b/zarrs_http/src/lib.rs
@@ -18,7 +18,7 @@ use zarrs_storage::{
     byte_range::ByteRange, Bytes, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
 };
 
-use itertools::Itertools;
+use itertools::{multiunzip, Itertools};
 use reqwest::{
     header::{HeaderValue, CONTENT_LENGTH, RANGE},
     StatusCode, Url,
@@ -101,16 +101,15 @@ impl ReadableStorageTraits for HTTPStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let url = self.key_to_url(key).map_err(handle_url_error)?;
         let Some(size) = self.size_key(key)? else {
             return Ok(None);
         };
-        let bytes_strs = byte_ranges
-            .iter()
-            .map(|byte_range| format!("{}-{}", byte_range.start(size), byte_range.end(size) - 1))
-            .join(", ");
+        let (bytes_strs, bytes_lengths, bytes_start_end): (Vec<String>, Vec<usize>, Vec<(usize, usize)>) = multiunzip(byte_ranges
+            .map(|byte_range| (format!("{}-{}", byte_range.start(size), byte_range.end(size) - 1), usize::try_from(byte_range.length(size)).unwrap(), (usize::try_from(byte_range.start(size)).unwrap(), usize::try_from(byte_range.end(size)).unwrap()))));
+        let bytes_strs = bytes_strs.join(", ");
 
         let range = HeaderValue::from_str(&format!("bytes={bytes_strs}")).unwrap();
         let response = self
@@ -126,15 +125,14 @@ impl ReadableStorageTraits for HTTPStore {
                 // TODO: Gracefully handle a response from the server which does not include all requested by ranges
                 let mut bytes = response.bytes().map_err(handle_reqwest_error)?;
                 if bytes.len() as u64
-                    == byte_ranges
+                    == bytes_lengths
                         .iter()
-                        .map(|byte_range| byte_range.length(size))
-                        .sum::<u64>()
+                        .sum::<usize>() as u64
                 {
-                    let mut out = Vec::with_capacity(byte_ranges.len());
-                    for byte_range in byte_ranges {
+                    let mut out = Vec::with_capacity(bytes_lengths.len());
+                    for length in bytes_lengths {
                         let bytes_range =
-                            bytes.split_to(usize::try_from(byte_range.length(size)).unwrap());
+                            bytes.split_to(length);
                         out.push(bytes_range);
                     }
                     Ok(Some(out))
@@ -147,10 +145,8 @@ impl ReadableStorageTraits for HTTPStore {
             StatusCode::OK => {
                 // Received all bytes
                 let bytes = response.bytes().map_err(handle_reqwest_error)?;
-                let mut out = Vec::with_capacity(byte_ranges.len());
-                for byte_range in byte_ranges {
-                    let start = usize::try_from(byte_range.start(size)).unwrap();
-                    let end = usize::try_from(byte_range.end(size)).unwrap();
+                let mut out = Vec::with_capacity(bytes_start_end.len());
+                for (start, end) in bytes_start_end {
                     out.push(bytes.slice(start..end));
                 }
                 Ok(Some(out))
@@ -230,7 +226,7 @@ mod tests {
         assert!(store
             .get_partial_values_key(
                 &"zarr.json".try_into().unwrap(),
-                &[ByteRange::FromStart(0, None)]
+                &mut [ByteRange::FromStart(0, None)].into_iter()
             )
             .is_err());
         assert!(store.size_key(&"zarr.json".try_into().unwrap()).is_err());

--- a/zarrs_object_store/src/lib.rs
+++ b/zarrs_object_store/src/lib.rs
@@ -100,13 +100,12 @@ impl<T: object_store::ObjectStore> AsyncReadableStorageTraits for AsyncObjectSto
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send)
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         let Some(size) = self.size_key(key).await? else {
             return Ok(None);
         };
         let ranges = byte_ranges
-            .iter()
             .map(|byte_range| byte_range.to_range(size))
             .collect::<Vec<_>>();
         let get_ranges = self

--- a/zarrs_object_store/src/lib.rs
+++ b/zarrs_object_store/src/lib.rs
@@ -41,7 +41,7 @@ use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 
 use zarrs_storage::{
-    async_store_set_partial_values, byte_range::ByteRange, AsyncBytes, AsyncListableStorageTraits,
+    async_store_set_partial_values, byte_range::ByteRangeIndexer, AsyncBytes, AsyncListableStorageTraits,
     AsyncReadableStorageTraits, AsyncWritableStorageTraits, MaybeAsyncBytes, StorageError,
     StoreKey, StoreKeyOffsetValue, StoreKeys, StoreKeysPrefixes, StorePrefix,
 };
@@ -100,12 +100,13 @@ impl<T: object_store::ObjectStore> AsyncReadableStorageTraits for AsyncObjectSto
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send)
+        byte_ranges: &dyn ByteRangeIndexer
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         let Some(size) = self.size_key(key).await? else {
             return Ok(None);
         };
         let ranges = byte_ranges
+            .iter()
             .map(|byte_range| byte_range.to_range(size))
             .collect::<Vec<_>>();
         let get_ranges = self

--- a/zarrs_storage/src/byte_range.rs
+++ b/zarrs_storage/src/byte_range.rs
@@ -177,44 +177,13 @@ impl InvalidByteRangeError {
     }
 }
 
-/// Trait to allow for creation of a borrowed iterator in more situations.
-pub trait ByteRangeIndexer: Send + Sync {
-    /// Returns an iterator over byte ranges.
-    fn iter(&self) -> Box<dyn Iterator<Item = &ByteRange> + Send + Sync + '_>;
-}
-
-impl ByteRangeIndexer for &[ByteRange] {
-    fn iter(&self) -> Box<dyn Iterator<Item = &ByteRange> + Send + Sync + '_> {
-        Box::new(<[ByteRange]>::iter(self))
-    }
-}
-
-impl<const N: usize> ByteRangeIndexer for [ByteRange; N] {
-    fn iter(&self) -> Box<dyn Iterator<Item = &ByteRange> + Send + Sync + '_> {
-        Box::new(<[ByteRange]>::iter(self.as_slice()))
-    }
-}
-
-impl ByteRangeIndexer for Vec<ByteRange> {
-    fn iter(&self) -> Box<dyn Iterator<Item = &ByteRange> + Send + Sync + '_> {
-        Box::new(<[ByteRange]>::iter(self.as_slice()))
-    }
-}
-
-
-impl ByteRangeIndexer for ByteRange {
-    fn iter(&self) -> Box<dyn Iterator<Item = &ByteRange> + Send + Sync + '_> {
-        Box::new(<[ByteRange]>::iter(core::slice::from_ref(self)))
-    }
-}
-
 fn is_valid(
-    byte_range: &ByteRange,
+    byte_range: ByteRange,
     bytes_len: u64
 ) -> bool {
     match byte_range {
         ByteRange::FromStart(offset, length) => offset + length.unwrap_or(0) <= bytes_len,
-        ByteRange::Suffix(length) => length <= &bytes_len,
+        ByteRange::Suffix(length) => length <= bytes_len,
     }
 }
 
@@ -224,14 +193,14 @@ fn is_valid(
 /// Returns [`InvalidByteRangeError`] if any bytes are requested beyond the end of `bytes`.
 pub fn extract_byte_ranges(
     bytes: &[u8],
-    byte_ranges: &dyn ByteRangeIndexer,
+    byte_ranges: impl Iterator<Item = ByteRange>,
 ) -> Result<Vec<Vec<u8>>, InvalidByteRangeError> {
     let bytes_len = bytes.len() as u64;
-    byte_ranges.iter().map(
+    byte_ranges.map(
         |byte_range| {
-            let valid = is_valid(byte_range, bytes_len);
+            let valid = is_valid(byte_range,bytes_len);
             if !valid {
-                return Err(InvalidByteRangeError(*byte_range, bytes_len));
+                return Err(InvalidByteRangeError(byte_range, bytes_len));
             }
             let start = usize::try_from(byte_range.start(bytes.len() as u64)).unwrap();
             let end = usize::try_from(byte_range.end(bytes.len() as u64)).unwrap();
@@ -246,15 +215,14 @@ pub fn extract_byte_ranges(
 /// Returns [`InvalidByteRangeError`] if any bytes are requested beyond the end of `bytes`.
 pub fn extract_byte_ranges_concat(
     bytes: &[u8],
-    byte_ranges: &dyn ByteRangeIndexer,
+    byte_ranges: impl Iterator<Item = ByteRange>,
 ) -> Result<Vec<u8>, InvalidByteRangeError> {
     let bytes_len = bytes.len() as u64;
     let lengths_and_starts = byte_ranges
-        .iter()
         .map(|byte_range| {
             let valid = is_valid(byte_range, bytes_len);
             if !valid {
-                return Err(InvalidByteRangeError(*byte_range, bytes_len));
+                return Err(InvalidByteRangeError(byte_range, bytes_len));
             }
             Ok((byte_range.length(bytes.len() as u64), byte_range.start(bytes.len() as u64)))
         }).collect::<Result<Vec<(u64, u64)>, InvalidByteRangeError>>()?;
@@ -301,28 +269,28 @@ pub fn extract_byte_ranges_concat(
 /// Panics if a byte has length exceeding [`usize::MAX`].
 pub fn extract_byte_ranges_read_seek<T: Read + Seek>(
     mut bytes: T,
-    byte_ranges: &dyn ByteRangeIndexer,
+    byte_ranges: impl Iterator<Item = ByteRange>,
 ) -> std::io::Result<Vec<Vec<u8>>> {
     let len: u64 = bytes.seek(SeekFrom::End(0))?;
-    byte_ranges.iter().map(|byte_range| {
+    byte_ranges.map(|byte_range| {
         let data: Vec<u8> = match byte_range {
             ByteRange::FromStart(offset, None) => {
-                bytes.seek(SeekFrom::Start(*offset))?;
+                bytes.seek(SeekFrom::Start(offset))?;
                 let length = usize::try_from(len).unwrap();
                 let mut data = vec![0; length];
                 bytes.read_exact(&mut data)?;
                 data
             }
             ByteRange::FromStart(offset, Some(length)) => {
-                bytes.seek(SeekFrom::Start(*offset))?;
-                let length = usize::try_from(*length).unwrap();
+                bytes.seek(SeekFrom::Start(offset))?;
+                let length = usize::try_from(length).unwrap();
                 let mut data = vec![0; length];
                 bytes.read_exact(&mut data)?;
                 data
             }
             ByteRange::Suffix(length) => {
-                bytes.seek(SeekFrom::End(-i64::try_from(*length).unwrap()))?;
-                let length = usize::try_from(*length).unwrap();
+                bytes.seek(SeekFrom::End(-i64::try_from(length).unwrap()))?;
+                let length = usize::try_from(length).unwrap();
                 let mut data = vec![0; length];
                 bytes.read_exact(&mut data)?;
                 data
@@ -345,16 +313,19 @@ pub fn extract_byte_ranges_read_seek<T: Read + Seek>(
 pub fn extract_byte_ranges_read<T: Read>(
     bytes: &mut T,
     size: u64,
-    byte_ranges: &dyn ByteRangeIndexer,
+    byte_ranges: impl Iterator<Item = ByteRange>,
 ) -> std::io::Result<Vec<Vec<u8>>> {
     // Could this be cleaner/more efficient?
+    let byte_ranges = byte_ranges.collect::<Vec<ByteRange>>();
     // Allocate output and find the endpoints of the "segments" of bytes which must be read
+    let mut out = Vec::with_capacity(byte_ranges.len());
     let mut segments_endpoints = BTreeSet::<u64>::new();
-    let mut out = byte_ranges.iter().map(|byte_range| {
+    for byte_range in &byte_ranges {
+        out.push(vec![0; usize::try_from(byte_range.length(size)).unwrap()]);
         segments_endpoints.insert(byte_range.start(size));
         segments_endpoints.insert(byte_range.end(size));
-        vec![0; usize::try_from(byte_range.length(size)).unwrap()]
-    }).collect::<Vec<Vec<u8>>>();
+    }
+
     // Find the overlapping part of each byte range with each segment
     //                 SEGMENT start     , end        OUTPUT index, offset
     let mut overlap: BTreeMap<(ByteOffset, ByteOffset), Vec<(usize, ByteOffset)>> = BTreeMap::new();
@@ -426,14 +397,14 @@ mod tests {
         assert_eq!(byte_range.to_range_usize(10), 1..6);
         assert_eq!(byte_range.length(10), 5);
 
-        assert!(is_valid(&ByteRange::FromStart(1, Some(5)), 6));
-        assert!(!is_valid(&ByteRange::FromStart(1, Some(5)), 2));
+        assert!(is_valid(ByteRange::FromStart(1, Some(5)), 6));
+        assert!(!is_valid(ByteRange::FromStart(1, Some(5)), 2));
 
-        assert!(is_valid(&ByteRange::Suffix(5), 6));
-        assert!(!is_valid(&ByteRange::Suffix(5), 2));
+        assert!(is_valid(ByteRange::Suffix(5), 6));
+        assert!(!is_valid(ByteRange::Suffix(5), 2));
 
-        assert!(extract_byte_ranges(&[1, 2, 3], &vec![ByteRange::FromStart(1, Some(2))]).is_ok());
-        let bytes = extract_byte_ranges(&[1, 2, 3], &vec![ByteRange::FromStart(1, Some(4))]);
+        assert!(extract_byte_ranges(&[1, 2, 3], Box::new(vec![ByteRange::FromStart(1, Some(2))].into_iter())).is_ok());
+        let bytes = extract_byte_ranges(&[1, 2, 3], Box::new(vec![ByteRange::FromStart(1, Some(4))].into_iter()));
         assert!(bytes.is_err());
         assert_eq!(
             bytes.unwrap_err().to_string(),
@@ -470,7 +441,7 @@ mod tests {
             ByteRange::FromStart(1, Some(1)),
             ByteRange::Suffix(5),
         ];
-        let out = extract_byte_ranges_read(&mut read, size, &byte_ranges).unwrap();
+        let out = extract_byte_ranges_read(&mut read, size, &mut byte_ranges.into_iter()).unwrap();
         assert_eq!(
             out,
             vec![vec![3, 4, 5], vec![4], vec![1], vec![5, 6, 7, 8, 9]]

--- a/zarrs_storage/src/storage_adapter/async_to_sync.rs
+++ b/zarrs_storage/src/storage_adapter/async_to_sync.rs
@@ -5,7 +5,7 @@
 //! The docs for the [`AsyncToSyncBlockOn`] trait include an example implementation for the `tokio` runtime.
 
 use crate::{
-    byte_range::ByteRange, AsyncListableStorageTraits, AsyncReadableStorageTraits,
+    byte_range::ByteRangeIndexer, AsyncListableStorageTraits, AsyncReadableStorageTraits,
     AsyncWritableStorageTraits, Bytes, ListableStorageTraits, ReadableStorageTraits, StorageError,
     StoreKey, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
 };
@@ -59,7 +59,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits, TBlockOn: AsyncToSyncBlockOn
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges: &dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.block_on(self.storage.get_partial_values_key(key, byte_ranges))
     }

--- a/zarrs_storage/src/storage_adapter/async_to_sync.rs
+++ b/zarrs_storage/src/storage_adapter/async_to_sync.rs
@@ -59,7 +59,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits, TBlockOn: AsyncToSyncBlockOn
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.block_on(self.storage.get_partial_values_key(key, byte_ranges))
     }

--- a/zarrs_storage/src/storage_adapter/async_to_sync.rs
+++ b/zarrs_storage/src/storage_adapter/async_to_sync.rs
@@ -5,7 +5,7 @@
 //! The docs for the [`AsyncToSyncBlockOn`] trait include an example implementation for the `tokio` runtime.
 
 use crate::{
-    byte_range::ByteRangeIndexer, AsyncListableStorageTraits, AsyncReadableStorageTraits,
+    byte_range::ByteRange, AsyncListableStorageTraits, AsyncReadableStorageTraits,
     AsyncWritableStorageTraits, Bytes, ListableStorageTraits, ReadableStorageTraits, StorageError,
     StoreKey, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
 };
@@ -59,7 +59,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits, TBlockOn: AsyncToSyncBlockOn
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &dyn ByteRangeIndexer,
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.block_on(self.storage.get_partial_values_key(key, byte_ranges))
     }

--- a/zarrs_storage/src/storage_adapter/performance_metrics.rs
+++ b/zarrs_storage/src/storage_adapter/performance_metrics.rs
@@ -1,7 +1,7 @@
 //! A storage transformer which records performance metrics.
 
 use crate::{
-    byte_range::{ByteRange,ByteRangeIndexer}, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey, StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits
+    byte_range::ByteRange, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey, StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits
 };
 
 #[cfg(feature = "async")]
@@ -109,10 +109,10 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges:&dyn ByteRangeIndexer,
+        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
-        let byte_ranges_collected = byte_ranges.iter().collect::<Vec<&ByteRange>>();
-        let values = self.storage.get_partial_values_key(key, byte_ranges)?;
+        let byte_ranges_collected = byte_ranges.collect::<Vec<ByteRange>>();
+        let values = self.storage.get_partial_values_key(key, &mut byte_ranges_collected.clone().into_iter())?;
         if let Some(values) = &values {
             let bytes_read = values.iter().map(Bytes::len).sum();
             self.bytes_read.fetch_add(bytes_read, Ordering::Relaxed);
@@ -221,16 +221,17 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &dyn ByteRangeIndexer,
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
+        let byte_ranges_collected: Vec<ByteRange> = byte_ranges.collect::<Vec<ByteRange>>();
         let values = self
             .storage
-            .get_partial_values_key(key, byte_ranges)
+            .get_partial_values_key(key, &mut byte_ranges_collected.clone().into_iter())
             .await?;
         if let Some(values) = &values {
             let bytes_read = values.iter().map(AsyncBytes::len).sum();
             self.bytes_read.fetch_add(bytes_read, Ordering::Relaxed);
-            self.reads.fetch_add(values.len(), Ordering::Relaxed);
+            self.reads.fetch_add(byte_ranges_collected.len(), Ordering::Relaxed);
         }
         Ok(values)
     }

--- a/zarrs_storage/src/storage_adapter/performance_metrics.rs
+++ b/zarrs_storage/src/storage_adapter/performance_metrics.rs
@@ -1,7 +1,7 @@
 //! A storage transformer which records performance metrics.
 
 use crate::{
-    byte_range::ByteRange, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey, StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits
+    byte_range::{ByteRange,ByteRangeIndexer}, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey, StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits
 };
 
 #[cfg(feature = "async")]
@@ -109,10 +109,10 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges:&dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
-        let byte_ranges_collected = byte_ranges.collect::<Vec<ByteRange>>();
-        let values = self.storage.get_partial_values_key(key, &mut byte_ranges_collected.clone().into_iter())?;
+        let byte_ranges_collected = byte_ranges.iter().collect::<Vec<&ByteRange>>();
+        let values = self.storage.get_partial_values_key(key, byte_ranges)?;
         if let Some(values) = &values {
             let bytes_read = values.iter().map(Bytes::len).sum();
             self.bytes_read.fetch_add(bytes_read, Ordering::Relaxed);
@@ -221,17 +221,16 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges: &dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
-        let byte_ranges_collected: Vec<ByteRange> = byte_ranges.collect::<Vec<ByteRange>>();
         let values = self
             .storage
-            .get_partial_values_key(key, &mut byte_ranges_collected.clone().into_iter())
+            .get_partial_values_key(key, byte_ranges)
             .await?;
         if let Some(values) = &values {
             let bytes_read = values.iter().map(AsyncBytes::len).sum();
             self.bytes_read.fetch_add(bytes_read, Ordering::Relaxed);
-            self.reads.fetch_add(byte_ranges_collected.len(), Ordering::Relaxed);
+            self.reads.fetch_add(values.len(), Ordering::Relaxed);
         }
         Ok(values)
     }

--- a/zarrs_storage/src/storage_adapter/usage_log.rs
+++ b/zarrs_storage/src/storage_adapter/usage_log.rs
@@ -8,7 +8,7 @@ use std::{
 use itertools::Itertools;
 
 use crate::{
-    byte_range::{ByteRange, ByteRangeIndexer}, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
+    byte_range::ByteRangeIndexer, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
     StorageError, StoreKey, StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes,
     StorePrefix, WritableStorageTraits,
 };

--- a/zarrs_storage/src/storage_adapter/usage_log.rs
+++ b/zarrs_storage/src/storage_adapter/usage_log.rs
@@ -8,7 +8,7 @@ use std::{
 use itertools::Itertools;
 
 use crate::{
-    byte_range::ByteRangeIndexer, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
+    byte_range::{ByteRange, ByteRangeIndexer}, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
     StorageError, StoreKey, StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes,
     StorePrefix, WritableStorageTraits,
 };

--- a/zarrs_storage/src/storage_adapter/usage_log.rs
+++ b/zarrs_storage/src/storage_adapter/usage_log.rs
@@ -96,14 +96,15 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
-        let result = self.storage.get_partial_values_key(key, byte_ranges);
+        let byte_ranges_collected = byte_ranges.collect::<Vec<ByteRange>>();
+        let result = self.storage.get_partial_values_key(key, &mut byte_ranges_collected.clone().into_iter());
         writeln!(
             self.handle.lock().unwrap(),
             "{}get_partial_values_key({key}, [{}]) -> len={:?}",
             (self.prefix_func)(),
-            byte_ranges.iter().format(", "),
+            byte_ranges_collected.iter().format(", "),
             result.as_ref().map(|v| {
                 v.as_ref()
                     .map_or(vec![], |v| v.iter().map(Bytes::len).collect_vec())
@@ -303,14 +304,15 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
-        let result = self.storage.get_partial_values_key(key, byte_ranges).await;
+        let byte_ranges_collected: Vec<ByteRange> = byte_ranges.collect::<Vec<ByteRange>>();
+        let result = self.storage.get_partial_values_key(key, &mut byte_ranges_collected.clone().into_iter()).await;
         writeln!(
             self.handle.lock().unwrap(),
             "{}get_partial_values_key({key}, [{}]) -> len={:?}",
             (self.prefix_func)(),
-            byte_ranges.iter().format(", "),
+            byte_ranges_collected.iter().format(", "),
             result.as_ref().map(|v| {
                 v.as_ref()
                     .map_or(vec![], |v| v.iter().map(AsyncBytes::len).collect_vec())

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -24,7 +24,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
     /// Returns a [`StorageError`] if the store key does not exist or there is an error with the underlying store.
     async fn get(&self, key: &StoreKey) -> Result<MaybeAsyncBytes, StorageError> {
         Ok(self
-            .get_partial_values_key(key, &mut vec![ByteRange::FromStart(0, None)].into_iter())
+            .get_partial_values_key(key, &mut [ByteRange::FromStart(0, None)].into_iter())
             .await?
             .map(|mut v| v.remove(0)))
     }
@@ -91,7 +91,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
             if key_range.key != *last_key_val {
                 // Found a new key, so do a batched get of the byte ranges of the last key
                 let bytes = (self
-                    .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())
+                    .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.iter().copied())
                     .await?)
                     .map_or_else(
                         || vec![None; byte_ranges_key.len()],
@@ -108,7 +108,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
             let bytes = (self
-                .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())
+                .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.iter().copied())
                 .await?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -5,7 +5,7 @@ use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 
 use super::{
-    byte_range::ByteRange, AsyncBytes, MaybeAsyncBytes, StorageError, StoreKey,
+    byte_range::{ByteRange, ByteRangeIndexer}, AsyncBytes, MaybeAsyncBytes, StorageError, StoreKey,
     StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes,
 };
 
@@ -24,7 +24,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
     /// Returns a [`StorageError`] if the store key does not exist or there is an error with the underlying store.
     async fn get(&self, key: &StoreKey) -> Result<MaybeAsyncBytes, StorageError> {
         Ok(self
-            .get_partial_values_key(key, &mut vec![ByteRange::FromStart(0, None)].into_iter())
+            .get_partial_values_key(key, &ByteRange::FromStart(0, None))
             .await?
             .map(|mut v| v.remove(0)))
     }
@@ -39,7 +39,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges: &dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError>;
 
     /// Retrieve partial bytes from a list of [`StoreKeyRange`].
@@ -91,7 +91,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
             if key_range.key != *last_key_val {
                 // Found a new key, so do a batched get of the byte ranges of the last key
                 let bytes = (self
-                    .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())
+                    .get_partial_values_key(last_key.unwrap(), &byte_ranges_key)
                     .await?)
                     .map_or_else(
                         || vec![None; byte_ranges_key.len()],
@@ -108,7 +108,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
             let bytes = (self
-                .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())
+                .get_partial_values_key(last_key.unwrap(), &byte_ranges_key)
                 .await?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -9,6 +9,8 @@ use super::{
     StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes,
 };
 
+
+
 /// Async readable storage traits.
 #[cfg_attr(feature = "async", async_trait::async_trait)]
 #[auto_impl(Arc)]
@@ -22,7 +24,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
     /// Returns a [`StorageError`] if the store key does not exist or there is an error with the underlying store.
     async fn get(&self, key: &StoreKey) -> Result<MaybeAsyncBytes, StorageError> {
         Ok(self
-            .get_partial_values_key(key, &[ByteRange::FromStart(0, None)])
+            .get_partial_values_key(key, &mut vec![ByteRange::FromStart(0, None)].into_iter())
             .await?
             .map(|mut v| v.remove(0)))
     }
@@ -37,7 +39,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError>;
 
     /// Retrieve partial bytes from a list of [`StoreKeyRange`].
@@ -89,7 +91,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
             if key_range.key != *last_key_val {
                 // Found a new key, so do a batched get of the byte ranges of the last key
                 let bytes = (self
-                    .get_partial_values_key(last_key.unwrap(), &byte_ranges_key)
+                    .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())
                     .await?)
                     .map_or_else(
                         || vec![None; byte_ranges_key.len()],
@@ -106,7 +108,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
             let bytes = (self
-                .get_partial_values_key(last_key.unwrap(), &byte_ranges_key)
+                .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())
                 .await?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],

--- a/zarrs_storage/src/storage_async.rs
+++ b/zarrs_storage/src/storage_async.rs
@@ -5,7 +5,7 @@ use futures::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 
 use super::{
-    byte_range::{ByteRange, ByteRangeIndexer}, AsyncBytes, MaybeAsyncBytes, StorageError, StoreKey,
+    byte_range::ByteRange, AsyncBytes, MaybeAsyncBytes, StorageError, StoreKey,
     StoreKeyOffsetValue, StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes,
 };
 
@@ -24,7 +24,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
     /// Returns a [`StorageError`] if the store key does not exist or there is an error with the underlying store.
     async fn get(&self, key: &StoreKey) -> Result<MaybeAsyncBytes, StorageError> {
         Ok(self
-            .get_partial_values_key(key, &ByteRange::FromStart(0, None))
+            .get_partial_values_key(key, &mut vec![ByteRange::FromStart(0, None)].into_iter())
             .await?
             .map(|mut v| v.remove(0)))
     }
@@ -39,7 +39,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &dyn ByteRangeIndexer,
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError>;
 
     /// Retrieve partial bytes from a list of [`StoreKeyRange`].
@@ -91,7 +91,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
             if key_range.key != *last_key_val {
                 // Found a new key, so do a batched get of the byte ranges of the last key
                 let bytes = (self
-                    .get_partial_values_key(last_key.unwrap(), &byte_ranges_key)
+                    .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())
                     .await?)
                     .map_or_else(
                         || vec![None; byte_ranges_key.len()],
@@ -108,7 +108,7 @@ pub trait AsyncReadableStorageTraits: Send + Sync {
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
             let bytes = (self
-                .get_partial_values_key(last_key.unwrap(), &byte_ranges_key)
+                .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())
                 .await?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],

--- a/zarrs_storage/src/storage_handle.rs
+++ b/zarrs_storage/src/storage_handle.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::{
-    byte_range::ByteRangeIndexer, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
+    byte_range::ByteRange, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
     StorageError, StoreKey, StorePrefix, WritableStorageTraits,
 };
 
@@ -32,7 +32,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits for Storage
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges:&dyn ByteRangeIndexer,
+        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges)
     }
@@ -114,7 +114,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &dyn ByteRangeIndexer,
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges).await
     }

--- a/zarrs_storage/src/storage_handle.rs
+++ b/zarrs_storage/src/storage_handle.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::{
-    byte_range::ByteRange, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
+    byte_range::ByteRangeIndexer, Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits,
     StorageError, StoreKey, StorePrefix, WritableStorageTraits,
 };
 
@@ -32,7 +32,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits for Storage
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges:&dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges)
     }
@@ -114,7 +114,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges: &dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges).await
     }

--- a/zarrs_storage/src/storage_handle.rs
+++ b/zarrs_storage/src/storage_handle.rs
@@ -32,7 +32,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits for Storage
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges)
     }
@@ -114,7 +114,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
     async fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges).await
     }

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -19,7 +19,7 @@ pub trait ReadableStorageTraits: Send + Sync {
     /// Returns a [`StorageError`] if there is an underlying storage error.
     fn get(&self, key: &StoreKey) -> Result<MaybeBytes, StorageError> {
         Ok(self
-            .get_partial_values_key(key, &[ByteRange::FromStart(0, None)])?
+            .get_partial_values_key(key, &mut [ByteRange::FromStart(0, None)].into_iter())?
             .map(|mut v| v.remove(0)))
     }
 
@@ -32,7 +32,7 @@ pub trait ReadableStorageTraits: Send + Sync {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError>;
 
     /// Retrieve partial bytes from a list of [`StoreKeyRange`].
@@ -81,7 +81,7 @@ pub trait ReadableStorageTraits: Send + Sync {
 
             if key_range.key != *last_key_val {
                 // Found a new key, so do a batched get of the byte ranges of the last key
-                let bytes = (self.get_partial_values_key(last_key.unwrap(), &byte_ranges_key)?)
+                let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())?)
                     .map_or_else(
                         || vec![None; byte_ranges_key.len()],
                         |partial_values| partial_values.into_iter().map(Some).collect(),
@@ -96,7 +96,7 @@ pub trait ReadableStorageTraits: Send + Sync {
 
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
-            let bytes = (self.get_partial_values_key(last_key.unwrap(), &byte_ranges_key)?)
+            let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],
                     |partial_values| partial_values.into_iter().map(Some).collect(),

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 use auto_impl::auto_impl;
 use itertools::Itertools;
 
-use crate::byte_range::ByteRangeIndexer;
-
 use super::{
     byte_range::ByteRange, Bytes, MaybeBytes, StorageError, StoreKey, StoreKeyOffsetValue,
     StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes,
@@ -21,7 +19,7 @@ pub trait ReadableStorageTraits: Send + Sync {
     /// Returns a [`StorageError`] if there is an underlying storage error.
     fn get(&self, key: &StoreKey) -> Result<MaybeBytes, StorageError> {
         Ok(self
-            .get_partial_values_key(key, &[ByteRange::FromStart(0, None)])?
+            .get_partial_values_key(key, &mut [ByteRange::FromStart(0, None)].into_iter())?
             .map(|mut v| v.remove(0)))
     }
 
@@ -34,7 +32,7 @@ pub trait ReadableStorageTraits: Send + Sync {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges:&dyn ByteRangeIndexer,
+        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError>;
 
     /// Retrieve partial bytes from a list of [`StoreKeyRange`].
@@ -83,7 +81,7 @@ pub trait ReadableStorageTraits: Send + Sync {
 
             if key_range.key != *last_key_val {
                 // Found a new key, so do a batched get of the byte ranges of the last key
-                let bytes = (self.get_partial_values_key(last_key.unwrap(), &byte_ranges_key)?)
+                let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())?)
                     .map_or_else(
                         || vec![None; byte_ranges_key.len()],
                         |partial_values| partial_values.into_iter().map(Some).collect(),
@@ -98,7 +96,7 @@ pub trait ReadableStorageTraits: Send + Sync {
 
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
-            let bytes = (self.get_partial_values_key(last_key.unwrap(), &byte_ranges_key)?)
+            let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],
                     |partial_values| partial_values.into_iter().map(Some).collect(),

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use auto_impl::auto_impl;
 use itertools::Itertools;
 
+use crate::byte_range::ByteRangeIndexer;
+
 use super::{
     byte_range::ByteRange, Bytes, MaybeBytes, StorageError, StoreKey, StoreKeyOffsetValue,
     StoreKeyRange, StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes,
@@ -19,7 +21,7 @@ pub trait ReadableStorageTraits: Send + Sync {
     /// Returns a [`StorageError`] if there is an underlying storage error.
     fn get(&self, key: &StoreKey) -> Result<MaybeBytes, StorageError> {
         Ok(self
-            .get_partial_values_key(key, &mut [ByteRange::FromStart(0, None)].into_iter())?
+            .get_partial_values_key(key, &[ByteRange::FromStart(0, None)])?
             .map(|mut v| v.remove(0)))
     }
 
@@ -32,7 +34,7 @@ pub trait ReadableStorageTraits: Send + Sync {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges:&dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<Bytes>>, StorageError>;
 
     /// Retrieve partial bytes from a list of [`StoreKeyRange`].
@@ -81,7 +83,7 @@ pub trait ReadableStorageTraits: Send + Sync {
 
             if key_range.key != *last_key_val {
                 // Found a new key, so do a batched get of the byte ranges of the last key
-                let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())?)
+                let bytes = (self.get_partial_values_key(last_key.unwrap(), &byte_ranges_key)?)
                     .map_or_else(
                         || vec![None; byte_ranges_key.len()],
                         |partial_values| partial_values.into_iter().map(Some).collect(),
@@ -96,7 +98,7 @@ pub trait ReadableStorageTraits: Send + Sync {
 
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
-            let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())?)
+            let bytes = (self.get_partial_values_key(last_key.unwrap(), &byte_ranges_key)?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],
                     |partial_values| partial_values.into_iter().map(Some).collect(),

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -81,7 +81,7 @@ pub trait ReadableStorageTraits: Send + Sync {
 
             if key_range.key != *last_key_val {
                 // Found a new key, so do a batched get of the byte ranges of the last key
-                let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())?)
+                let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.iter().copied())?)
                     .map_or_else(
                         || vec![None; byte_ranges_key.len()],
                         |partial_values| partial_values.into_iter().map(Some).collect(),
@@ -96,7 +96,7 @@ pub trait ReadableStorageTraits: Send + Sync {
 
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
-            let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.clone().into_iter())?)
+            let bytes = (self.get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.iter().copied())?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],
                     |partial_values| partial_values.into_iter().map(Some).collect(),

--- a/zarrs_storage/src/storage_value_io.rs
+++ b/zarrs_storage/src/storage_value_io.rs
@@ -68,7 +68,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Read for StorageValueIO<TStorage>
         let len = buf.len() as u64;
         let data = self
             .storage
-            .get_partial_values_key(&self.key, &mut [ByteRange::FromStart(self.pos, Some(len))].into_iter())
+            .get_partial_values_key(&self.key, &[ByteRange::FromStart(self.pos, Some(len))])
             .map_err(|err| std::io::Error::other(err.to_string()))?
             .map(|mut v| v.remove(0));
         if let Some(data) = data {

--- a/zarrs_storage/src/storage_value_io.rs
+++ b/zarrs_storage/src/storage_value_io.rs
@@ -68,7 +68,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Read for StorageValueIO<TStorage>
         let len = buf.len() as u64;
         let data = self
             .storage
-            .get_partial_values_key(&self.key, &[ByteRange::FromStart(self.pos, Some(len))])
+            .get_partial_values_key(&self.key, &mut [ByteRange::FromStart(self.pos, Some(len))].into_iter())
             .map_err(|err| std::io::Error::other(err.to_string()))?
             .map(|mut v| v.remove(0));
         if let Some(data) = data {

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -4,7 +4,7 @@ use parking_lot::RwLock; // TODO: std::sync::RwLock with Rust 1.78+
 use std::sync::Mutex;
 
 use crate::{
-    byte_range::{ByteOffset, ByteRange, ByteRangeIndexer, InvalidByteRangeError},
+    byte_range::{ByteOffset, ByteRangeIndexer, InvalidByteRangeError},
     Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
     StoreKeyOffsetValue, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
 };
@@ -90,7 +90,7 @@ impl ReadableStorageTraits for MemoryStore {
                 let start = usize::try_from(byte_range.start(data.len() as u64)).unwrap();
                 let end = usize::try_from(byte_range.end(data.len() as u64)).unwrap();
                 if end > data.len() {
-                    return Err(InvalidByteRangeError::new(byte_range.clone(), data.len() as u64));
+                    return Err(InvalidByteRangeError::new(*byte_range, data.len() as u64));
                 }
                 Ok(data[start..end].to_vec().into())
             }).collect::<Result<Vec<Bytes>, InvalidByteRangeError>>()?;

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -4,7 +4,7 @@ use parking_lot::RwLock; // TODO: std::sync::RwLock with Rust 1.78+
 use std::sync::Mutex;
 
 use crate::{
-    byte_range::{ByteOffset, ByteRangeIndexer, InvalidByteRangeError},
+    byte_range::{ByteOffset, ByteRange, ByteRangeIndexer, InvalidByteRangeError},
     Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
     StoreKeyOffsetValue, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
 };
@@ -90,7 +90,7 @@ impl ReadableStorageTraits for MemoryStore {
                 let start = usize::try_from(byte_range.start(data.len() as u64)).unwrap();
                 let end = usize::try_from(byte_range.end(data.len() as u64)).unwrap();
                 if end > data.len() {
-                    return Err(InvalidByteRangeError::new(*byte_range, data.len() as u64));
+                    return Err(InvalidByteRangeError::new(byte_range.clone(), data.len() as u64));
                 }
                 Ok(data[start..end].to_vec().into())
             }).collect::<Result<Vec<Bytes>, InvalidByteRangeError>>()?;

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -4,7 +4,7 @@ use parking_lot::RwLock; // TODO: std::sync::RwLock with Rust 1.78+
 use std::sync::Mutex;
 
 use crate::{
-    byte_range::{ByteOffset, ByteRange, InvalidByteRangeError},
+    byte_range::{ByteOffset, ByteRange, ByteRangeIndexer, InvalidByteRangeError},
     Bytes, ListableStorageTraits, MaybeBytes, ReadableStorageTraits, StorageError, StoreKey,
     StoreKeyOffsetValue, StoreKeys, StoreKeysPrefixes, StorePrefix, WritableStorageTraits,
 };
@@ -78,7 +78,7 @@ impl ReadableStorageTraits for MemoryStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges:&dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let data_map = self.data_map.lock().unwrap();
         let data = data_map.get(key);
@@ -86,11 +86,11 @@ impl ReadableStorageTraits for MemoryStore {
             let data = data.clone();
             drop(data_map);
             let data = data.read();
-            let out = byte_ranges.map(|byte_range| {
+            let out = byte_ranges.iter().map(|byte_range| {
                 let start = usize::try_from(byte_range.start(data.len() as u64)).unwrap();
                 let end = usize::try_from(byte_range.end(data.len() as u64)).unwrap();
                 if end > data.len() {
-                    return Err(InvalidByteRangeError::new(byte_range, data.len() as u64));
+                    return Err(InvalidByteRangeError::new(byte_range.clone(), data.len() as u64));
                 }
                 Ok(data[start..end].to_vec().into())
             }).collect::<Result<Vec<Bytes>, InvalidByteRangeError>>()?;

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -78,7 +78,7 @@ impl ReadableStorageTraits for MemoryStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges:&mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let data_map = self.data_map.lock().unwrap();
         let data = data_map.get(key);
@@ -86,16 +86,14 @@ impl ReadableStorageTraits for MemoryStore {
             let data = data.clone();
             drop(data_map);
             let data = data.read();
-            let mut out = Vec::with_capacity(byte_ranges.len());
-            for byte_range in byte_ranges {
+            let out = byte_ranges.map(|byte_range| {
                 let start = usize::try_from(byte_range.start(data.len() as u64)).unwrap();
                 let end = usize::try_from(byte_range.end(data.len() as u64)).unwrap();
                 if end > data.len() {
-                    return Err(InvalidByteRangeError::new(*byte_range, data.len() as u64).into());
+                    return Err(InvalidByteRangeError::new(byte_range, data.len() as u64));
                 }
-                let bytes = data[start..end].to_vec();
-                out.push(bytes.into());
-            }
+                Ok(data[start..end].to_vec().into())
+            }).collect::<Result<Vec<Bytes>, InvalidByteRangeError>>()?;
             Ok(Some(out))
         } else {
             Ok(None)

--- a/zarrs_storage/src/store_test.rs
+++ b/zarrs_storage/src/store_test.rs
@@ -67,7 +67,7 @@ pub fn store_read<T: ReadableStorageTraits>(store: &T) -> Result<(), Box<dyn Err
     assert_eq!(
         store.get_partial_values_key(
             &"a/b".try_into()?,
-            &mut [ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)].into_iter()
+            &[ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)]
         )?,
         Some(vec![vec![1].into(), vec![3].into()])
     );
@@ -251,7 +251,7 @@ pub async fn async_store_read<T: AsyncReadableStorageTraits>(
         store
             .get_partial_values_key(
                 &"a/b".try_into()?,
-                &mut [ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)].into_iter()
+                &[ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)]
             )
             .await?,
         Some(vec![vec![1].into(), vec![3].into()])

--- a/zarrs_storage/src/store_test.rs
+++ b/zarrs_storage/src/store_test.rs
@@ -67,7 +67,7 @@ pub fn store_read<T: ReadableStorageTraits>(store: &T) -> Result<(), Box<dyn Err
     assert_eq!(
         store.get_partial_values_key(
             &"a/b".try_into()?,
-            &[ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)]
+            &mut [ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)].into_iter()
         )?,
         Some(vec![vec![1].into(), vec![3].into()])
     );
@@ -251,7 +251,7 @@ pub async fn async_store_read<T: AsyncReadableStorageTraits>(
         store
             .get_partial_values_key(
                 &"a/b".try_into()?,
-                &[ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)]
+                &mut [ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)].into_iter()
             )
             .await?,
         Some(vec![vec![1].into(), vec![3].into()])

--- a/zarrs_zip/src/lib.rs
+++ b/zarrs_zip/src/lib.rs
@@ -21,7 +21,7 @@
 //! - the MIT license [LICENSE-MIT](https://docs.rs/crate/zarrs_zip/latest/source/LICENCE-MIT) or <http://opensource.org/licenses/MIT>, at your option.
 
 use zarrs_storage::{
-    byte_range::{extract_byte_ranges_read, ByteRange, ByteRangeIndexer},
+    byte_range::{extract_byte_ranges_read, ByteRange},
     Bytes, ListableStorageTraits, ReadableStorageTraits, StorageError, StorageValueIO, StoreKey,
     StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes,
 };
@@ -93,7 +93,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ZipStorageAdapter<TStorage> {
     fn get_impl(
         &self,
         key: &StoreKey,
-        byte_ranges: &dyn ByteRangeIndexer,
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let mut zip_archive = self.zip_archive.lock().unwrap();
         let mut file = {
@@ -127,7 +127,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &dyn ByteRangeIndexer,
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.get_impl(key, byte_ranges)
     }

--- a/zarrs_zip/src/lib.rs
+++ b/zarrs_zip/src/lib.rs
@@ -21,7 +21,7 @@
 //! - the MIT license [LICENSE-MIT](https://docs.rs/crate/zarrs_zip/latest/source/LICENCE-MIT) or <http://opensource.org/licenses/MIT>, at your option.
 
 use zarrs_storage::{
-    byte_range::{extract_byte_ranges_read, ByteRange},
+    byte_range::{extract_byte_ranges_read, ByteRange, ByteRangeIndexer},
     Bytes, ListableStorageTraits, ReadableStorageTraits, StorageError, StorageValueIO, StoreKey,
     StoreKeys, StoreKeysPrefixes, StorePrefix, StorePrefixes,
 };
@@ -93,7 +93,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ZipStorageAdapter<TStorage> {
     fn get_impl(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges: &dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let mut zip_archive = self.zip_archive.lock().unwrap();
         let mut file = {
@@ -127,7 +127,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
+        byte_ranges: &dyn ByteRangeIndexer,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.get_impl(key, byte_ranges)
     }

--- a/zarrs_zip/src/lib.rs
+++ b/zarrs_zip/src/lib.rs
@@ -93,7 +93,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ZipStorageAdapter<TStorage> {
     fn get_impl(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let mut zip_archive = self.zip_archive.lock().unwrap();
         let mut file = {
@@ -127,7 +127,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &[ByteRange],
+        byte_ranges: &mut (dyn Iterator<Item = ByteRange> + Send),
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.get_impl(key, byte_ranges)
     }


### PR DESCRIPTION
For #231 (specifically https://github.com/zarrs/zarrs/pull/231/files#diff-9a4bab3c725daa82d11fe7ebc287fda388d2c237e1d3944c07e98f71dec21b50R64)

I just wanted to see how this would go following it through to the end i.e., using iterators everhwere we formerly didn't for handling multiple `ByteRange`s.  On the whole, ok, but my biggest concern would be passing around iterators in public methods - not sure why, but it feels wrong given that they can be empty in theory (yea?).

 This means that we now have to track if an iterator is spent or not as far as a I can tell, at least internally i.e., make copies of some sort if we want re-use, which happens a few times (like https://github.com/zarrs/zarrs/compare/generic_indexer_api2...ilan-gold:ig/byte_ranges?expand=1#diff-c59173d3944b41335cd1e9749119b9d70d76af58783655ef98376e710c46a4baR43).  I don't find that to be super ideal, but all the tests do pass (whether or not that actually is a meaningful data point is probably a different story). Maybe there's a way around it.

Hopefully this at least helps reason as to whether or not this is a good idea or if its scope should be limited!