### PR TITLE
refactor: simplify `[Async]ReadableStorageTraits`

### DIFF
--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -644,9 +644,7 @@ impl BytesPartialDecoderTraits for StoragePartialDecoder {
         decoded_regions: ByteRangeIterator,
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let bytes = self
-            .storage
-            .get_partial_values_key(&self.key, decoded_regions)?;
+        let bytes = self.storage.get_byte_ranges(&self.key, decoded_regions)?;
         if let Some(bytes) = bytes {
             let bytes = bytes
                 .map(|b| Ok::<_, StorageError>(Cow::Owned(b?.to_vec())))
@@ -684,7 +682,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
         let bytes = self
             .storage
-            .get_partial_values_key(&self.key, decoded_regions)
+            .get_byte_ranges(&self.key, decoded_regions)
             .await?;
         Ok(if let Some(bytes) = bytes {
             use futures::{StreamExt, TryStreamExt};
@@ -786,9 +784,7 @@ impl BytesPartialDecoderTraits for StoragePartialEncoder {
         decoded_regions: ByteRangeIterator,
         _options: &CodecOptions,
     ) -> Result<Option<Vec<RawBytes<'_>>>, CodecError> {
-        let results = self
-            .storage
-            .get_partial_values_key(&self.key, decoded_regions)?;
+        let results = self.storage.get_byte_ranges(&self.key, decoded_regions)?;
         if let Some(results) = results {
             Ok(Some(
                 results

--- a/zarrs_filesystem/src/lib.rs
+++ b/zarrs_filesystem/src/lib.rs
@@ -249,7 +249,7 @@ impl FilesystemStore {
 }
 
 impl ReadableStorageTraits for FilesystemStore {
-    fn get_partial_values_key<'a>(
+    fn get_byte_ranges<'a>(
         &'a self,
         key: &StoreKey,
         byte_ranges: ByteRangeIterator<'a>,

--- a/zarrs_http/src/lib.rs
+++ b/zarrs_http/src/lib.rs
@@ -99,7 +99,7 @@ impl ReadableStorageTraits for HTTPStore {
         }
     }
 
-    fn get_partial_values_key<'a>(
+    fn get_byte_ranges<'a>(
         &'a self,
         key: &StoreKey,
         byte_ranges: ByteRangeIterator<'a>,
@@ -232,9 +232,9 @@ mod tests {
         let store = HTTPStore::new("https://raw.githubusercontent.com/bad").unwrap();
         assert!(store.get(&"zarr.json".try_into().unwrap()).is_err());
         assert!(store
-            .get_partial_values_key(
+            .get_byte_range(
                 &"zarr.json".try_into().unwrap(),
-                Box::new([ByteRange::FromStart(0, None)].into_iter())
+                ByteRange::FromStart(0, None)
             )
             .is_err());
         assert!(store.size_key(&"zarr.json".try_into().unwrap()).is_err());

--- a/zarrs_object_store/src/lib.rs
+++ b/zarrs_object_store/src/lib.rs
@@ -99,7 +99,7 @@ impl<T: object_store::ObjectStore> AsyncReadableStorageTraits for AsyncObjectSto
         }
     }
 
-    async fn get_partial_values_key<'a>(
+    async fn get_byte_ranges<'a>(
         &'a self,
         key: &StoreKey,
         byte_ranges: ByteRangeIterator<'a>,

--- a/zarrs_storage/src/lib.rs
+++ b/zarrs_storage/src/lib.rs
@@ -22,7 +22,7 @@ mod store_key;
 mod store_prefix;
 
 pub mod byte_range;
-use byte_range::{ByteOffset, ByteRange, InvalidByteRangeError};
+use byte_range::{ByteOffset, InvalidByteRangeError};
 
 pub use maybe::{MaybeSend, MaybeSync};
 
@@ -126,29 +126,6 @@ type AsyncBytesIterator<'a> = futures::stream::BoxStream<'a, Result<Bytes, Stora
 #[cfg(feature = "async")]
 /// An asynchronous iterator of [`Bytes`] which may be [`None`] indicating the bytes are not present.
 pub type AsyncMaybeBytesIterator<'a> = Option<AsyncBytesIterator<'a>>;
-
-/// A [`StoreKey`] and [`ByteRange`].
-#[derive(Debug, Clone)]
-pub struct StoreKeyRange {
-    /// The key for the range.
-    key: StoreKey,
-    /// The byte range.
-    byte_range: ByteRange,
-}
-
-impl StoreKeyRange {
-    /// Create a new [`StoreKeyRange`].
-    #[must_use]
-    pub const fn new(key: StoreKey, byte_range: ByteRange) -> Self {
-        Self { key, byte_range }
-    }
-}
-
-impl std::fmt::Display for StoreKeyRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{}:{}", self.key, self.byte_range)
-    }
-}
 
 /// A [`StoreKey`], [`ByteOffset`], and value (bytes).
 #[derive(Debug, Clone)]

--- a/zarrs_storage/src/storage_adapter/async_to_sync.rs
+++ b/zarrs_storage/src/storage_adapter/async_to_sync.rs
@@ -58,12 +58,12 @@ impl<TStorage: ?Sized, TBlockOn: AsyncToSyncBlockOn> AsyncToSyncStorageAdapter<T
 impl<TStorage: ?Sized + AsyncReadableStorageTraits, TBlockOn: AsyncToSyncBlockOn>
     ReadableStorageTraits for AsyncToSyncStorageAdapter<TStorage, TBlockOn>
 {
-    fn get_partial_values_key<'a>(
+    fn get_byte_ranges<'a>(
         &'a self,
         key: &StoreKey,
         byte_ranges: ByteRangeIterator<'a>,
     ) -> Result<MaybeBytesIterator<'a>, StorageError> {
-        let results = self.block_on(self.storage.get_partial_values_key(key, byte_ranges))?;
+        let results = self.block_on(self.storage.get_byte_ranges(key, byte_ranges))?;
         if let Some(results) = results {
             let results = self.block_on(results.collect::<Vec<_>>());
             Ok(Some(Box::new(results.into_iter())))

--- a/zarrs_storage/src/storage_handle.rs
+++ b/zarrs_storage/src/storage_handle.rs
@@ -29,19 +29,12 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits for Storage
         self.0.get(key)
     }
 
-    fn get_partial_values_key<'a>(
+    fn get_byte_ranges<'a>(
         &'a self,
         key: &StoreKey,
         byte_ranges: ByteRangeIterator<'a>,
     ) -> Result<MaybeBytesIterator<'a>, StorageError> {
-        self.0.get_partial_values_key(key, byte_ranges)
-    }
-
-    fn get_partial_values(
-        &self,
-        key_ranges: &[super::StoreKeyRange],
-    ) -> Result<Vec<MaybeBytes>, StorageError> {
-        self.0.get_partial_values(key_ranges)
+        self.0.get_byte_ranges(key, byte_ranges)
     }
 
     fn size_key(&self, key: &super::StoreKey) -> Result<Option<u64>, super::StorageError> {
@@ -112,19 +105,12 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits> AsyncReadableStorageTraits
         self.0.get(key).await
     }
 
-    async fn get_partial_values_key<'a>(
+    async fn get_byte_ranges<'a>(
         &'a self,
         key: &StoreKey,
         byte_ranges: ByteRangeIterator<'a>,
     ) -> Result<AsyncMaybeBytesIterator<'a>, StorageError> {
-        self.0.get_partial_values_key(key, byte_ranges).await
-    }
-
-    async fn get_partial_values(
-        &self,
-        key_ranges: &[super::StoreKeyRange],
-    ) -> Result<Vec<MaybeBytes>, StorageError> {
-        self.0.get_partial_values(key_ranges).await
+        self.0.get_byte_ranges(key, byte_ranges).await
     }
 
     async fn size_key(&self, key: &super::StoreKey) -> Result<Option<u64>, super::StorageError> {

--- a/zarrs_storage/src/storage_value_io.rs
+++ b/zarrs_storage/src/storage_value_io.rs
@@ -68,18 +68,9 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Read for StorageValueIO<TStorage>
         let len = buf.len() as u64;
         let data = self
             .storage
-            .get_partial_values_key(
-                &self.key,
-                Box::new([ByteRange::FromStart(self.pos, Some(len))].into_iter()),
-            )
-            .map_err(|err| std::io::Error::other(err.to_string()))?
-            .map(|mut v| {
-                let bytes = v.next().expect("one byte range");
-                debug_assert!(v.next().is_none());
-                bytes
-            });
+            .get_byte_range(&self.key, ByteRange::FromStart(self.pos, Some(len)))
+            .map_err(|err| std::io::Error::other(err.to_string()))?;
         if let Some(data) = data {
-            let data = data.map_err(|e| std::io::Error::other(e.to_string()))?;
             buf.copy_from_slice(&data);
             self.pos += data.len() as u64;
             Ok(data.len())

--- a/zarrs_storage/src/store/memory_store.rs
+++ b/zarrs_storage/src/store/memory_store.rs
@@ -63,7 +63,7 @@ impl ReadableStorageTraits for MemoryStore {
         }
     }
 
-    fn get_partial_values_key<'a>(
+    fn get_byte_ranges<'a>(
         &'a self,
         key: &StoreKey,
         byte_ranges: ByteRangeIterator<'a>,

--- a/zarrs_zip/src/lib.rs
+++ b/zarrs_zip/src/lib.rs
@@ -124,7 +124,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> ZipStorageAdapter<TStorage> {
 impl<TStorage: ?Sized + ReadableStorageTraits> ReadableStorageTraits
     for ZipStorageAdapter<TStorage>
 {
-    fn get_partial_values_key<'a>(
+    fn get_byte_ranges<'a>(
         &'a self,
         key: &StoreKey,
         byte_ranges: ByteRangeIterator<'a>,


### PR DESCRIPTION
- Remove `StoreKeyRange`
- Revise `[Async]ReadableStorageTraits`:
  - Add `get_byte_range`
  - Rename `get_partial_values_key` to `get_byte_ranges`
  - Remove `get_partial_values_batched_by_key`

This is drifting further away from the [abstract store interface](https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html#id26) in the Zarr specification, which was not intended to be normative.