### PR TITLE
refactor: revise partial encoding API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Implement `Indexer` for `ArraySubset`, `&ArraySubset`, `&[ArrayIndices]`, `&[T]` where `T: Indexer`, and more
   - **Breaking**: Partial decoders and encoders use `&dyn Indexer` instead of `&ArraySubset`
   - **Breaking**: Move `ArraySubset::byte_ranges` to `Indexer` trait
-- Impl `BytesPartialEncoderTraits` for `Mutex<Option<Vec<u8>>>`
 - Add `[StorageTransformerChain,StorageTransformerExtension]::create[_async]_readable_writable_transformer`
 
 ### Changed
@@ -99,6 +98,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: `CodecError` enum revisions
   - Rename `InvalidArraySubsetError` to `IncompatibleIndexer`
   - Remove `InvalidArraySubsetDimensionalityError`, included in `IncompatibleIndexer`
+- **Breaking**: Refactor partial encoding and the `[Async]{Array,Bytes}PartialEncoderTraits` traits:
+  - The partial decoder traits are now a supertrait of the partial encoder traits
+  - Input/output handle parameters are fused in relevant methods
+  ```diff
+  - input_handle: Arc<dyn ArrayPartialDecoderTraits>,
+  - output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+  + input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+  ```
+  - Add `[Async]{Array,Bytes}PartialEncoderTraits::into_dyn_decoder`
+  - Impl `{Array,Bytes}PartialEncoderTrait` for `Mutex<Option<Vec<u8>>>`
 - Optimised chunk key encoders
 - Conditional use of `Send` / `Sync` / `async_trait(?Send)` based on `target_arch` for WASM compatibility ([#245] by [@keller-mark])
 - Bump `zarrs_metadata_ext` to 0.2.0
@@ -121,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Permit data types with empty configurations that do not require one
 - Erase chunks before writing the updated chunk in `ArrayTo{Array,Bytes}PartialEncoderDefault`
+- Fix `squeeze` and `transpose` codec partial encoding
 
 [#245]: https://github.com/zarrs/zarrs/pull/245
 

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -501,7 +501,7 @@ pub trait AsyncArrayPartialEncoderTraits:
     AsyncArrayPartialDecoderTraits + Any + MaybeSend + MaybeSync
 {
     /// Return the encoder as an [`Arc<AsyncArrayPartialDecoderTraits>`].
-    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits>;
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits>;
 
     /// Erase the chunk.
     ///
@@ -553,7 +553,7 @@ pub trait AsyncBytesPartialEncoderTraits:
     AsyncBytesPartialDecoderTraits + Any + MaybeSend + MaybeSync
 {
     /// Return the encoder as an [`Arc<AsyncBytesPartialDecoderTraits>`].
-    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncBytesPartialDecoderTraits>;
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncBytesPartialDecoderTraits>;
 
     /// Erase the chunk.
     ///

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -115,18 +115,16 @@ use zarrs_data_type::{DataTypeExtensionError, DataTypeFillValueError, FillValue}
 use zarrs_metadata::{v3::MetadataV3, ArrayShape};
 use zarrs_plugin::PluginUnsupportedError;
 use zarrs_registry::ExtensionAliasesCodecV3;
+use zarrs_storage::byte_range::extract_byte_ranges;
 use zarrs_storage::{MaybeSend, MaybeSync};
 
 use crate::config::global_config;
-use crate::storage::{StoreKeyOffsetValue, WritableStorage};
+use crate::storage::{ReadableWritableStorage, StoreKeyOffsetValue};
 use crate::{
     array_subset::{ArraySubset, IncompatibleDimensionalityError},
     indexer::IncompatibleIndexerError,
     plugin::{Plugin, PluginCreateError},
-    storage::byte_range::{
-        extract_byte_ranges_read_seek, ByteOffset, ByteRange, ByteRangeIterator,
-        InvalidByteRangeError,
-    },
+    storage::byte_range::{ByteOffset, ByteRange, ByteRangeIterator, InvalidByteRangeError},
     storage::{ReadableStorage, StorageError, StoreKey},
 };
 
@@ -471,7 +469,12 @@ pub trait ArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
 }
 
 /// Partial array encoder traits.
-pub trait ArrayPartialEncoderTraits: Any + MaybeSend + MaybeSync {
+pub trait ArrayPartialEncoderTraits:
+    ArrayPartialDecoderTraits + Any + MaybeSend + MaybeSync
+{
+    /// Return the encoder as an [`Arc<ArrayPartialDecoderTraits>`].
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn ArrayPartialDecoderTraits>;
+
     /// Erase the chunk.
     ///
     /// # Errors
@@ -494,7 +497,12 @@ pub trait ArrayPartialEncoderTraits: Any + MaybeSend + MaybeSync {
 /// Asynchronous partial array encoder traits.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait AsyncArrayPartialEncoderTraits: Any + MaybeSend + MaybeSync {
+pub trait AsyncArrayPartialEncoderTraits:
+    AsyncArrayPartialDecoderTraits + Any + MaybeSend + MaybeSync
+{
+    /// Return the encoder as an [`Arc<AsyncArrayPartialDecoderTraits>`].
+    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits>;
+
     /// Erase the chunk.
     ///
     /// # Errors
@@ -514,7 +522,12 @@ pub trait AsyncArrayPartialEncoderTraits: Any + MaybeSend + MaybeSync {
 }
 
 /// Partial bytes encoder traits.
-pub trait BytesPartialEncoderTraits: Any + MaybeSend + MaybeSync {
+pub trait BytesPartialEncoderTraits:
+    BytesPartialDecoderTraits + Any + MaybeSend + MaybeSync
+{
+    /// Return the encoder as an [`Arc<BytesPartialDecoderTraits>`].
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn BytesPartialDecoderTraits>;
+
     /// Erase the chunk.
     ///
     /// # Errors
@@ -536,7 +549,12 @@ pub trait BytesPartialEncoderTraits: Any + MaybeSend + MaybeSync {
 /// Asynhronous partial bytes encoder traits.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait AsyncBytesPartialEncoderTraits: Any + MaybeSend + MaybeSync {
+pub trait AsyncBytesPartialEncoderTraits:
+    AsyncBytesPartialDecoderTraits + Any + MaybeSend + MaybeSync
+{
+    /// Return the encoder as an [`Arc<AsyncBytesPartialDecoderTraits>`].
+    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncBytesPartialDecoderTraits>;
+
     /// Erase the chunk.
     ///
     /// # Errors
@@ -669,20 +687,38 @@ impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
     }
 }
 
-/// A [`WritableStorage`] store value partial encoder.
-pub struct StoragePartialEncoder {
-    storage: WritableStorage,
-    key: StoreKey,
-}
+impl BytesPartialDecoderTraits for Mutex<Option<Vec<u8>>> {
+    fn size(&self) -> usize {
+        self.lock().unwrap().as_ref().map_or(0, Vec::len)
+    }
 
-impl StoragePartialEncoder {
-    /// Create a new storage partial encoder.
-    pub fn new(storage: WritableStorage, key: StoreKey) -> Self {
-        Self { storage, key }
+    fn partial_decode(
+        &self,
+        decoded_regions: &mut dyn ByteRangeIterator,
+        _options: &CodecOptions,
+    ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
+        if let Some(input) = self.lock().unwrap().as_ref() {
+            let size = input.len() as u64;
+            let mut outputs = vec![];
+            for byte_range in decoded_regions {
+                if byte_range.end(size) <= size {
+                    outputs.push(Cow::Owned(input[byte_range.to_range_usize(size)].to_vec()));
+                } else {
+                    return Err(InvalidByteRangeError::new(byte_range, size).into());
+                }
+            }
+            Ok(Some(outputs))
+        } else {
+            Ok(None)
+        }
     }
 }
 
 impl BytesPartialEncoderTraits for Mutex<Option<Vec<u8>>> {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn BytesPartialDecoderTraits> {
+        self.clone()
+    }
+
     fn erase(&self) -> Result<(), CodecError> {
         *self.lock().unwrap() = None;
         Ok(())
@@ -714,7 +750,46 @@ impl BytesPartialEncoderTraits for Mutex<Option<Vec<u8>>> {
     }
 }
 
+/// A [`ReadableWritableStorage`] store value partial encoder.
+pub struct StoragePartialEncoder {
+    storage: ReadableWritableStorage,
+    key: StoreKey,
+}
+
+impl StoragePartialEncoder {
+    /// Create a new storage partial encoder.
+    pub fn new(storage: ReadableWritableStorage, key: StoreKey) -> Self {
+        Self { storage, key }
+    }
+}
+
+impl BytesPartialDecoderTraits for StoragePartialEncoder {
+    fn size(&self) -> usize {
+        0
+    }
+
+    fn partial_decode(
+        &self,
+        decoded_regions: &mut dyn ByteRangeIterator,
+        _options: &CodecOptions,
+    ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
+        Ok(self
+            .storage
+            .get_partial_values_key(&self.key, decoded_regions)?
+            .map(|vec_bytes| {
+                vec_bytes
+                    .into_iter()
+                    .map(|bytes| Cow::Owned(bytes.to_vec()))
+                    .collect()
+            }))
+    }
+}
+
 impl BytesPartialEncoderTraits for StoragePartialEncoder {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn BytesPartialDecoderTraits> {
+        self.clone()
+    }
+
     fn erase(&self) -> Result<(), CodecError> {
         Ok(self.storage.erase(&self.key)?)
     }
@@ -881,14 +956,12 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     #[allow(unused_variables)]
     fn partial_encoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
-        output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+        input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(ArrayToArrayPartialEncoderDefault::new(
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation.clone(),
             self.into_dyn(),
         )))
@@ -925,14 +998,12 @@ pub trait ArrayToArrayCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     #[allow(unused_variables)]
     fn async_partial_encoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
-        output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
+        input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(AsyncArrayToArrayPartialEncoderDefault::new(
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation.clone(),
             self.into_dyn(),
         )))
@@ -1042,14 +1113,12 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     #[allow(unused_variables)]
     fn partial_encoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(ArrayToBytesPartialEncoderDefault::new(
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation.clone(),
             self.into_dyn(),
         )))
@@ -1086,14 +1155,12 @@ pub trait ArrayToBytesCodecTraits: ArrayCodecTraits + core::fmt::Debug {
     #[allow(unused_variables)]
     async fn async_partial_encoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-        output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(AsyncArrayToBytesPartialEncoderDefault::new(
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation.clone(),
             self.into_dyn(),
         )))
@@ -1175,14 +1242,12 @@ pub trait BytesToBytesCodecTraits: CodecTraits + core::fmt::Debug {
     #[allow(unused_variables)]
     fn partial_encoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         decoded_representation: &BytesRepresentation,
         options: &CodecOptions,
     ) -> Result<Arc<dyn BytesPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(BytesToBytesPartialEncoderDefault::new(
-            input_handle,
-            output_handle,
+            input_output_handle,
             *decoded_representation,
             self.into_dyn(),
         )))
@@ -1219,24 +1284,19 @@ pub trait BytesToBytesCodecTraits: CodecTraits + core::fmt::Debug {
     #[allow(unused_variables)]
     async fn async_partial_encoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-        output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         decoded_representation: &BytesRepresentation,
         options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncBytesPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(AsyncBytesToBytesPartialEncoderDefault::new(
-            input_handle,
-            output_handle,
+            input_output_handle,
             *decoded_representation,
             self.into_dyn(),
         )))
     }
 }
 
-impl<T> BytesPartialDecoderTraits for T
-where
-    T: AsRef<[u8]> + MaybeSend + MaybeSync + 'static,
-{
+impl BytesPartialDecoderTraits for Cow<'static, [u8]> {
     fn size(&self) -> usize {
         self.as_ref().len()
     }
@@ -1247,7 +1307,26 @@ where
         _parallel: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(Some(
-            extract_byte_ranges_read_seek(std::io::Cursor::new(self), decoded_regions)?
+            extract_byte_ranges(self, decoded_regions)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
+        ))
+    }
+}
+
+impl BytesPartialDecoderTraits for Vec<u8> {
+    fn size(&self) -> usize {
+        self.len()
+    }
+
+    fn partial_decode(
+        &self,
+        decoded_regions: &mut dyn ByteRangeIterator,
+        _parallel: &CodecOptions,
+    ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
+        Ok(Some(
+            extract_byte_ranges(self, decoded_regions)?
                 .into_iter()
                 .map(Cow::Owned)
                 .collect(),
@@ -1258,17 +1337,32 @@ where
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<T> AsyncBytesPartialDecoderTraits for T
-where
-    T: AsRef<[u8]> + MaybeSend + MaybeSync + 'static,
-{
+impl AsyncBytesPartialDecoderTraits for Cow<'static, [u8]> {
     async fn partial_decode(
         &self,
         decoded_regions: &mut dyn ByteRangeIterator,
         _parallel: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(Some(
-            extract_byte_ranges_read_seek(std::io::Cursor::new(self), decoded_regions)?
+            extract_byte_ranges(self, decoded_regions)?
+                .into_iter()
+                .map(Cow::Owned)
+                .collect(),
+        ))
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl AsyncBytesPartialDecoderTraits for Vec<u8> {
+    async fn partial_decode(
+        &self,
+        decoded_regions: &mut dyn ByteRangeIterator,
+        _parallel: &CodecOptions,
+    ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
+        Ok(Some(
+            extract_byte_ranges(self, decoded_regions)?
                 .into_iter()
                 .map(Cow::Owned)
                 .collect(),

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec.rs
@@ -151,12 +151,16 @@ impl ArrayToArrayCodecTraits for SqueezeCodec {
 
     fn partial_encoder(
         self: Arc<Self>,
-        _input_handle: Arc<dyn ArrayPartialDecoderTraits>,
-        _output_handle: Arc<dyn ArrayPartialEncoderTraits>,
-        _decoded_representation: &ChunkRepresentation,
+        input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+        decoded_representation: &ChunkRepresentation,
         _options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
-        todo!("the squeeze codec does not yet support partial encoding")
+        Ok(Arc::new(
+            super::squeeze_partial_encoder::SqueezePartialEncoder::new(
+                input_output_handle,
+                decoded_representation.clone(),
+            ),
+        ))
     }
 
     #[cfg(feature = "async")]

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_partial_encoder.rs
@@ -1,0 +1,145 @@
+use std::{num::NonZeroU64, sync::Arc};
+
+use itertools::{izip, Itertools};
+
+use crate::{
+    array::{
+        codec::{
+            ArrayBytes, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, ArraySubset,
+            CodecError, CodecOptions,
+        },
+        ArrayIndices, ChunkRepresentation, DataType,
+    },
+    indexer::{IncompatibleIndexerError, Indexer},
+};
+
+// #[cfg(feature = "async")]
+// use crate::array::codec::AsyncArrayPartialEncoderTraits;
+
+/// Partial encoder for the `squeeze` codec.
+pub(crate) struct SqueezePartialEncoder {
+    input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+    decoded_representation: ChunkRepresentation,
+}
+
+impl SqueezePartialEncoder {
+    /// Create a new partial encoder for the `squeeze` codec.
+    pub(crate) fn new(
+        input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+        decoded_representation: ChunkRepresentation,
+    ) -> Self {
+        Self {
+            input_output_handle,
+            decoded_representation,
+        }
+    }
+}
+
+fn get_squeezed_array_subset(
+    decoded_region: &ArraySubset,
+    shape: &[NonZeroU64],
+) -> Result<ArraySubset, CodecError> {
+    if decoded_region.dimensionality() != shape.len() {
+        return Err(IncompatibleIndexerError::new_incompatible_dimensionality(
+            decoded_region.dimensionality(),
+            shape.len(),
+        )
+        .into());
+    }
+
+    let ranges = izip!(
+        decoded_region.start().iter(),
+        decoded_region.shape().iter(),
+        shape.iter()
+    )
+    .filter(|(_, _, &shape)| shape.get() > 1)
+    .map(|(rstart, rshape, _)| *rstart..rstart + rshape);
+
+    let decoded_region_squeeze = ArraySubset::from(ranges);
+    Ok(decoded_region_squeeze)
+}
+
+fn get_squeezed_indexer(
+    indexer: &dyn Indexer,
+    shape: &[NonZeroU64],
+) -> Result<impl Indexer, CodecError> {
+    let indices = indexer
+        .iter_indices()
+        .map(|indices| {
+            if indices.len() == shape.len() {
+                Ok(indices
+                    .into_iter()
+                    .zip(shape)
+                    .filter_map(
+                        |(indices, &shape)| if shape.get() > 1 { Some(indices) } else { None },
+                    )
+                    .collect_vec())
+            } else {
+                Err(IncompatibleIndexerError::new_incompatible_dimensionality(
+                    indices.len(),
+                    shape.len(),
+                ))
+            }
+        })
+        .collect::<Result<Vec<ArrayIndices>, _>>()?;
+
+    Ok(indices)
+}
+
+// FIXME: Repeated from SqueezePartialDecoder
+impl ArrayPartialDecoderTraits for SqueezePartialEncoder {
+    fn data_type(&self) -> &DataType {
+        self.decoded_representation.data_type()
+    }
+
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
+    fn partial_decode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        options: &CodecOptions,
+    ) -> Result<ArrayBytes<'_>, CodecError> {
+        if let Some(array_subset) = indexer.as_array_subset() {
+            let array_subset_squeezed =
+                get_squeezed_array_subset(array_subset, self.decoded_representation.shape())?;
+            self.input_output_handle
+                .partial_decode(&array_subset_squeezed, options)
+        } else {
+            let indexer_squeezed =
+                get_squeezed_indexer(indexer, self.decoded_representation.shape())?;
+            self.input_output_handle
+                .partial_decode(&indexer_squeezed, options)
+        }
+    }
+}
+
+impl ArrayPartialEncoderTraits for SqueezePartialEncoder {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn ArrayPartialDecoderTraits> {
+        self.clone()
+    }
+
+    fn erase(&self) -> Result<(), CodecError> {
+        self.input_output_handle.erase()
+    }
+
+    fn partial_encode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        bytes: &ArrayBytes<'_>,
+        options: &CodecOptions,
+    ) -> Result<(), CodecError> {
+        if let Some(array_subset) = indexer.as_array_subset() {
+            let array_subset_squeezed =
+                get_squeezed_array_subset(array_subset, self.decoded_representation.shape())?;
+            self.input_output_handle
+                .partial_encode(&array_subset_squeezed, bytes, options)
+        } else {
+            let indexer_squeezed =
+                get_squeezed_indexer(indexer, self.decoded_representation.shape())?;
+            self.input_output_handle
+                .partial_encode(&indexer_squeezed, bytes, options)
+        }
+    }
+}

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_decoder.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use super::{calculate_order_decode, permute, transpose_array, TransposeOrder};
-use crate::{
-    array::{
-        codec::{ArrayBytes, ArrayPartialDecoderTraits, ArraySubset, CodecError, CodecOptions},
-        ChunkRepresentation, DataType,
-    },
-    indexer::{IncompatibleIndexerError, Indexer},
+use super::{do_transpose, get_transposed_array_subset, get_transposed_indexer, TransposeOrder};
+use crate::array::{
+    codec::{ArrayBytes, ArrayPartialDecoderTraits, CodecError, CodecOptions},
+    ChunkRepresentation, DataType,
 };
 
 #[cfg(feature = "async")]
@@ -34,75 +31,6 @@ impl TransposePartialDecoder {
     }
 }
 
-fn validate_regions(
-    indexer: &dyn crate::indexer::Indexer,
-    dimensionality: usize,
-) -> Result<(), CodecError> {
-    if indexer.dimensionality() == dimensionality {
-        Ok(())
-    } else {
-        Err(IncompatibleIndexerError::new_incompatible_dimensionality(
-            indexer.dimensionality(),
-            dimensionality,
-        )
-        .into())
-    }
-}
-
-fn get_transposed_array_subset(
-    order: &TransposeOrder,
-    decoded_region: &ArraySubset,
-) -> ArraySubset {
-    let start = permute(decoded_region.start(), &order.0);
-    let size = permute(decoded_region.shape(), &order.0);
-    let ranges = start.iter().zip(size).map(|(&st, si)| st..(st + si));
-    ArraySubset::from(ranges)
-}
-
-fn get_transposed_indexer(order: &TransposeOrder, indexer: &dyn Indexer) -> impl Indexer {
-    indexer
-        .iter_indices()
-        .map(|indices| permute(&indices, &order.0))
-        .collect::<Vec<_>>()
-}
-
-/// Reverse the transpose on each subset
-fn do_transpose<'a>(
-    encoded_value: ArrayBytes<'a>,
-    subset: &ArraySubset,
-    order: &TransposeOrder,
-    decoded_representation: &ChunkRepresentation,
-) -> Result<ArrayBytes<'a>, CodecError> {
-    let order_decode = calculate_order_decode(order, decoded_representation.shape().len());
-    let data_type_size = decoded_representation.data_type().size();
-    encoded_value.validate(subset.num_elements(), data_type_size)?;
-    match encoded_value {
-        ArrayBytes::Variable(bytes, offsets) => {
-            let mut order_decode = vec![0; decoded_representation.shape().len()];
-            for (i, val) in order.0.iter().enumerate() {
-                order_decode[*val] = i;
-            }
-            Ok(super::transpose_vlen(
-                &bytes,
-                &offsets,
-                &subset.shape_usize(),
-                order_decode,
-            ))
-        }
-        ArrayBytes::Fixed(bytes) => {
-            let data_type_size = decoded_representation.data_type().fixed_size().unwrap();
-            let bytes = transpose_array(
-                &order_decode,
-                &permute(subset.shape(), &order.0),
-                data_type_size,
-                &bytes,
-            )
-            .map_err(|_| CodecError::Other("transpose_array error".to_string()))?;
-            Ok(ArrayBytes::from(bytes))
-        }
-    }
-}
-
 impl ArrayPartialDecoderTraits for TransposePartialDecoder {
     fn data_type(&self) -> &DataType {
         self.decoded_representation.data_type()
@@ -117,10 +45,8 @@ impl ArrayPartialDecoderTraits for TransposePartialDecoder {
         indexer: &dyn crate::indexer::Indexer,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'_>, CodecError> {
-        validate_regions(indexer, self.decoded_representation.dimensionality())?;
-
         if let Some(array_subset) = indexer.as_array_subset() {
-            let array_subset_transposed = get_transposed_array_subset(&self.order, array_subset);
+            let array_subset_transposed = get_transposed_array_subset(&self.order, array_subset)?;
             let encoded_value = self
                 .input_handle
                 .partial_decode(&array_subset_transposed, options)?;
@@ -131,7 +57,7 @@ impl ArrayPartialDecoderTraits for TransposePartialDecoder {
                 &self.decoded_representation,
             )
         } else {
-            let indexer_transposed = get_transposed_indexer(&self.order, indexer);
+            let indexer_transposed = get_transposed_indexer(&self.order, indexer)?;
             self.input_handle
                 .partial_decode(&indexer_transposed, options)
         }
@@ -175,10 +101,8 @@ impl AsyncArrayPartialDecoderTraits for AsyncTransposePartialDecoder {
         indexer: &dyn crate::indexer::Indexer,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'_>, CodecError> {
-        validate_regions(indexer, self.decoded_representation.dimensionality())?;
-
         if let Some(array_subset) = indexer.as_array_subset() {
-            let array_subset_transposed = get_transposed_array_subset(&self.order, array_subset);
+            let array_subset_transposed = get_transposed_array_subset(&self.order, array_subset)?;
             let encoded_value = self
                 .input_handle
                 .partial_decode(&array_subset_transposed, options)
@@ -190,7 +114,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncTransposePartialDecoder {
                 &self.decoded_representation,
             )
         } else {
-            let indexer_transposed = get_transposed_indexer(&self.order, indexer);
+            let indexer_transposed = get_transposed_indexer(&self.order, indexer)?;
             self.input_handle
                 .partial_decode(&indexer_transposed, options)
                 .await

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_partial_encoder.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+
+use super::{do_transpose, get_transposed_array_subset, get_transposed_indexer, TransposeOrder};
+
+use crate::array::{
+    codec::{CodecError, CodecOptions},
+    ArrayBytes, ChunkRepresentation, DataType,
+};
+
+use crate::array::codec::{ArrayPartialDecoderTraits, ArrayPartialEncoderTraits};
+
+/// The `transpose` partial encoder.
+pub(crate) struct TransposePartialEncoder {
+    input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+    decoded_representation: ChunkRepresentation,
+    order: TransposeOrder,
+}
+
+impl TransposePartialEncoder {
+    /// Create a new [`TransposePartialEncoder`].
+    #[must_use]
+    pub(crate) fn new(
+        input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+        decoded_representation: ChunkRepresentation,
+        order: TransposeOrder,
+    ) -> Self {
+        Self {
+            input_output_handle,
+            decoded_representation,
+            order,
+        }
+    }
+}
+
+impl ArrayPartialDecoderTraits for TransposePartialEncoder {
+    fn data_type(&self) -> &DataType {
+        self.decoded_representation.data_type()
+    }
+
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
+    fn partial_decode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        options: &CodecOptions,
+    ) -> Result<ArrayBytes<'_>, CodecError> {
+        if let Some(array_subset) = indexer.as_array_subset() {
+            let array_subset_transposed = get_transposed_array_subset(&self.order, array_subset)?;
+            let encoded_value = self
+                .input_output_handle
+                .partial_decode(&array_subset_transposed, options)?;
+            do_transpose(
+                encoded_value,
+                array_subset,
+                &self.order,
+                &self.decoded_representation,
+            )
+        } else {
+            let indexer_transposed = get_transposed_indexer(&self.order, indexer)?;
+            self.input_output_handle
+                .partial_decode(&indexer_transposed, options)
+        }
+    }
+}
+
+impl ArrayPartialEncoderTraits for TransposePartialEncoder {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn ArrayPartialDecoderTraits> {
+        self.clone()
+    }
+
+    fn erase(&self) -> Result<(), CodecError> {
+        self.input_output_handle.erase()
+    }
+
+    fn partial_encode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        bytes: &ArrayBytes<'_>,
+        options: &CodecOptions,
+    ) -> Result<(), CodecError> {
+        if let Some(array_subset) = indexer.as_array_subset() {
+            let array_subset_transposed = get_transposed_array_subset(&self.order, array_subset)?;
+            self.input_output_handle
+                .partial_encode(&array_subset_transposed, bytes, options)
+        } else {
+            let indexer_transposed = get_transposed_indexer(&self.order, indexer)?;
+            self.input_output_handle
+                .partial_encode(&indexer_transposed, bytes, options)
+        }
+    }
+}

--- a/zarrs/src/array/codec/array_to_array_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/array_to_array_partial_decoder_default.rs
@@ -11,14 +11,14 @@ use crate::array::codec::AsyncArrayPartialDecoderTraits;
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_handle: &Arc<dyn AsyncArrayPartialDecoderTraits>,
+    input_handle: &dyn AsyncArrayPartialDecoderTraits,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToArrayCodecTraits>,
     indexer: &dyn crate::indexer::Indexer,
     options: &CodecOptions,
 )))]
-fn partial_decode<'a>(
-    input_handle: &Arc<dyn ArrayPartialDecoderTraits>,
+pub(crate) fn partial_decode<'a>(
+    input_handle: &dyn ArrayPartialDecoderTraits,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToArrayCodecTraits>,
     indexer: &dyn crate::indexer::Indexer,
@@ -103,7 +103,7 @@ impl ArrayPartialDecoderTraits for ArrayToArrayPartialDecoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         partial_decode(
-            &self.input_handle,
+            self.input_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -152,7 +152,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncArrayToArrayPartialDecoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         partial_decode_async(
-            &self.input_handle,
+            self.input_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             indexer,

--- a/zarrs/src/array/codec/array_to_array_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/array_to_array_partial_decoder_default.rs
@@ -11,14 +11,14 @@ use crate::array::codec::AsyncArrayPartialDecoderTraits;
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_handle: &dyn AsyncArrayPartialDecoderTraits,
+    input_handle: &Arc<dyn AsyncArrayPartialDecoderTraits>,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToArrayCodecTraits>,
     indexer: &dyn crate::indexer::Indexer,
     options: &CodecOptions,
 )))]
 pub(crate) fn partial_decode<'a>(
-    input_handle: &dyn ArrayPartialDecoderTraits,
+    input_handle: &Arc<dyn ArrayPartialDecoderTraits>,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToArrayCodecTraits>,
     indexer: &dyn crate::indexer::Indexer,
@@ -103,7 +103,7 @@ impl ArrayPartialDecoderTraits for ArrayToArrayPartialDecoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         partial_decode(
-            self.input_handle.as_ref(),
+            &self.input_handle,
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -152,7 +152,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncArrayToArrayPartialDecoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         partial_decode_async(
-            self.input_handle.as_ref(),
+            &self.input_handle,
             &self.decoded_representation,
             &self.codec,
             indexer,

--- a/zarrs/src/array/codec/array_to_array_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/array_to_array_partial_encoder_default.rs
@@ -12,7 +12,7 @@ use crate::array::codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncod
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-        input_output_handle: &dyn AsyncArrayPartialEncoderTraits,
+        input_output_handle: &Arc<dyn AsyncArrayPartialEncoderTraits>,
         decoded_representation: &ChunkRepresentation,
         codec: &Arc<dyn ArrayToArrayCodecTraits>,
         chunk_subset_indexer: &dyn crate::indexer::Indexer,
@@ -20,7 +20,7 @@ use crate::array::codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncod
         options: &super::CodecOptions,
 )))]
 pub(crate) fn partial_encode_default(
-    input_output_handle: &dyn ArrayPartialEncoderTraits,
+    input_output_handle: &Arc<dyn ArrayPartialEncoderTraits>,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToArrayCodecTraits>,
     chunk_subset_indexer: &dyn crate::indexer::Indexer,
@@ -129,7 +129,7 @@ impl ArrayPartialDecoderTraits for ArrayToArrayPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         super::array_to_array_partial_decoder_default::partial_decode(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle.clone().into_dyn_decoder(),
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -154,7 +154,7 @@ impl ArrayPartialEncoderTraits for ArrayToArrayPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode_default(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle,
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -203,7 +203,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncArrayToArrayPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         super::array_to_array_partial_decoder_default::partial_decode_async(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle.clone().into_dyn_decoder(),
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -217,7 +217,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncArrayToArrayPartialEncoderDefault {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialEncoderTraits for AsyncArrayToArrayPartialEncoderDefault {
-    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits> {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits> {
         self.clone()
     }
 
@@ -232,7 +232,7 @@ impl AsyncArrayPartialEncoderTraits for AsyncArrayToArrayPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode_default_async(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle,
             &self.decoded_representation,
             &self.codec,
             indexer,

--- a/zarrs/src/array/codec/array_to_array_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/array_to_array_partial_encoder_default.rs
@@ -12,17 +12,15 @@ use crate::array::codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncod
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-        input_handle: &Arc<dyn AsyncArrayPartialDecoderTraits>,
-        output_handle: &Arc<dyn AsyncArrayPartialEncoderTraits>,
+        input_output_handle: &dyn AsyncArrayPartialEncoderTraits,
         decoded_representation: &ChunkRepresentation,
         codec: &Arc<dyn ArrayToArrayCodecTraits>,
         chunk_subset_indexer: &dyn crate::indexer::Indexer,
         chunk_subset_bytes: &ArrayBytes<'_>,
         options: &super::CodecOptions,
 )))]
-fn partial_encode(
-    input_handle: &Arc<dyn ArrayPartialDecoderTraits>,
-    output_handle: &Arc<dyn ArrayPartialEncoderTraits>,
+pub(crate) fn partial_encode_default(
+    input_output_handle: &dyn ArrayPartialEncoderTraits,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToArrayCodecTraits>,
     chunk_subset_indexer: &dyn crate::indexer::Indexer,
@@ -34,14 +32,14 @@ fn partial_encode(
     let array_subset_all = ArraySubset::new_with_shape(chunk_shape.clone());
     #[cfg(feature = "async")]
     let encoded_value = if _async {
-        input_handle
+        input_output_handle
             .partial_decode(&array_subset_all, options)
             .await
     } else {
-        input_handle.partial_decode(&array_subset_all, options)
+        input_output_handle.partial_decode(&array_subset_all, options)
     }?;
     #[cfg(not(feature = "async"))]
-    let encoded_value = input_handle.partial_decode(&array_subset_all, options)?;
+    let encoded_value = input_output_handle.partial_decode(&array_subset_all, options)?;
     let mut decoded_value = codec.decode(encoded_value, decoded_representation, options)?;
 
     // Validate the bytes
@@ -66,12 +64,12 @@ fn partial_encode(
     // Erase existing data
     #[cfg(feature = "async")]
     if _async {
-        output_handle.erase().await?;
+        input_output_handle.erase().await?;
     } else {
-        output_handle.erase()?;
+        input_output_handle.erase()?;
     }
     #[cfg(not(feature = "async"))]
-    output_handle.erase()?;
+    input_output_handle.erase()?;
 
     let is_fill_value = !options.store_empty_chunks()
         && decoded_value.is_fill_value(decoded_representation.fill_value());
@@ -82,21 +80,20 @@ fn partial_encode(
         let encoded_value = codec.encode(decoded_value, decoded_representation, options)?;
         #[cfg(feature = "async")]
         if _async {
-            output_handle
+            input_output_handle
                 .partial_encode(&array_subset_all, &encoded_value, options)
                 .await
         } else {
-            output_handle.partial_encode(&array_subset_all, &encoded_value, options)
+            input_output_handle.partial_encode(&array_subset_all, &encoded_value, options)
         }
         #[cfg(not(feature = "async"))]
-        output_handle.partial_encode(&array_subset_all, &encoded_value, options)
+        input_output_handle.partial_encode(&array_subset_all, &encoded_value, options)
     }
 }
 
 /// The default array-to-array partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
 pub struct ArrayToArrayPartialEncoderDefault {
-    input_handle: Arc<dyn ArrayPartialDecoderTraits>,
-    output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+    input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
     decoded_representation: ChunkRepresentation,
     codec: Arc<dyn ArrayToArrayCodecTraits>,
 }
@@ -105,23 +102,49 @@ impl ArrayToArrayPartialEncoderDefault {
     /// Create a new [`ArrayToArrayPartialEncoderDefault`].
     #[must_use]
     pub fn new(
-        input_handle: Arc<dyn ArrayPartialDecoderTraits>,
-        output_handle: Arc<dyn ArrayPartialEncoderTraits>,
+        input_output_handle: Arc<dyn ArrayPartialEncoderTraits>,
         decoded_representation: ChunkRepresentation,
         codec: Arc<dyn ArrayToArrayCodecTraits>,
     ) -> Self {
         Self {
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation,
             codec,
         }
     }
 }
 
+impl ArrayPartialDecoderTraits for ArrayToArrayPartialEncoderDefault {
+    fn data_type(&self) -> &super::DataType {
+        self.decoded_representation.data_type()
+    }
+
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
+    fn partial_decode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        options: &super::CodecOptions,
+    ) -> Result<ArrayBytes<'_>, super::CodecError> {
+        super::array_to_array_partial_decoder_default::partial_decode(
+            self.input_output_handle.as_ref(),
+            &self.decoded_representation,
+            &self.codec,
+            indexer,
+            options,
+        )
+    }
+}
+
 impl ArrayPartialEncoderTraits for ArrayToArrayPartialEncoderDefault {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn ArrayPartialDecoderTraits> {
+        self.clone()
+    }
+
     fn erase(&self) -> Result<(), super::CodecError> {
-        self.output_handle.erase()
+        self.input_output_handle.erase()
     }
 
     fn partial_encode(
@@ -130,9 +153,8 @@ impl ArrayPartialEncoderTraits for ArrayToArrayPartialEncoderDefault {
         bytes: &ArrayBytes<'_>,
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
-        partial_encode(
-            &self.input_handle,
-            &self.output_handle,
+        partial_encode_default(
+            self.input_output_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -145,8 +167,7 @@ impl ArrayPartialEncoderTraits for ArrayToArrayPartialEncoderDefault {
 #[cfg(feature = "async")]
 /// The default asynchronous array-to-array partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
 pub struct AsyncArrayToArrayPartialEncoderDefault {
-    input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
-    output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
+    input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
     decoded_representation: ChunkRepresentation,
     codec: Arc<dyn ArrayToArrayCodecTraits>,
 }
@@ -156,14 +177,12 @@ impl AsyncArrayToArrayPartialEncoderDefault {
     /// Create a new [`AsyncArrayToArrayPartialEncoderDefault`].
     #[must_use]
     pub fn new(
-        input_handle: Arc<dyn AsyncArrayPartialDecoderTraits>,
-        output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
+        input_output_handle: Arc<dyn AsyncArrayPartialEncoderTraits>,
         decoded_representation: ChunkRepresentation,
         codec: Arc<dyn ArrayToArrayCodecTraits>,
     ) -> Self {
         Self {
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation,
             codec,
         }
@@ -173,9 +192,37 @@ impl AsyncArrayToArrayPartialEncoderDefault {
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl AsyncArrayPartialDecoderTraits for AsyncArrayToArrayPartialEncoderDefault {
+    fn data_type(&self) -> &super::DataType {
+        self.decoded_representation.data_type()
+    }
+
+    async fn partial_decode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        options: &super::CodecOptions,
+    ) -> Result<ArrayBytes<'_>, super::CodecError> {
+        super::array_to_array_partial_decoder_default::partial_decode_async(
+            self.input_output_handle.as_ref(),
+            &self.decoded_representation,
+            &self.codec,
+            indexer,
+            options,
+        )
+        .await
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialEncoderTraits for AsyncArrayToArrayPartialEncoderDefault {
+    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits> {
+        self.clone()
+    }
+
     async fn erase(&self) -> Result<(), super::CodecError> {
-        self.output_handle.erase().await
+        self.input_output_handle.erase().await
     }
 
     async fn partial_encode(
@@ -184,9 +231,8 @@ impl AsyncArrayPartialEncoderTraits for AsyncArrayToArrayPartialEncoderDefault {
         bytes: &ArrayBytes<'_>,
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
-        partial_encode_async(
-            &self.input_handle,
-            &self.output_handle,
+        partial_encode_default_async(
+            self.input_output_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             indexer,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -467,15 +467,13 @@ impl ArrayToBytesCodecTraits for ShardingCodec {
 
     fn partial_encoder(
         self: Arc<Self>,
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         decoded_representation: &ChunkRepresentation,
         options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
         Ok(Arc::new(
             sharding_partial_encoder::ShardingPartialEncoder::new(
-                input_handle,
-                output_handle,
+                input_output_handle,
                 decoded_representation.clone(),
                 self.chunk_shape.clone(),
                 self.inner_codecs.clone(),

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -64,7 +64,7 @@ impl ShardingPartialEncoder {
 
         // Decode the index
         let shard_index = super::decode_shard_index_partial_decoder(
-            &*input_output_handle,
+            input_output_handle.clone().into_dyn_decoder().as_ref(),
             &index_codecs,
             index_location,
             inner_chunk_representation.shape(),

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -15,11 +15,11 @@ use crate::{
         chunk_grid::RegularChunkGrid,
         codec::{
             array_to_bytes::sharding::{calculate_chunks_per_shard, compute_index_encoded_size},
-            ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+            ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, ArrayToBytesCodecTraits,
             BytesPartialEncoderTraits, CodecError, CodecOptions,
         },
         ravel_indices, transmute_to_bytes, ArrayBytes, ArraySize, ChunkRepresentation, ChunkShape,
-        CodecChain, RawBytes,
+        CodecChain, DataType, RawBytes,
     },
     indexer::IncompatibleIndexerError,
     storage::byte_range::ByteRange,
@@ -28,8 +28,7 @@ use crate::{
 use super::{sharding_index_decoded_representation, ShardingIndexLocation};
 
 pub(crate) struct ShardingPartialEncoder {
-    input_handle: Arc<dyn BytesPartialDecoderTraits>,
-    output_handle: Arc<dyn BytesPartialEncoderTraits>,
+    input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
     decoded_representation: ChunkRepresentation,
     chunk_grid: RegularChunkGrid,
     inner_codecs: Arc<CodecChain>,
@@ -44,8 +43,7 @@ impl ShardingPartialEncoder {
     /// Create a new partial encoder for the sharding codec.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         decoded_representation: ChunkRepresentation,
         chunk_shape: ChunkShape,
         inner_codecs: Arc<CodecChain>,
@@ -66,7 +64,7 @@ impl ShardingPartialEncoder {
 
         // Decode the index
         let shard_index = super::decode_shard_index_partial_decoder(
-            &*input_handle,
+            &*input_output_handle,
             &index_codecs,
             index_location,
             inner_chunk_representation.shape(),
@@ -81,8 +79,7 @@ impl ShardingPartialEncoder {
 
         let shard_shape = decoded_representation.shape_u64();
         Ok(Self {
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation,
             chunk_grid: RegularChunkGrid::new(shard_shape, chunk_shape)
                 .map_err(|err| CodecError::from(err.to_string()))?,
@@ -96,9 +93,39 @@ impl ShardingPartialEncoder {
     }
 }
 
+impl ArrayPartialDecoderTraits for ShardingPartialEncoder {
+    fn data_type(&self) -> &DataType {
+        self.decoded_representation.data_type()
+    }
+
+    fn size(&self) -> usize {
+        self.shard_index.lock().unwrap().len()
+    }
+
+    fn partial_decode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        options: &CodecOptions,
+    ) -> Result<ArrayBytes<'_>, CodecError> {
+        super::sharding_partial_decoder_sync::partial_decode(
+            &self.input_output_handle.clone().into_dyn_decoder(),
+            &self.decoded_representation,
+            &self.inner_chunk_representation,
+            &self.inner_codecs,
+            Some(self.shard_index.lock().unwrap().as_slice()),
+            indexer,
+            options,
+        )
+    }
+}
+
 impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn ArrayPartialDecoderTraits> {
+        self.clone()
+    }
+
     fn erase(&self) -> Result<(), super::CodecError> {
-        self.output_handle.erase()
+        self.input_output_handle.erase()
     }
 
     #[allow(clippy::too_many_lines)]
@@ -226,7 +253,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
 
         // Read the straddling inner chunks
         let inner_chunks_encoded = self
-            .input_handle
+            .input_output_handle
             .partial_decode(&mut byte_ranges.into_iter(), options)?
             .map(|bytes| bytes.into_iter().map(Cow::into_owned).collect::<Vec<_>>());
 
@@ -337,7 +364,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
             shard_index[usize::try_from(inner_chunk_index * 2 + 1).unwrap()] = u64::MAX;
         }
         let max_data_offset = if shard_index.par_iter().all(|&x| x == u64::MAX) {
-            self.output_handle.erase()?;
+            self.input_output_handle.erase()?;
             0
         } else {
             max_data_offset
@@ -371,7 +398,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
 
         if shard_index.par_iter().all(|&x| x == u64::MAX) {
             // Erase the shard if all chunks are empty
-            self.output_handle.erase()?;
+            self.input_output_handle.erase()?;
         } else {
             // Encode the updated shard index
             let shard_index_bytes: RawBytes = transmute_to_bytes(shard_index.as_slice()).into();
@@ -407,7 +434,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
             // Write the encoded index and updated inner chunks
             match self.index_location {
                 ShardingIndexLocation::Start => {
-                    self.output_handle.partial_encode(
+                    self.input_output_handle.partial_encode(
                         &[
                             (0, Cow::Owned(encoded_array_index)),
                             (offset_new_chunks, Cow::Owned(encoded_output)),
@@ -417,7 +444,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
                 }
                 ShardingIndexLocation::End => {
                     encoded_output.extend(encoded_array_index);
-                    self.output_handle.partial_encode(
+                    self.input_output_handle.partial_encode(
                         &[(offset_new_chunks, Cow::Owned(encoded_output))],
                         options,
                     )?;

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_macros.rs
@@ -150,14 +150,12 @@ macro_rules! vlen_v2_codec {
 
             fn partial_encoder(
                 self: Arc<Self>,
-                input_handle: Arc<dyn BytesPartialDecoderTraits>,
-                output_handle: Arc<dyn BytesPartialEncoderTraits>,
+                input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
                 decoded_representation: &ChunkRepresentation,
                 options: &CodecOptions,
             ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, CodecError> {
                 self.inner.clone().partial_encoder(
-                    input_handle,
-                    output_handle,
+                    input_output_handle,
                     decoded_representation,
                     options,
                 )

--- a/zarrs/src/array/codec/array_to_bytes_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/array_to_bytes_partial_decoder_default.rs
@@ -12,14 +12,14 @@ use crate::array::codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecod
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_handle: &dyn AsyncBytesPartialDecoderTraits,
+    input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToBytesCodecTraits>,
     indexer: &dyn crate::indexer::Indexer,
     options: &CodecOptions,
 )))]
 pub(crate) fn partial_decode<'a>(
-    input_handle: &dyn BytesPartialDecoderTraits,
+    input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToBytesCodecTraits>,
     indexer: &dyn crate::indexer::Indexer,
@@ -91,7 +91,7 @@ impl ArrayPartialDecoderTraits for ArrayToBytesPartialDecoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         partial_decode(
-            self.input_handle.as_ref(),
+            &self.input_handle,
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -139,7 +139,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncArrayToBytesPartialDecoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         partial_decode_async(
-            self.input_handle.as_ref(),
+            &self.input_handle,
             &self.decoded_representation,
             &self.codec,
             indexer,

--- a/zarrs/src/array/codec/array_to_bytes_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/array_to_bytes_partial_decoder_default.rs
@@ -12,14 +12,14 @@ use crate::array::codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecod
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
+    input_handle: &dyn AsyncBytesPartialDecoderTraits,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToBytesCodecTraits>,
     indexer: &dyn crate::indexer::Indexer,
     options: &CodecOptions,
 )))]
-fn partial_decode<'a>(
-    input_handle: &Arc<dyn BytesPartialDecoderTraits>,
+pub(crate) fn partial_decode<'a>(
+    input_handle: &dyn BytesPartialDecoderTraits,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToBytesCodecTraits>,
     indexer: &dyn crate::indexer::Indexer,
@@ -91,7 +91,7 @@ impl ArrayPartialDecoderTraits for ArrayToBytesPartialDecoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         partial_decode(
-            &self.input_handle,
+            self.input_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -139,7 +139,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncArrayToBytesPartialDecoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         partial_decode_async(
-            &self.input_handle,
+            self.input_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             indexer,

--- a/zarrs/src/array/codec/array_to_bytes_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/array_to_bytes_partial_encoder_default.rs
@@ -1,21 +1,20 @@
 use std::sync::Arc;
 
-use crate::array::{array_bytes::update_array_bytes, ArrayBytes, ArraySize, ChunkRepresentation};
-
-use super::{
-    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
-    BytesPartialEncoderTraits,
+use crate::array::{
+    array_bytes::update_array_bytes, codec::ArrayPartialDecoderTraits, ArrayBytes, ArraySize,
+    ChunkRepresentation,
 };
+
+use super::{ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialEncoderTraits};
 
 #[cfg(feature = "async")]
 use crate::array::codec::{
-    AsyncArrayPartialEncoderTraits, AsyncBytesPartialDecoderTraits, AsyncBytesPartialEncoderTraits,
+    AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits, AsyncBytesPartialEncoderTraits,
 };
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
-    output_handle: &Arc<dyn AsyncBytesPartialEncoderTraits>,
+    input_output_handle: &dyn AsyncBytesPartialEncoderTraits,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToBytesCodecTraits>,
     chunk_subset_indexer: &dyn crate::indexer::Indexer,
@@ -23,8 +22,7 @@ use crate::array::codec::{
     options: &super::CodecOptions,
 )))]
 fn partial_encode(
-    input_handle: &Arc<dyn BytesPartialDecoderTraits>,
-    output_handle: &Arc<dyn BytesPartialEncoderTraits>,
+    input_output_handle: &dyn BytesPartialEncoderTraits,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToBytesCodecTraits>,
     chunk_subset_indexer: &dyn crate::indexer::Indexer,
@@ -35,12 +33,12 @@ fn partial_encode(
     let chunk_shape = decoded_representation.shape_u64();
     #[cfg(feature = "async")]
     let chunk_bytes = if _async {
-        input_handle.decode(options).await
+        input_output_handle.decode(options).await
     } else {
-        input_handle.decode(options)
+        input_output_handle.decode(options)
     }?;
     #[cfg(not(feature = "async"))]
-    let chunk_bytes = input_handle.decode(options)?;
+    let chunk_bytes = input_output_handle.decode(options)?;
 
     // Handle a missing chunk
     let mut chunk_bytes = if let Some(chunk_bytes) = chunk_bytes {
@@ -76,12 +74,12 @@ fn partial_encode(
     // Erase existing data
     #[cfg(feature = "async")]
     if _async {
-        output_handle.erase().await?;
+        input_output_handle.erase().await?;
     } else {
-        output_handle.erase()?;
+        input_output_handle.erase()?;
     }
     #[cfg(not(feature = "async"))]
-    output_handle.erase()?;
+    input_output_handle.erase()?;
 
     let is_fill_value = !options.store_empty_chunks()
         && chunk_bytes.is_fill_value(decoded_representation.fill_value());
@@ -92,21 +90,20 @@ fn partial_encode(
         let chunk_bytes = codec.encode(chunk_bytes, decoded_representation, options)?;
         #[cfg(feature = "async")]
         if _async {
-            output_handle
+            input_output_handle
                 .partial_encode(&[(0, chunk_bytes)], options)
                 .await
         } else {
-            output_handle.partial_encode(&[(0, chunk_bytes)], options)
+            input_output_handle.partial_encode(&[(0, chunk_bytes)], options)
         }
         #[cfg(not(feature = "async"))]
-        output_handle.partial_encode(&[(0, chunk_bytes)], options)
+        input_output_handle.partial_encode(&[(0, chunk_bytes)], options)
     }
 }
 
 /// The default array-to-bytes partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
 pub struct ArrayToBytesPartialEncoderDefault {
-    input_handle: Arc<dyn BytesPartialDecoderTraits>,
-    output_handle: Arc<dyn BytesPartialEncoderTraits>,
+    input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
     decoded_representation: ChunkRepresentation,
     codec: Arc<dyn ArrayToBytesCodecTraits>,
 }
@@ -115,23 +112,49 @@ impl ArrayToBytesPartialEncoderDefault {
     /// Create a new [`ArrayToBytesPartialEncoderDefault`].
     #[must_use]
     pub fn new(
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         decoded_representation: ChunkRepresentation,
         codec: Arc<dyn ArrayToBytesCodecTraits>,
     ) -> Self {
         Self {
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation,
             codec,
         }
     }
 }
 
+impl ArrayPartialDecoderTraits for ArrayToBytesPartialEncoderDefault {
+    fn data_type(&self) -> &super::DataType {
+        self.decoded_representation.data_type()
+    }
+
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
+    fn partial_decode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        options: &super::CodecOptions,
+    ) -> Result<ArrayBytes<'_>, super::CodecError> {
+        super::array_to_bytes_partial_decoder_default::partial_decode(
+            self.input_output_handle.as_ref(),
+            &self.decoded_representation,
+            &self.codec,
+            indexer,
+            options,
+        )
+    }
+}
+
 impl ArrayPartialEncoderTraits for ArrayToBytesPartialEncoderDefault {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn ArrayPartialDecoderTraits> {
+        self.clone()
+    }
+
     fn erase(&self) -> Result<(), super::CodecError> {
-        self.output_handle.erase()
+        self.input_output_handle.erase()
     }
 
     fn partial_encode(
@@ -141,8 +164,7 @@ impl ArrayPartialEncoderTraits for ArrayToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode(
-            &self.input_handle,
-            &self.output_handle,
+            self.input_output_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -155,8 +177,7 @@ impl ArrayPartialEncoderTraits for ArrayToBytesPartialEncoderDefault {
 #[cfg(feature = "async")]
 /// The default asynchronous array-to-bytes partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
 pub struct AsyncArrayToBytesPartialEncoderDefault {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-    output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
+    input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
     decoded_representation: ChunkRepresentation,
     codec: Arc<dyn ArrayToBytesCodecTraits>,
 }
@@ -166,14 +187,12 @@ impl AsyncArrayToBytesPartialEncoderDefault {
     /// Create a new [`ArrayToBytesPartialEncoderDefault`].
     #[must_use]
     pub fn new(
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-        output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         decoded_representation: ChunkRepresentation,
         codec: Arc<dyn ArrayToBytesCodecTraits>,
     ) -> Self {
         Self {
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation,
             codec,
         }
@@ -183,9 +202,37 @@ impl AsyncArrayToBytesPartialEncoderDefault {
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl AsyncArrayPartialDecoderTraits for AsyncArrayToBytesPartialEncoderDefault {
+    fn data_type(&self) -> &super::DataType {
+        self.decoded_representation.data_type()
+    }
+
+    async fn partial_decode(
+        &self,
+        indexer: &dyn crate::indexer::Indexer,
+        options: &super::CodecOptions,
+    ) -> Result<ArrayBytes<'_>, super::CodecError> {
+        super::array_to_bytes_partial_decoder_default::partial_decode_async(
+            self.input_output_handle.as_ref(),
+            &self.decoded_representation,
+            &self.codec,
+            indexer,
+            options,
+        )
+        .await
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialEncoderTraits for AsyncArrayToBytesPartialEncoderDefault {
+    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits> {
+        self.clone()
+    }
+
     async fn erase(&self) -> Result<(), super::CodecError> {
-        self.output_handle.erase().await
+        self.input_output_handle.erase().await
     }
 
     async fn partial_encode(
@@ -195,8 +242,7 @@ impl AsyncArrayPartialEncoderTraits for AsyncArrayToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode_async(
-            &self.input_handle,
-            &self.output_handle,
+            self.input_output_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             indexer,

--- a/zarrs/src/array/codec/array_to_bytes_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/array_to_bytes_partial_encoder_default.rs
@@ -14,7 +14,7 @@ use crate::array::codec::{
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_output_handle: &dyn AsyncBytesPartialEncoderTraits,
+    input_output_handle: &Arc<dyn AsyncBytesPartialEncoderTraits>,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToBytesCodecTraits>,
     chunk_subset_indexer: &dyn crate::indexer::Indexer,
@@ -22,7 +22,7 @@ use crate::array::codec::{
     options: &super::CodecOptions,
 )))]
 fn partial_encode(
-    input_output_handle: &dyn BytesPartialEncoderTraits,
+    input_output_handle: &Arc<dyn BytesPartialEncoderTraits>,
     decoded_representation: &ChunkRepresentation,
     codec: &Arc<dyn ArrayToBytesCodecTraits>,
     chunk_subset_indexer: &dyn crate::indexer::Indexer,
@@ -139,7 +139,7 @@ impl ArrayPartialDecoderTraits for ArrayToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         super::array_to_bytes_partial_decoder_default::partial_decode(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle.clone().into_dyn_decoder(),
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -164,7 +164,7 @@ impl ArrayPartialEncoderTraits for ArrayToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle,
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -213,7 +213,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncArrayToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<ArrayBytes<'_>, super::CodecError> {
         super::array_to_bytes_partial_decoder_default::partial_decode_async(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle.clone().into_dyn_decoder(),
             &self.decoded_representation,
             &self.codec,
             indexer,
@@ -227,7 +227,7 @@ impl AsyncArrayPartialDecoderTraits for AsyncArrayToBytesPartialEncoderDefault {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialEncoderTraits for AsyncArrayToBytesPartialEncoderDefault {
-    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits> {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncArrayPartialDecoderTraits> {
         self.clone()
     }
 
@@ -242,7 +242,7 @@ impl AsyncArrayPartialEncoderTraits for AsyncArrayToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode_async(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle,
             &self.decoded_representation,
             &self.codec,
             indexer,

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
@@ -11,14 +11,14 @@ use crate::array::codec::AsyncBytesPartialDecoderTraits;
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_handle: &dyn AsyncBytesPartialDecoderTraits,
+    input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
     decoded_regions: &mut dyn ByteRangeIterator,
     options: &CodecOptions,
 )))]
 pub(crate) fn partial_decode<'a>(
-    input_handle: &dyn BytesPartialDecoderTraits,
+    input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
     decoded_regions: &mut dyn ByteRangeIterator,
@@ -84,7 +84,7 @@ impl BytesPartialDecoderTraits for BytesToBytesPartialDecoderDefault {
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode(
-            self.input_handle.as_ref(),
+            &self.input_handle,
             &self.decoded_representation,
             &self.codec,
             decoded_regions,
@@ -128,7 +128,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialDecoderDefault {
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode_async(
-            self.input_handle.as_ref(),
+            &self.input_handle,
             &self.decoded_representation,
             &self.codec,
             decoded_regions,

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
@@ -11,14 +11,14 @@ use crate::array::codec::AsyncBytesPartialDecoderTraits;
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
+    input_handle: &dyn AsyncBytesPartialDecoderTraits,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
     decoded_regions: &mut dyn ByteRangeIterator,
     options: &CodecOptions,
 )))]
-fn partial_decode<'a>(
-    input_handle: &Arc<dyn BytesPartialDecoderTraits>,
+pub(crate) fn partial_decode<'a>(
+    input_handle: &dyn BytesPartialDecoderTraits,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
     decoded_regions: &mut dyn ByteRangeIterator,
@@ -84,7 +84,7 @@ impl BytesPartialDecoderTraits for BytesToBytesPartialDecoderDefault {
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode(
-            &self.input_handle,
+            self.input_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             decoded_regions,
@@ -128,7 +128,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialDecoderDefault {
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode_async(
-            &self.input_handle,
+            self.input_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             decoded_regions,

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_encoder_default.rs
@@ -14,14 +14,14 @@ use crate::array::codec::{AsyncBytesPartialDecoderTraits, AsyncBytesPartialEncod
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_output_handle: &dyn AsyncBytesPartialEncoderTraits,
+    input_output_handle: &Arc<dyn AsyncBytesPartialEncoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
     offsets_and_bytes: &[(ByteOffset, crate::array::RawBytes<'_>)],
     options: &super::CodecOptions,
 )))]
 fn partial_encode(
-    input_output_handle: &dyn BytesPartialEncoderTraits,
+    input_output_handle: &Arc<dyn BytesPartialEncoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
     offsets_and_bytes: &[(ByteOffset, crate::array::RawBytes<'_>)],
@@ -108,7 +108,7 @@ impl BytesPartialDecoderTraits for BytesToBytesPartialEncoderDefault {
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         super::bytes_to_bytes_partial_decoder_default::partial_decode(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle.clone().into_dyn_decoder(),
             &self.decoded_representation,
             &self.codec,
             decoded_regions,
@@ -132,7 +132,7 @@ impl BytesPartialEncoderTraits for BytesToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle,
             &self.decoded_representation,
             &self.codec,
             offsets_and_bytes,
@@ -176,7 +176,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialEncoderDefault {
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         super::bytes_to_bytes_partial_decoder_default::partial_decode_async(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle.clone().into_dyn_decoder(),
             &self.decoded_representation,
             &self.codec,
             decoded_regions,
@@ -190,7 +190,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialEncoderDefault {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialEncoderTraits for AsyncBytesToBytesPartialEncoderDefault {
-    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncBytesPartialDecoderTraits> {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncBytesPartialDecoderTraits> {
         self.clone()
     }
 
@@ -204,7 +204,7 @@ impl AsyncBytesPartialEncoderTraits for AsyncBytesToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode_async(
-            self.input_output_handle.as_ref(),
+            &self.input_output_handle,
             &self.decoded_representation,
             &self.codec,
             offsets_and_bytes,

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_encoder_default.rs
@@ -1,8 +1,11 @@
 use std::{borrow::Cow, sync::Arc};
 
-use zarrs_storage::byte_range::ByteOffset;
+use zarrs_storage::byte_range::{ByteOffset, ByteRangeIterator};
 
-use crate::array::BytesRepresentation;
+use crate::array::{
+    codec::{CodecError, CodecOptions},
+    BytesRepresentation, RawBytes,
+};
 
 use super::{BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesToBytesCodecTraits};
 
@@ -11,16 +14,14 @@ use crate::array::codec::{AsyncBytesPartialDecoderTraits, AsyncBytesPartialEncod
 
 #[cfg_attr(feature = "async", async_generic::async_generic(
     async_signature(
-    input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
-    output_handle: &Arc<dyn AsyncBytesPartialEncoderTraits>,
+    input_output_handle: &dyn AsyncBytesPartialEncoderTraits,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
     offsets_and_bytes: &[(ByteOffset, crate::array::RawBytes<'_>)],
     options: &super::CodecOptions,
 )))]
 fn partial_encode(
-    input_handle: &Arc<dyn BytesPartialDecoderTraits>,
-    output_handle: &Arc<dyn BytesPartialEncoderTraits>,
+    input_output_handle: &dyn BytesPartialEncoderTraits,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
     offsets_and_bytes: &[(ByteOffset, crate::array::RawBytes<'_>)],
@@ -28,13 +29,13 @@ fn partial_encode(
 ) -> Result<(), super::CodecError> {
     #[cfg(feature = "async")]
     let encoded_value = if _async {
-        input_handle.decode(options).await
+        input_output_handle.decode(options).await
     } else {
-        input_handle.decode(options)
+        input_output_handle.decode(options)
     }?
     .map(Cow::into_owned);
     #[cfg(not(feature = "async"))]
-    let encoded_value = input_handle.decode(options)?.map(Cow::into_owned);
+    let encoded_value = input_output_handle.decode(options)?.map(Cow::into_owned);
 
     let mut decoded_value = if let Some(encoded_value) = encoded_value {
         codec
@@ -63,20 +64,19 @@ fn partial_encode(
 
     #[cfg(feature = "async")]
     if _async {
-        output_handle
+        input_output_handle
             .partial_encode(&[(0, Cow::Owned(bytes_encoded))], options)
             .await
     } else {
-        output_handle.partial_encode(&[(0, Cow::Owned(bytes_encoded))], options)
+        input_output_handle.partial_encode(&[(0, Cow::Owned(bytes_encoded))], options)
     }
     #[cfg(not(feature = "async"))]
-    output_handle.partial_encode(&[(0, Cow::Owned(bytes_encoded))], options)
+    input_output_handle.partial_encode(&[(0, Cow::Owned(bytes_encoded))], options)
 }
 
 /// The default bytes-to-bytes partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
 pub struct BytesToBytesPartialEncoderDefault {
-    input_handle: Arc<dyn BytesPartialDecoderTraits>,
-    output_handle: Arc<dyn BytesPartialEncoderTraits>,
+    input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
     decoded_representation: BytesRepresentation,
     codec: Arc<dyn BytesToBytesCodecTraits>,
 }
@@ -85,23 +85,45 @@ impl BytesToBytesPartialEncoderDefault {
     /// Create a new [`BytesToBytesPartialEncoderDefault`].
     #[must_use]
     pub fn new(
-        input_handle: Arc<dyn BytesPartialDecoderTraits>,
-        output_handle: Arc<dyn BytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn BytesPartialEncoderTraits>,
         decoded_representation: BytesRepresentation,
         codec: Arc<dyn BytesToBytesCodecTraits>,
     ) -> Self {
         Self {
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation,
             codec,
         }
     }
 }
 
+impl BytesPartialDecoderTraits for BytesToBytesPartialEncoderDefault {
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
+    fn partial_decode(
+        &self,
+        decoded_regions: &mut dyn ByteRangeIterator,
+        options: &CodecOptions,
+    ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
+        super::bytes_to_bytes_partial_decoder_default::partial_decode(
+            self.input_output_handle.as_ref(),
+            &self.decoded_representation,
+            &self.codec,
+            decoded_regions,
+            options,
+        )
+    }
+}
+
 impl BytesPartialEncoderTraits for BytesToBytesPartialEncoderDefault {
+    fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn BytesPartialDecoderTraits> {
+        self.clone()
+    }
+
     fn erase(&self) -> Result<(), super::CodecError> {
-        self.output_handle.erase()
+        self.input_output_handle.erase()
     }
 
     fn partial_encode(
@@ -110,8 +132,7 @@ impl BytesPartialEncoderTraits for BytesToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode(
-            &self.input_handle,
-            &self.output_handle,
+            self.input_output_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             offsets_and_bytes,
@@ -123,8 +144,7 @@ impl BytesPartialEncoderTraits for BytesToBytesPartialEncoderDefault {
 #[cfg(feature = "async")]
 /// The default asynchronous bytes-to-bytes partial encoder. Decodes the entire chunk, updates it, and writes the entire chunk.
 pub struct AsyncBytesToBytesPartialEncoderDefault {
-    input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-    output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
+    input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
     decoded_representation: BytesRepresentation,
     codec: Arc<dyn BytesToBytesCodecTraits>,
 }
@@ -134,14 +154,12 @@ impl AsyncBytesToBytesPartialEncoderDefault {
     /// Create a new [`AsyncBytesToBytesPartialEncoderDefault`].
     #[must_use]
     pub fn new(
-        input_handle: Arc<dyn AsyncBytesPartialDecoderTraits>,
-        output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
+        input_output_handle: Arc<dyn AsyncBytesPartialEncoderTraits>,
         decoded_representation: BytesRepresentation,
         codec: Arc<dyn BytesToBytesCodecTraits>,
     ) -> Self {
         Self {
-            input_handle,
-            output_handle,
+            input_output_handle,
             decoded_representation,
             codec,
         }
@@ -151,9 +169,33 @@ impl AsyncBytesToBytesPartialEncoderDefault {
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialEncoderDefault {
+    async fn partial_decode(
+        &self,
+        decoded_regions: &mut dyn ByteRangeIterator,
+        options: &CodecOptions,
+    ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
+        super::bytes_to_bytes_partial_decoder_default::partial_decode_async(
+            self.input_output_handle.as_ref(),
+            &self.decoded_representation,
+            &self.codec,
+            decoded_regions,
+            options,
+        )
+        .await
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialEncoderTraits for AsyncBytesToBytesPartialEncoderDefault {
+    async fn into_dyn_decoder(self: Arc<Self>) -> Arc<dyn AsyncBytesPartialDecoderTraits> {
+        self.clone()
+    }
+
     async fn erase(&self) -> Result<(), super::CodecError> {
-        self.output_handle.erase().await
+        self.input_output_handle.erase().await
     }
 
     async fn partial_encode(
@@ -162,8 +204,7 @@ impl AsyncBytesPartialEncoderTraits for AsyncBytesToBytesPartialEncoderDefault {
         options: &super::CodecOptions,
     ) -> Result<(), super::CodecError> {
         partial_encode_async(
-            &self.input_handle,
-            &self.output_handle,
+            self.input_output_handle.as_ref(),
             &self.decoded_representation,
             &self.codec,
             offsets_and_bytes,

--- a/zarrs/tests/indexer.rs
+++ b/zarrs/tests/indexer.rs
@@ -329,7 +329,6 @@ fn indexer_partial_encode_impl<T: ElementOwned>(
     let partial_encoder = codec
         .clone()
         .partial_encoder(
-            encoded_chunk,
             output.clone(),
             &decoded_representation,
             &CodecOptions::default(),
@@ -397,7 +396,7 @@ async fn async_indexer_array_subsets_fixed() {
                 Arc::new(BytesCodec::little()),
                 vec![],
             )),
-            false, // FIXME: Add squeeze / transpose partial encoder
+            true,
         ),
         (
             Arc::new(CodecChain::new(
@@ -407,13 +406,12 @@ async fn async_indexer_array_subsets_fixed() {
                     Arc::new(TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap())),
                 ],
                 ShardingCodecBuilder::new(
-                    // FIXME: Add generic indexing support to sharding indexed partial encoder
                     vec![NonZeroU64::new(2).unwrap(), NonZeroU64::new(2).unwrap()].into(),
                 )
                 .build_arc(),
                 vec![],
             )),
-            false,
+            false, // FIXME: Add generic indexing support to sharding indexed partial encoder
         ),
     ];
 
@@ -526,7 +524,7 @@ async fn async_indexer_array_subsets_variable() {
                 Arc::new(VlenCodec::default()),
                 vec![],
             )),
-            false, // FIXME: Add squeeze / transpose partial encoder
+            true,
         ),
         (
             Arc::new(CodecChain::new(
@@ -536,14 +534,13 @@ async fn async_indexer_array_subsets_variable() {
                     Arc::new(TransposeCodec::new(TransposeOrder::new(&[1, 0]).unwrap())),
                 ],
                 ShardingCodecBuilder::new(
-                    // FIXME: Add generic indexing support to sharding indexed partial encoder
                     vec![NonZeroU64::new(2).unwrap(), NonZeroU64::new(2).unwrap()].into(),
                 )
                 .array_to_bytes_codec(Arc::new(VlenCodec::default()))
                 .build_arc(),
                 vec![],
             )),
-            false,
+            false, // FIXME: Add generic indexing support to sharding indexed partial encoder
         ),
     ];
 


### PR DESCRIPTION
This is how it should have been done from the start. A combined input/output handle that can do partial encoding and decoding.

Better code reuse amongst encoders/decoders can be introduced later. Async and a few codecs need to be supported before the experimental status can be removed from partial encoding.