### PR TITLE
refactor: change `ByteRangeIterator` to `Box` iterator type instead of trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking**: `ArrayPartialEncoderTraits:` trait changes:
   - `partial_encode()`: parameter `subsets_and_bytes: &[(&ArraySubset, ArrayBytes<'_>)]` changed to `indexer: &dyn Indexer` and `bytes: &ArrayBytes<'_>`
 - **Breaking**: `[Async]BytesPartialDecoderTraits` trait changes:
-  - `partial_decode[_concat]`: parameter `decoded_regions: &[ByteRange]` changed to `&mut (dyn Iterator<Item = ByteRange> + Send)`
+  - `partial_decode[_concat]`: parameter `decoded_regions: &[ByteRange]` changed to `ByteRangeIterator`
 - **Breaking**: `Array::set_shape()` now returns a `Result`
   - Previously it was possible to resize an array to a shape incompatible with a `rectangular` chunk grid
 - **Breaking**: Refactor `ChunkGridTraits` and `ChunkGridPlugin`, chunk grids are initialised with the array shape

--- a/zarrs/examples/zip_array_write_read.rs
+++ b/zarrs/examples/zip_array_write_read.rs
@@ -116,8 +116,8 @@ fn read_array_from_store<TStorage: ReadableStorageTraits + 'static>(
 }
 
 // https://github.com/zip-rs/zip/blob/master/examples/write_dir.rs
-fn zip_dir(
-    it: &mut dyn Iterator<Item = walkdir::DirEntry>,
+fn zip_dir<I: Iterator<Item = walkdir::DirEntry>>(
+    it: I,
     prefix: &str,
     writer: File,
     method: zip::CompressionMethod,

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_partial_decoder.rs
@@ -68,12 +68,12 @@ impl ArrayPartialDecoderTraits for BytesPartialDecoder {
 
         let chunk_shape = self.decoded_representation.shape_u64();
         // Get byte ranges
-        let mut byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
+        let byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
 
         // Decode
         let decoded = self
             .input_handle
-            .partial_decode_concat(&mut byte_ranges, options)?
+            .partial_decode_concat(Box::new(byte_ranges), options)?
             .map_or_else(
                 || {
                     let array_size = ArraySize::new(
@@ -154,12 +154,12 @@ impl AsyncArrayPartialDecoderTraits for AsyncBytesPartialDecoder {
         let chunk_shape = self.decoded_representation.shape_u64();
 
         // Get byte ranges
-        let mut byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
+        let byte_ranges = indexer.byte_ranges(&chunk_shape, data_type_size)?;
 
         // Decode
         let decoded = self
             .input_handle
-            .partial_decode_concat(&mut byte_ranges, options)
+            .partial_decode_concat(Box::new(byte_ranges), options)
             .await?
             .map_or_else(
                 || {

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
@@ -80,7 +80,7 @@ fn partial_decode<'a>(
         .collect::<Vec<_>>();
 
     // Convert to byte ranges, skipping the padding encoding byte
-    let mut byte_ranges = bit_ranges.iter().map(|bit_range| {
+    let byte_ranges = bit_ranges.iter().map(|bit_range| {
         let byte_start = offset + bit_range.start(encoded_length_bits).div(8);
         let byte_end = offset + bit_range.end(encoded_length_bits).div_ceil(8);
         ByteRange::new(byte_start..byte_end)
@@ -89,19 +89,21 @@ fn partial_decode<'a>(
     // Retrieve those bytes
     #[cfg(feature = "async")]
     let encoded_bytes = if _async {
-        input_handle.partial_decode(&mut byte_ranges, options).await
+        input_handle
+            .partial_decode(Box::new(byte_ranges), options)
+            .await
     } else {
-        input_handle.partial_decode(&mut byte_ranges, options)
+        input_handle.partial_decode(Box::new(byte_ranges), options)
     }?;
     #[cfg(not(feature = "async"))]
-    let encoded_bytes = input_handle.partial_decode(&mut byte_ranges, options)?;
+    let encoded_bytes = input_handle.partial_decode(Box::new(byte_ranges), options)?;
 
     // Convert to elements
     let decoded_bytes = if let Some(encoded_bytes) = encoded_bytes {
         let mut bytes_dec: Vec<u8> =
             vec![0; usize::try_from(indexer.len() * data_type_size_dec as u64).unwrap()];
         let mut component_idx_outer = 0;
-        for (packed_elements, bit_range) in encoded_bytes.into_iter().zip(bit_ranges) {
+        for (packed_elements, bit_range) in encoded_bytes.into_iter().zip(&bit_ranges) {
             // Get the bit range within the entire chunk
             let bit_start = bit_range.start(encoded_length_bits);
             let bit_end = bit_range.end(encoded_length_bits);

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -268,7 +268,7 @@ fn decode_shard_index_partial_decoder(
     let index_byte_range =
         get_index_byte_range(&index_array_representation, index_codecs, index_location)?;
     let encoded_shard_index = input_handle
-        .partial_decode(&mut [index_byte_range].into_iter(), options)?
+        .partial_decode(Box::new([index_byte_range].into_iter()), options)?
         .map(|mut v| v.remove(0));
     Ok(match encoded_shard_index {
         Some(encoded_shard_index) => Some(decode_shard_index(
@@ -296,7 +296,7 @@ async fn decode_shard_index_async_partial_decoder(
     let index_byte_range =
         get_index_byte_range(&index_array_representation, index_codecs, index_location)?;
     let encoded_shard_index = input_handle
-        .partial_decode(&mut [index_byte_range].into_iter(), options)
+        .partial_decode(Box::new([index_byte_range].into_iter()), options)
         .await?
         .map(|mut v| v.remove(0));
     Ok(match encoded_shard_index {

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -93,7 +93,7 @@ impl AsyncShardingPartialDecoder {
         let byte_range = self.inner_chunk_byte_range(chunk_indices)?;
         if let Some(byte_range) = byte_range {
             self.input_handle
-                .partial_decode_concat(&mut [byte_range].into_iter(), &CodecOptions::default())
+                .partial_decode_concat(Box::new([byte_range].into_iter()), &CodecOptions::default())
                 .await
         } else {
             Ok(None)

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -92,7 +92,7 @@ impl ShardingPartialDecoder {
         let byte_range = self.inner_chunk_byte_range(chunk_indices)?;
         if let Some(byte_range) = byte_range {
             self.input_handle
-                .partial_decode_concat(&mut [byte_range].into_iter(), &CodecOptions::default())
+                .partial_decode_concat(Box::new([byte_range].into_iter()), &CodecOptions::default())
         } else {
             Ok(None)
         }

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -258,7 +258,7 @@ impl ArrayPartialEncoderTraits for ShardingPartialEncoder {
         // Read the straddling inner chunks
         let inner_chunks_encoded = self
             .input_output_handle
-            .partial_decode(&mut byte_ranges.into_iter(), options)?
+            .partial_decode(Box::new(byte_ranges.into_iter()), options)?
             .map(|bytes| bytes.into_iter().map(Cow::into_owned).collect::<Vec<_>>());
 
         // Decode the straddling inner chunks

--- a/zarrs/src/array/codec/byte_interval_partial_decoder.rs
+++ b/zarrs/src/array/codec/byte_interval_partial_decoder.rs
@@ -41,10 +41,10 @@ impl BytesPartialDecoderTraits for ByteIntervalPartialDecoder {
 
     fn partial_decode(
         &self,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let mut byte_ranges = byte_ranges.map(|byte_range| match byte_range {
+        let byte_ranges = byte_ranges.map(|byte_range| match byte_range {
             ByteRange::FromStart(offset, None) => {
                 ByteRange::FromStart(self.byte_offset + offset, Some(self.byte_length))
             }
@@ -55,7 +55,8 @@ impl BytesPartialDecoderTraits for ByteIntervalPartialDecoder {
                 ByteRange::FromStart(self.byte_offset + self.byte_length - length, Some(length))
             }
         });
-        self.input_handle.partial_decode(&mut byte_ranges, options)
+        self.input_handle
+            .partial_decode(Box::new(byte_ranges), options)
     }
 }
 
@@ -89,12 +90,12 @@ impl AsyncByteIntervalPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder {
-    async fn partial_decode(
-        &self,
-        byte_ranges: &mut dyn ByteRangeIterator,
+    async fn partial_decode<'a>(
+        &'a self,
+        byte_ranges: ByteRangeIterator<'a>,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let mut byte_ranges = byte_ranges.map(|byte_range| match byte_range {
+        let byte_ranges = byte_ranges.map(|byte_range| match byte_range {
             ByteRange::FromStart(offset, None) => {
                 ByteRange::FromStart(self.byte_offset + offset, Some(self.byte_length))
             }
@@ -106,7 +107,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder {
             }
         });
         self.input_handle
-            .partial_decode(&mut byte_ranges, options)
+            .partial_decode(Box::new(byte_ranges), options)
             .await
     }
 }

--- a/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
+++ b/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
@@ -27,7 +27,10 @@ impl BytesPartialDecoderCache {
         options: &CodecOptions,
     ) -> Result<Self, CodecError> {
         let cache = input_handle
-            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)?
+            .partial_decode(
+                Box::new([ByteRange::FromStart(0, None)].into_iter()),
+                options,
+            )?
             .map(|mut bytes| bytes.remove(0).into_owned());
         Ok(Self { cache })
     }
@@ -42,7 +45,10 @@ impl BytesPartialDecoderCache {
         options: &CodecOptions,
     ) -> Result<BytesPartialDecoderCache, CodecError> {
         let cache = input_handle
-            .partial_decode(&mut [ByteRange::FromStart(0, None)].into_iter(), options)
+            .partial_decode(
+                Box::new([ByteRange::FromStart(0, None)].into_iter()),
+                options,
+            )
             .await?
             .map(|mut bytes| bytes.remove(0).into_owned());
         Ok(Self { cache })
@@ -56,7 +62,7 @@ impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+        decoded_regions: ByteRangeIterator,
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         Ok(match &self.cache {
@@ -76,9 +82,9 @@ impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for BytesPartialDecoderCache {
-    async fn partial_decode(
-        &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+    async fn partial_decode<'a>(
+        &'a self,
+        decoded_regions: ByteRangeIterator<'a>,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         BytesPartialDecoderTraits::partial_decode(self, decoded_regions, options)

--- a/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
@@ -154,7 +154,10 @@ mod tests {
                 .unwrap();
             assert_eq!(partial_decoder.size(), input_handle.size()); // adler32 partial decoder does not hold bytes
             let decoded_partial_chunk = partial_decoder
-                .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+                .partial_decode(
+                    Box::new(decoded_regions.into_iter()),
+                    &CodecOptions::default(),
+                )
                 .unwrap()
                 .unwrap();
             let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -195,7 +198,10 @@ mod tests {
                 .await
                 .unwrap();
             let decoded_partial_chunk = partial_decoder
-                .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+                .partial_decode(
+                    Box::new(decoded_regions.into_iter()),
+                    &CodecOptions::default(),
+                )
                 .await
                 .unwrap()
                 .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
@@ -383,7 +383,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -396,7 +396,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // blosc partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(Box::new(decoded_regions), &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -432,7 +432,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -445,7 +445,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(Box::new(decoded_regions), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
@@ -34,7 +34,7 @@ impl BytesPartialDecoderTraits for BloscPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+        decoded_regions: ByteRangeIterator,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
@@ -79,9 +79,9 @@ impl AsyncBloscPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder {
-    async fn partial_decode(
-        &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+    async fn partial_decode<'a>(
+        &'a self,
+        decoded_regions: ByteRangeIterator<'a>,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
@@ -123,7 +123,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -136,7 +136,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // bz2 partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(Box::new(decoded_regions), &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(Box::new(decoded_regions), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
@@ -135,7 +135,10 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // crc32c partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .unwrap()
             .unwrap();
         let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -172,7 +175,10 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
@@ -149,7 +149,10 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // fletcher32 partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .unwrap()
             .unwrap();
         let answer: &[Vec<u8>] = &[vec![3, 4]];
@@ -189,7 +192,10 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
@@ -351,7 +351,10 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // gdeflate partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .unwrap()
             .unwrap();
 
@@ -393,7 +396,10 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
@@ -143,7 +143,10 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // gzip partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .unwrap()
             .unwrap();
 
@@ -184,7 +187,10 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
@@ -127,7 +127,10 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // shuffle partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .unwrap()
             .unwrap();
 
@@ -168,7 +171,10 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
@@ -37,14 +37,14 @@ impl BytesPartialDecoderTraits for StripSuffixPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+        decoded_regions: ByteRangeIterator,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         decoded_regions
             .map(|decoded_region| {
                 let bytes = self
                     .input_handle
-                    .partial_decode_concat(&mut [decoded_region].into_iter(), options)?;
+                    .partial_decode_concat(Box::new([decoded_region].into_iter()), options)?;
                 Ok::<_, CodecError>(bytes.map(|bytes| match decoded_region {
                     ByteRange::FromStart(_, Some(_)) => bytes,
                     ByteRange::FromStart(_, None) => {
@@ -87,9 +87,9 @@ impl AsyncStripSuffixPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncStripSuffixPartialDecoder {
-    async fn partial_decode(
-        &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+    async fn partial_decode<'a>(
+        &'a self,
+        decoded_regions: ByteRangeIterator<'a>,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         use futures::{StreamExt, TryStreamExt};
@@ -98,13 +98,13 @@ impl AsyncBytesPartialDecoderTraits for AsyncStripSuffixPartialDecoder {
             match decoded_region {
                 ByteRange::FromStart(_, Some(_)) => Ok::<_, CodecError>(
                     self.input_handle
-                        .partial_decode_concat(&mut [decoded_region].into_iter(), options)
+                        .partial_decode_concat(Box::new([decoded_region].into_iter()), options)
                         .await?,
                 ),
                 ByteRange::FromStart(_, None) | ByteRange::Suffix(_) => {
                     let bytes = self
                         .input_handle
-                        .partial_decode_concat(&mut [decoded_region].into_iter(), options)
+                        .partial_decode_concat(Box::new([decoded_region].into_iter()), options)
                         .await?;
                     if let Some(bytes) = bytes {
                         let length = bytes.len() - self.suffix_size;

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
@@ -64,7 +64,10 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // test unbounded partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .unwrap()
             .unwrap();
 
@@ -106,7 +109,10 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -30,7 +30,7 @@ impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+        decoded_regions: ByteRangeIterator,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options)?;
@@ -66,9 +66,9 @@ impl AsyncTestUnboundedPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder {
-    async fn partial_decode(
-        &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+    async fn partial_decode<'a>(
+        &'a self,
+        decoded_regions: ByteRangeIterator<'a>,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let encoded_value = self.input_handle.decode(options).await?;

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
@@ -124,7 +124,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -137,7 +137,7 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // zlib partial decoder does not hold bytes
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(Box::new(decoded_regions), &CodecOptions::default())
             .unwrap()
             .unwrap();
 
@@ -171,7 +171,7 @@ mod tests {
         let encoded = codec
             .encode(Cow::Owned(bytes), &CodecOptions::default())
             .unwrap();
-        let mut decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
+        let decoded_regions = ArraySubset::new_with_ranges(&[0..2, 1..2, 0..1])
             .byte_ranges(array_representation.shape(), data_type_size)
             .unwrap();
         let input_handle = Arc::new(encoded);
@@ -184,7 +184,7 @@ mod tests {
             .await
             .unwrap();
         let decoded = partial_decoder
-            .partial_decode_concat(&mut decoded_regions, &CodecOptions::default())
+            .partial_decode_concat(Box::new(decoded_regions), &CodecOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
@@ -129,7 +129,10 @@ mod tests {
             .unwrap();
         assert_eq!(partial_decoder.size(), input_handle.size()); // zstd partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .unwrap()
             .unwrap();
 
@@ -171,7 +174,10 @@ mod tests {
             .await
             .unwrap();
         let decoded_partial_chunk = partial_decoder
-            .partial_decode_concat(&mut decoded_regions.into_iter(), &CodecOptions::default())
+            .partial_decode_concat(
+                Box::new(decoded_regions.into_iter()),
+                &CodecOptions::default(),
+            )
             .await
             .unwrap()
             .unwrap();

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_decoder_default.rs
@@ -14,14 +14,14 @@ use crate::array::codec::AsyncBytesPartialDecoderTraits;
     input_handle: &Arc<dyn AsyncBytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
-    decoded_regions: &mut dyn ByteRangeIterator,
+    decoded_regions: ByteRangeIterator<'_>,
     options: &CodecOptions,
 )))]
 pub(crate) fn partial_decode<'a>(
     input_handle: &Arc<dyn BytesPartialDecoderTraits>,
     decoded_representation: &BytesRepresentation,
     codec: &Arc<dyn BytesToBytesCodecTraits>,
-    decoded_regions: &mut dyn ByteRangeIterator,
+    decoded_regions: ByteRangeIterator,
     options: &CodecOptions,
 ) -> Result<Option<Vec<RawBytes<'a>>>, CodecError> {
     #[cfg(feature = "async")]
@@ -80,7 +80,7 @@ impl BytesPartialDecoderTraits for BytesToBytesPartialDecoderDefault {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+        decoded_regions: ByteRangeIterator,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode(
@@ -122,9 +122,9 @@ impl AsyncBytesToBytesPartialDecoderDefault {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialDecoderDefault {
-    async fn partial_decode(
-        &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+    async fn partial_decode<'a>(
+        &'a self,
+        decoded_regions: ByteRangeIterator<'a>,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         partial_decode_async(

--- a/zarrs/src/array/codec/bytes_to_bytes_partial_encoder_default.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes_partial_encoder_default.rs
@@ -104,7 +104,7 @@ impl BytesPartialDecoderTraits for BytesToBytesPartialEncoderDefault {
 
     fn partial_decode(
         &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+        decoded_regions: ByteRangeIterator,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         super::bytes_to_bytes_partial_decoder_default::partial_decode(
@@ -170,9 +170,9 @@ impl AsyncBytesToBytesPartialEncoderDefault {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncBytesToBytesPartialEncoderDefault {
-    async fn partial_decode(
-        &self,
-        decoded_regions: &mut dyn ByteRangeIterator,
+    async fn partial_decode<'a>(
+        &'a self,
+        decoded_regions: ByteRangeIterator<'a>,
         options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         super::bytes_to_bytes_partial_decoder_default::partial_decode_async(

--- a/zarrs_filesystem/src/lib.rs
+++ b/zarrs_filesystem/src/lib.rs
@@ -253,7 +253,7 @@ impl ReadableStorageTraits for FilesystemStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let file = self.get_file_mutex(key);
         let _lock = file.read();

--- a/zarrs_http/src/lib.rs
+++ b/zarrs_http/src/lib.rs
@@ -101,7 +101,7 @@ impl ReadableStorageTraits for HTTPStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let url = self.key_to_url(key).map_err(handle_url_error)?;
         let Some(size) = self.size_key(key)? else {
@@ -239,7 +239,7 @@ mod tests {
         assert!(store
             .get_partial_values_key(
                 &"zarr.json".try_into().unwrap(),
-                &mut [ByteRange::FromStart(0, None)].into_iter()
+                Box::new([ByteRange::FromStart(0, None)].into_iter())
             )
             .is_err());
         assert!(store.size_key(&"zarr.json".try_into().unwrap()).is_err());

--- a/zarrs_object_store/src/lib.rs
+++ b/zarrs_object_store/src/lib.rs
@@ -99,10 +99,10 @@ impl<T: object_store::ObjectStore> AsyncReadableStorageTraits for AsyncObjectSto
         }
     }
 
-    async fn get_partial_values_key(
-        &self,
+    async fn get_partial_values_key<'a>(
+        &'a self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator<'a>,
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         let Some(size) = self.size_key(key).await? else {
             return Ok(None);

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Breaking**: Add upcasting methods to storage traits (`readable()`, `writable()`, etc.)
-- **Breaking**: Change `byte_ranges: &[ByteRange]` parameter to `byte_ranges: impl Iterator<Item = ByteRange>` for
+- **Breaking**: Change `byte_ranges: &[ByteRange]` parameter to `byte_ranges: ByteRangeIterator` for
   - `extract_byte_ranges[{_concat,_read_seek,_read}]`
   - `[Async]ReadableStorageTraits::get_partial_values_key`
 

--- a/zarrs_storage/src/byte_range.rs
+++ b/zarrs_storage/src/byte_range.rs
@@ -309,10 +309,8 @@ pub fn extract_byte_ranges_read_seek<T: Read + Seek>(
         .collect::<std::io::Result<Vec<Vec<u8>>>>()
 }
 
-/// This trait combines `Iterator` and `MaybeSend`,
-/// as they cannot be combined together directly in function signatures.
-pub trait ByteRangeIterator: Iterator<Item = ByteRange> + MaybeSend {}
-impl<T: Iterator<Item = ByteRange> + MaybeSend> ByteRangeIterator for T {}
+/// A [`ByteRange`] iterator.
+pub type ByteRangeIterator<'a> = Box<dyn Iterator<Item = ByteRange> + MaybeSend + 'a>;
 
 #[cfg(test)]
 mod tests {

--- a/zarrs_storage/src/byte_range.rs
+++ b/zarrs_storage/src/byte_range.rs
@@ -309,8 +309,14 @@ pub fn extract_byte_ranges_read_seek<T: Read + Seek>(
         .collect::<std::io::Result<Vec<Vec<u8>>>>()
 }
 
+/// This trait combines [`Iterator<Item = ByteRange>`] and [`MaybeSend`],
+/// as they cannot be combined together directly in function signatures.
+pub trait MaybeSendByteRangeIterator: Iterator<Item = ByteRange> + MaybeSend {}
+
+impl<T> MaybeSendByteRangeIterator for T where T: Iterator<Item = ByteRange> + MaybeSend {}
+
 /// A [`ByteRange`] iterator.
-pub type ByteRangeIterator<'a> = Box<dyn Iterator<Item = ByteRange> + MaybeSend + 'a>;
+pub type ByteRangeIterator<'a> = Box<dyn MaybeSendByteRangeIterator + 'a>;
 
 #[cfg(test)]
 mod tests {

--- a/zarrs_storage/src/storage_adapter/async_to_sync.rs
+++ b/zarrs_storage/src/storage_adapter/async_to_sync.rs
@@ -60,7 +60,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits, TBlockOn: AsyncToSyncBlockOn
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.block_on(self.storage.get_partial_values_key(key, byte_ranges))
     }

--- a/zarrs_storage/src/storage_adapter/performance_metrics.rs
+++ b/zarrs_storage/src/storage_adapter/performance_metrics.rs
@@ -111,7 +111,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let size_hint_lower_bound = byte_ranges.size_hint().0;
         let values = self.storage.get_partial_values_key(key, byte_ranges)?;
@@ -224,10 +224,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
         value
     }
 
-    async fn get_partial_values_key(
-        &self,
+    async fn get_partial_values_key<'a>(
+        &'a self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator<'a>,
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         let size_hint_lower_bound = byte_ranges.size_hint().0;
         let values = self

--- a/zarrs_storage/src/storage_adapter/usage_log.rs
+++ b/zarrs_storage/src/storage_adapter/usage_log.rs
@@ -102,12 +102,12 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let byte_ranges = byte_ranges.collect::<Vec<ByteRange>>();
         let result = self
             .storage
-            .get_partial_values_key(key, &mut byte_ranges.iter().copied());
+            .get_partial_values_key(key, Box::new(byte_ranges.iter().copied()));
         writeln!(
             self.handle.lock().unwrap(),
             "{}get_partial_values_key({key}, [{}]) -> len={:?}",
@@ -310,15 +310,15 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
         result
     }
 
-    async fn get_partial_values_key(
-        &self,
+    async fn get_partial_values_key<'a>(
+        &'a self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator<'a>,
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         let byte_ranges: Vec<ByteRange> = byte_ranges.collect::<Vec<ByteRange>>();
         let result = self
             .storage
-            .get_partial_values_key(key, &mut byte_ranges.iter().copied())
+            .get_partial_values_key(key, Box::new(byte_ranges.iter().copied()))
             .await;
         writeln!(
             self.handle.lock().unwrap(),

--- a/zarrs_storage/src/storage_handle.rs
+++ b/zarrs_storage/src/storage_handle.rs
@@ -32,7 +32,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits for Storage
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges)
     }
@@ -112,10 +112,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
         self.0.get(key).await
     }
 
-    async fn get_partial_values_key(
-        &self,
+    async fn get_partial_values_key<'a>(
+        &'a self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator<'a>,
     ) -> Result<Option<Vec<AsyncBytes>>, StorageError> {
         self.0.get_partial_values_key(key, byte_ranges).await
     }

--- a/zarrs_storage/src/storage_sync.rs
+++ b/zarrs_storage/src/storage_sync.rs
@@ -20,7 +20,7 @@ pub trait ReadableStorageTraits: MaybeSend + MaybeSync {
     /// Returns a [`StorageError`] if there is an underlying storage error.
     fn get(&self, key: &StoreKey) -> Result<MaybeBytes, StorageError> {
         Ok(self
-            .get_partial_values_key(key, &mut [ByteRange::FromStart(0, None)].into_iter())?
+            .get_partial_values_key(key, Box::new([ByteRange::FromStart(0, None)].into_iter()))?
             .map(|mut v| v.remove(0)))
     }
 
@@ -33,7 +33,7 @@ pub trait ReadableStorageTraits: MaybeSend + MaybeSync {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError>;
 
     /// Retrieve partial bytes from a list of [`StoreKeyRange`].
@@ -84,7 +84,7 @@ pub trait ReadableStorageTraits: MaybeSend + MaybeSync {
                 // Found a new key, so do a batched get of the byte ranges of the last key
                 let bytes = (self.get_partial_values_key(
                     last_key.unwrap(),
-                    &mut byte_ranges_key.iter().copied(),
+                    Box::new(byte_ranges_key.iter().copied()),
                 )?)
                 .map_or_else(
                     || vec![None; byte_ranges_key.len()],
@@ -100,8 +100,10 @@ pub trait ReadableStorageTraits: MaybeSend + MaybeSync {
 
         if !byte_ranges_key.is_empty() {
             // Get the byte ranges of the last key
-            let bytes = (self
-                .get_partial_values_key(last_key.unwrap(), &mut byte_ranges_key.iter().copied())?)
+            let bytes = (self.get_partial_values_key(
+                last_key.unwrap(),
+                Box::new(byte_ranges_key.iter().copied()),
+            )?)
             .map_or_else(
                 || vec![None; byte_ranges_key.len()],
                 |partial_values| partial_values.into_iter().map(Some).collect(),

--- a/zarrs_storage/src/storage_value_io.rs
+++ b/zarrs_storage/src/storage_value_io.rs
@@ -70,7 +70,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Read for StorageValueIO<TStorage>
             .storage
             .get_partial_values_key(
                 &self.key,
-                &mut [ByteRange::FromStart(self.pos, Some(len))].into_iter(),
+                Box::new([ByteRange::FromStart(self.pos, Some(len))].into_iter()),
             )
             .map_err(|err| std::io::Error::other(err.to_string()))?
             .map(|mut v| v.remove(0));

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -78,7 +78,7 @@ impl ReadableStorageTraits for MemoryStore {
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let data_map = self.data_map.lock().unwrap();
         let data = data_map.get(key);

--- a/zarrs_storage/src/store_test.rs
+++ b/zarrs_storage/src/store_test.rs
@@ -67,7 +67,7 @@ pub fn store_read<T: ReadableStorageTraits>(store: &T) -> Result<(), Box<dyn Err
     assert_eq!(
         store.get_partial_values_key(
             &"a/b".try_into()?,
-            &mut [ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)].into_iter()
+            Box::new([ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)].into_iter())
         )?,
         Some(vec![vec![1].into(), vec![3].into()])
     );
@@ -251,7 +251,7 @@ pub async fn async_store_read<T: AsyncReadableStorageTraits>(
         store
             .get_partial_values_key(
                 &"a/b".try_into()?,
-                &mut [ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)].into_iter()
+                Box::new([ByteRange::FromStart(1, Some(1)), ByteRange::Suffix(1)].into_iter())
             )
             .await?,
         Some(vec![vec![1].into(), vec![3].into()])

--- a/zarrs_zip/src/lib.rs
+++ b/zarrs_zip/src/lib.rs
@@ -93,7 +93,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ZipStorageAdapter<TStorage> {
     fn get_impl(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         let mut zip_archive = self.zip_archive.lock().unwrap();
         let mut file = {
@@ -126,7 +126,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     fn get_partial_values_key(
         &self,
         key: &StoreKey,
-        byte_ranges: &mut dyn ByteRangeIterator,
+        byte_ranges: ByteRangeIterator,
     ) -> Result<Option<Vec<Bytes>>, StorageError> {
         self.get_impl(key, byte_ranges)
     }
@@ -264,8 +264,8 @@ mod tests {
     };
 
     // https://github.com/zip-rs/zip/blob/master/examples/write_dir.rs
-    fn zip_dir(
-        it: &mut dyn Iterator<Item = walkdir::DirEntry>,
+    fn zip_dir<I: Iterator<Item = walkdir::DirEntry>>(
+        it: I,
         prefix: &str,
         writer: File,
         method: zip::CompressionMethod,


### PR DESCRIPTION
Methods now consume `ByteRangeIterator`

Stage 1 of a transition of storage methods to iterators