### PR TITLE
refactor: rename `[Async]{Array,Bytes}PartialDecoderTraits::size()` to `size_held()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,12 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `partial_decode[_into]()`: parameter `array_subsets: &[ArraySubset]` changed to `indexer: &dyn Indexer`
   - `partial_decode[_into]()`: returns `ArrayBytes<'_>` instead of `Vec<ArrayBytes<'_>>`
   - `partial_encode()`: parameter `subsets_and_bytes: &[(&ArraySubset, ArrayBytes<'_>)]` changed to `indexer: &dyn Indexer` and `bytes: &ArrayBytes<'_>`
-  - Rename `size()` to `size_held()`
+  - Rename `size()` to `size_held()` and add to `AsyncArrayPartialDecoderTraits`
 - **Breaking**: `[Async]BytesPartialDecoderTraits` trait changes:
   - Rename `partial_decode` to `partial_decode_many` and change parameter `decoded_regions: &[ByteRange]` to `ByteRangeIterator`
   - Add `partial_decode` for decoding a single byte range
   - Remove `partial_decode_concat`
-  - Rename `size()` to `size_held()`
+  - Rename `size()` to `size_held()` and add to `AsyncBytesPartialDecoderTraits`
 - **Breaking**: `[Async]BytesPartialEncoderTraits` trait changes:
   - Rename `partial_encode` to `partial_encode_many` and change parameter `offsets_and_bytes: &[(ByteOffset, RawBytes<'_>)]` to `offset_values: OffsetBytesIterator<crate::array::RawBytes<'_>>`
   - Add `partial_encode` for decoding a single byte range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,12 +69,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Major Breaking**: `[Async]ArrayPartialDecoderTraits` trait changes: 
   - `partial_decode[_into]()`: parameter `array_subsets: &[ArraySubset]` changed to `indexer: &dyn Indexer`
   - `partial_decode[_into]()`: returns `ArrayBytes<'_>` instead of `Vec<ArrayBytes<'_>>`
-- **Breaking**: `ArrayPartialEncoderTraits:` trait changes:
   - `partial_encode()`: parameter `subsets_and_bytes: &[(&ArraySubset, ArrayBytes<'_>)]` changed to `indexer: &dyn Indexer` and `bytes: &ArrayBytes<'_>`
+  - Rename `size()` to `size_held()`
 - **Breaking**: `[Async]BytesPartialDecoderTraits` trait changes:
   - Rename `partial_decode` to `partial_decode_many` and change parameter `decoded_regions: &[ByteRange]` to `ByteRangeIterator`
   - Add `partial_decode` for decoding a single byte range
   - Remove `partial_decode_concat`
+  - Rename `size()` to `size_held()`
 - **Breaking**: `[Async]BytesPartialEncoderTraits` trait changes:
   - Rename `partial_encode` to `partial_encode_many` and change parameter `offsets_and_bytes: &[(ByteOffset, RawBytes<'_>)]` to `offset_values: OffsetBytesIterator<crate::array::RawBytes<'_>>`
   - Add `partial_encode` for decoding a single byte range

--- a/zarrs/src/array/chunk_cache.rs
+++ b/zarrs/src/array/chunk_cache.rs
@@ -53,7 +53,7 @@ impl ChunkCacheType for ChunkCacheTypeDecoded {
 
 impl ChunkCacheType for ChunkCacheTypePartialDecoder {
     fn size(&self) -> usize {
-        self.as_ref().size()
+        self.as_ref().size_held()
     }
 }
 

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -297,7 +297,7 @@ pub trait ArrayCodecTraits: CodecTraits {
 /// Partial bytes decoder traits.
 pub trait BytesPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     /// Returns the size of chunk bytes held by the partial decoder.
-    fn size(&self) -> usize;
+    fn size_held(&self) -> usize;
 
     /// Partially decode a byte range.
     ///
@@ -344,7 +344,7 @@ pub trait BytesPartialDecoderTraits: Any + MaybeSend + MaybeSync {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait AsyncBytesPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     /// Returns the size of chunk bytes held by the partial decoder.
-    fn size(&self) -> usize;
+    fn size_held(&self) -> usize;
 
     /// Partially decode a byte range.
     ///
@@ -396,7 +396,7 @@ pub trait ArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     fn data_type(&self) -> &DataType;
 
     /// Returns the size of chunk bytes held by the partial decoder.
-    fn size(&self) -> usize;
+    fn size_held(&self) -> usize;
 
     /// Partially decode a chunk.
     ///
@@ -585,7 +585,7 @@ pub trait AsyncArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     fn data_type(&self) -> &DataType;
 
     /// Returns the size of chunk bytes held by the partial decoder.
-    fn size(&self) -> usize;
+    fn size_held(&self) -> usize;
 
     /// Partially decode a chunk.
     ///
@@ -636,7 +636,7 @@ impl StoragePartialDecoder {
 }
 
 impl BytesPartialDecoderTraits for StoragePartialDecoder {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         0
     }
 
@@ -676,7 +676,7 @@ impl AsyncStoragePartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         0
     }
 
@@ -704,7 +704,7 @@ impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
 }
 
 impl BytesPartialDecoderTraits for Mutex<Option<Vec<u8>>> {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.lock().unwrap().as_ref().map_or(0, Vec::len)
     }
 
@@ -774,7 +774,7 @@ impl StoragePartialEncoder {
 }
 
 impl BytesPartialDecoderTraits for StoragePartialEncoder {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         0
     }
 
@@ -1310,7 +1310,7 @@ pub trait BytesToBytesCodecTraits: CodecTraits + core::fmt::Debug {
 }
 
 impl BytesPartialDecoderTraits for Cow<'static, [u8]> {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.as_ref().len()
     }
 
@@ -1329,7 +1329,7 @@ impl BytesPartialDecoderTraits for Cow<'static, [u8]> {
 }
 
 impl BytesPartialDecoderTraits for Vec<u8> {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.len()
     }
 
@@ -1351,7 +1351,7 @@ impl BytesPartialDecoderTraits for Vec<u8> {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for Cow<'static, [u8]> {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.as_ref().len()
     }
 
@@ -1373,7 +1373,7 @@ impl AsyncBytesPartialDecoderTraits for Cow<'static, [u8]> {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for Vec<u8> {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.len()
     }
 

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -343,6 +343,9 @@ pub trait BytesPartialDecoderTraits: Any + MaybeSend + MaybeSync {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait AsyncBytesPartialDecoderTraits: Any + MaybeSend + MaybeSync {
+    /// Returns the size of chunk bytes held by the partial decoder.
+    fn size(&self) -> usize;
+
     /// Partially decode a byte range.
     ///
     /// Returns [`None`] if partial decoding of the input handle returns [`None`].
@@ -581,6 +584,9 @@ pub trait AsyncArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     /// Return the data type of the partial decoder.
     fn data_type(&self) -> &DataType;
 
+    /// Returns the size of chunk bytes held by the partial decoder.
+    fn size(&self) -> usize;
+
     /// Partially decode a chunk.
     ///
     /// # Errors
@@ -670,6 +676,10 @@ impl AsyncStoragePartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncStoragePartialDecoder {
+    fn size(&self) -> usize {
+        0
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,
@@ -1341,6 +1351,10 @@ impl BytesPartialDecoderTraits for Vec<u8> {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for Cow<'static, [u8]> {
+    fn size(&self) -> usize {
+        self.as_ref().len()
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,
@@ -1359,6 +1373,10 @@ impl AsyncBytesPartialDecoderTraits for Cow<'static, [u8]> {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for Vec<u8> {
+    fn size(&self) -> usize {
+        self.len()
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,

--- a/zarrs/src/array/codec.rs
+++ b/zarrs/src/array/codec.rs
@@ -297,6 +297,8 @@ pub trait ArrayCodecTraits: CodecTraits {
 /// Partial bytes decoder traits.
 pub trait BytesPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     /// Returns the size of chunk bytes held by the partial decoder.
+    ///
+    /// Intended for use by size-constrained partial decoder caches.
     fn size_held(&self) -> usize;
 
     /// Partially decode a byte range.
@@ -344,6 +346,8 @@ pub trait BytesPartialDecoderTraits: Any + MaybeSend + MaybeSync {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait AsyncBytesPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     /// Returns the size of chunk bytes held by the partial decoder.
+    ///
+    /// Intended for use by size-constrained partial decoder caches.
     fn size_held(&self) -> usize;
 
     /// Partially decode a byte range.
@@ -396,6 +400,8 @@ pub trait ArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     fn data_type(&self) -> &DataType;
 
     /// Returns the size of chunk bytes held by the partial decoder.
+    ///
+    /// Intended for use by size-constrained partial decoder caches.
     fn size_held(&self) -> usize;
 
     /// Partially decode a chunk.
@@ -585,6 +591,8 @@ pub trait AsyncArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
     fn data_type(&self) -> &DataType;
 
     /// Returns the size of chunk bytes held by the partial decoder.
+    ///
+    /// Intended for use by size-constrained partial decoder caches.
     fn size_held(&self) -> usize;
 
     /// Partially decode a chunk.

--- a/zarrs/src/array/codec/array_partial_decoder_cache.rs
+++ b/zarrs/src/array/codec/array_partial_decoder_cache.rs
@@ -60,7 +60,7 @@ impl ArrayPartialDecoderCache {
 }
 
 impl ArrayPartialDecoderTraits for ArrayPartialDecoderCache {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.cache.size()
     }
 
@@ -90,7 +90,7 @@ impl AsyncArrayPartialDecoderTraits for ArrayPartialDecoderCache {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.cache.size()
     }
 

--- a/zarrs/src/array/codec/array_partial_decoder_cache.rs
+++ b/zarrs/src/array/codec/array_partial_decoder_cache.rs
@@ -90,6 +90,10 @@ impl AsyncArrayPartialDecoderTraits for ArrayPartialDecoderCache {
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.cache.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_array/bitround.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround.rs
@@ -450,7 +450,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // bitround partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // bitround partial decoder does not hold bytes
         let decoded_regions = [
             ArraySubset::new_with_ranges(&[3..5]),
             ArraySubset::new_with_ranges(&[17..21]),

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec_partial.rs
@@ -50,8 +50,8 @@ where
         &self.data_type
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     fn partial_decode(
@@ -103,8 +103,8 @@ where
         &self.data_type
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec_partial.rs
@@ -103,6 +103,10 @@ where
         &self.data_type
     }
 
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_array/squeeze.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze.rs
@@ -235,7 +235,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // squeeze partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // squeeze partial decoder does not hold bytes
 
         let decoded_regions = [
             ArraySubset::new_with_ranges(&[0..1, 0..4, 0..1, 0..4, 0..1]),

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec_partial.rs
@@ -40,8 +40,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     fn partial_decode(
@@ -106,8 +106,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec_partial.rs
@@ -106,6 +106,10 @@ where
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_array/transpose.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose.rs
@@ -353,7 +353,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // transpose partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // transpose partial decoder does not hold bytes
         let decoded_regions = [
             ArraySubset::new_with_ranges(&[0..4, 0..4]),
             ArraySubset::new_with_ranges(&[1..3, 1..4]),

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec_partial.rs
@@ -112,6 +112,10 @@ where
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec_partial.rs
@@ -43,8 +43,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     fn partial_decode(
@@ -112,8 +112,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/bytes.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes.rs
@@ -316,7 +316,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // bytes partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // bytes partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode(&decoded_region, &CodecOptions::default())
             .unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec_partial.rs
@@ -51,8 +51,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     fn partial_decode(
@@ -120,8 +120,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec_partial.rs
@@ -120,6 +120,10 @@ where
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
+++ b/zarrs/src/array/codec/array_to_bytes/codec_chain.rs
@@ -887,7 +887,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), decoded.size()); // codec chain caches with most decompression codecs
+        assert_eq!(partial_decoder.size_held(), decoded.size()); // codec chain caches with most decompression codecs
         let decoded_partial_chunk = partial_decoder
             .partial_decode(decoded_region, &CodecOptions::default())
             .unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/packbits.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits.rs
@@ -311,7 +311,7 @@ mod tests {
                     &CodecOptions::default(),
                 )
                 .unwrap();
-            assert_eq!(partial_decoder.size(), input_handle.size()); // packbits partial decoder does not hold bytes
+            assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // packbits partial decoder does not hold bytes
             let decoded_partial_chunk = partial_decoder
                 .partial_decode(&decoded_region, &CodecOptions::default())
                 .unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
@@ -246,6 +246,10 @@ impl AsyncArrayPartialDecoderTraits for AsyncPackBitsPartialDecoder {
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
@@ -187,8 +187,8 @@ impl ArrayPartialDecoderTraits for PackBitsPartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode(
@@ -246,8 +246,8 @@ impl AsyncArrayPartialDecoderTraits for AsyncPackBitsPartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/pcodec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec.rs
@@ -368,7 +368,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // packbits partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // packbits partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode(&decoded_region, &CodecOptions::default())
             .unwrap();

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
@@ -169,6 +169,10 @@ impl AsyncArrayPartialDecoderTraits for AsyncPCodecPartialDecoder {
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/pcodec/pcodec_partial_decoder.rs
@@ -118,8 +118,8 @@ impl ArrayPartialDecoderTraits for PcodecPartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode(
@@ -169,8 +169,8 @@ impl AsyncArrayPartialDecoderTraits for AsyncPCodecPartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -735,8 +735,8 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            partial_decoder.size(),
-            input_handle.size() + size_of::<u64>() * 2 * 2 * 2 * 2
+            partial_decoder.size_held(),
+            input_handle.size_held() + size_of::<u64>() * 2 * 2 * 2 * 2
         ); // sharding partial decoder holds the shard index
         let decoded_partial_chunk = partial_decoder
             .partial_decode(&decoded_region, &CodecOptions::default())
@@ -778,8 +778,8 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            partial_decoder.size(),
-            input_handle.size() + size_of::<u64>() * 2 * 2 * 2
+            partial_decoder.size_held(),
+            input_handle.size_held() + size_of::<u64>() * 2 * 2 * 2
         ); // sharding partial decoder holds the shard index
         let decoded_partial_chunk = partial_decoder
             .partial_decode(&decoded_region, &CodecOptions::default())

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -110,8 +110,9 @@ impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
         self.shard_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size() + self.shard_index.as_ref().map_or(0, Vec::len) * size_of::<u64>()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
+            + self.shard_index.as_ref().map_or(0, Vec::len) * size_of::<u64>()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -110,6 +110,10 @@ impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
         self.shard_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_handle.size() + self.shard_index.as_ref().map_or(0, Vec::len) * size_of::<u64>()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -173,8 +173,9 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder {
         self.shard_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size() + self.shard_index.as_ref().map_or(0, Vec::len) * size_of::<u64>()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
+            + self.shard_index.as_ref().map_or(0, Vec::len) * size_of::<u64>()
     }
 
     fn partial_decode(

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -100,7 +100,7 @@ impl ArrayPartialDecoderTraits for ShardingPartialEncoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.shard_index.lock().unwrap().len()
     }
 

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
@@ -96,8 +96,8 @@ impl ArrayPartialDecoderTraits for VlenPartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode(
@@ -162,8 +162,8 @@ impl AsyncArrayPartialDecoderTraits for AsyncVlenPartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
@@ -162,6 +162,10 @@ impl AsyncArrayPartialDecoderTraits for AsyncVlenPartialDecoder {
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_partial_decoder.rs
@@ -53,8 +53,8 @@ impl ArrayPartialDecoderTraits for VlenV2PartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode(
@@ -103,8 +103,8 @@ impl AsyncArrayPartialDecoderTraits for AsyncVlenV2PartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_partial_decoder.rs
@@ -103,6 +103,10 @@ impl AsyncArrayPartialDecoderTraits for AsyncVlenV2PartialDecoder {
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_bytes/zfp.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp.rs
@@ -691,7 +691,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // zfp partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // zfp partial decoder does not hold bytes
 
         for (decoded_region, expected) in decoded_regions.into_iter().zip([
             vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
@@ -144,6 +144,10 @@ impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder {
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,

--- a/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/zfp/zfp_partial_decoder.rs
@@ -55,8 +55,8 @@ impl ArrayPartialDecoderTraits for ZfpPartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode(
@@ -144,8 +144,8 @@ impl AsyncArrayPartialDecoderTraits for AsyncZfpPartialDecoder {
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/byte_interval_partial_decoder.rs
+++ b/zarrs/src/array/codec/byte_interval_partial_decoder.rs
@@ -35,8 +35,8 @@ impl ByteIntervalPartialDecoder {
 }
 
 impl BytesPartialDecoderTraits for ByteIntervalPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode_many(
@@ -90,8 +90,8 @@ impl AsyncByteIntervalPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode_many<'a>(

--- a/zarrs/src/array/codec/byte_interval_partial_decoder.rs
+++ b/zarrs/src/array/codec/byte_interval_partial_decoder.rs
@@ -90,6 +90,10 @@ impl AsyncByteIntervalPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncByteIntervalPartialDecoder {
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         byte_ranges: ByteRangeIterator<'a>,

--- a/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
+++ b/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
@@ -76,6 +76,10 @@ impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for BytesPartialDecoderCache {
+    fn size(&self) -> usize {
+        self.cache.as_ref().map_or(0, Vec::len)
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,

--- a/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
+++ b/zarrs/src/array/codec/bytes_partial_decoder_cache.rs
@@ -50,7 +50,7 @@ impl BytesPartialDecoderCache {
 }
 
 impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.cache.as_ref().map_or(0, Vec::len)
     }
 
@@ -76,7 +76,7 @@ impl BytesPartialDecoderTraits for BytesPartialDecoderCache {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for BytesPartialDecoderCache {
-    fn size(&self) -> usize {
+    fn size_held(&self) -> usize {
         self.cache.as_ref().map_or(0, Vec::len)
     }
 

--- a/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/adler32.rs
@@ -152,7 +152,7 @@ mod tests {
                     &CodecOptions::default(),
                 )
                 .unwrap();
-            assert_eq!(partial_decoder.size(), input_handle.size()); // adler32 partial decoder does not hold bytes
+            assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // adler32 partial decoder does not hold bytes
             let decoded_partial_chunk = partial_decoder
                 .partial_decode_many(
                     Box::new(decoded_regions.into_iter()),

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc.rs
@@ -394,7 +394,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // blosc partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // blosc partial decoder does not hold bytes
         let decoded = partial_decoder
             .partial_decode_many(Box::new(decoded_regions), &CodecOptions::default())
             .unwrap()

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
@@ -79,6 +79,10 @@ impl AsyncBloscPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder {
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,

--- a/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/blosc/blosc_partial_decoder.rs
@@ -28,8 +28,8 @@ impl BloscPartialDecoder {
 }
 
 impl BytesPartialDecoderTraits for BloscPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode_many(
@@ -79,8 +79,8 @@ impl AsyncBloscPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncBloscPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode_many<'a>(

--- a/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/bz2.rs
@@ -134,7 +134,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // bz2 partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // bz2 partial decoder does not hold bytes
         let decoded = partial_decoder
             .partial_decode_many(Box::new(decoded_regions), &CodecOptions::default())
             .unwrap()

--- a/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/crc32c.rs
@@ -133,7 +133,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // crc32c partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // crc32c partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode_many(
                 Box::new(decoded_regions.into_iter()),

--- a/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/fletcher32.rs
@@ -147,7 +147,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // fletcher32 partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // fletcher32 partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode_many(
                 Box::new(decoded_regions.into_iter()),

--- a/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gdeflate.rs
@@ -349,7 +349,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // gdeflate partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // gdeflate partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode_many(
                 Box::new(decoded_regions.into_iter()),

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip.rs
@@ -141,7 +141,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // gzip partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // gzip partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode_many(
                 Box::new(decoded_regions.into_iter()),

--- a/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/shuffle.rs
@@ -125,7 +125,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // shuffle partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // shuffle partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode_many(
                 Box::new(decoded_regions.into_iter()),

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_prefix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_prefix_partial_decoder.rs
@@ -77,6 +77,10 @@ impl AsyncStripPrefixPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncStripPrefixPartialDecoder {
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_prefix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_prefix_partial_decoder.rs
@@ -31,8 +31,8 @@ impl StripPrefixPartialDecoder {
 }
 
 impl BytesPartialDecoderTraits for StripPrefixPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode_many(
@@ -77,8 +77,8 @@ impl AsyncStripPrefixPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncStripPrefixPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode_many<'a>(

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
@@ -85,6 +85,10 @@ impl AsyncStripSuffixPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncStripSuffixPartialDecoder {
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,

--- a/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/strip_suffix_partial_decoder.rs
@@ -31,8 +31,8 @@ impl StripSuffixPartialDecoder {
 }
 
 impl BytesPartialDecoderTraits for StripSuffixPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode_many(
@@ -85,8 +85,8 @@ impl AsyncStripSuffixPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncStripSuffixPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode_many<'a>(

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded.rs
@@ -62,7 +62,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // test unbounded partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // test unbounded partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode_many(
                 Box::new(decoded_regions.into_iter()),

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -66,6 +66,10 @@ impl AsyncTestUnboundedPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder {
+    fn size(&self) -> usize {
+        self.input_handle.size()
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,

--- a/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/test_unbounded/test_unbounded_partial_decoder.rs
@@ -24,8 +24,8 @@ impl TestUnboundedPartialDecoder {
 }
 
 impl BytesPartialDecoderTraits for TestUnboundedPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     fn partial_decode_many(
@@ -66,8 +66,8 @@ impl AsyncTestUnboundedPartialDecoder {
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncBytesPartialDecoderTraits for AsyncTestUnboundedPartialDecoder {
-    fn size(&self) -> usize {
-        self.input_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_handle.size_held()
     }
 
     async fn partial_decode_many<'a>(

--- a/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zlib.rs
@@ -135,7 +135,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // zlib partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // zlib partial decoder does not hold bytes
         let decoded = partial_decoder
             .partial_decode_many(Box::new(decoded_regions), &CodecOptions::default())
             .unwrap()

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
@@ -127,7 +127,7 @@ mod tests {
                 &CodecOptions::default(),
             )
             .unwrap();
-        assert_eq!(partial_decoder.size(), input_handle.size()); // zstd partial decoder does not hold bytes
+        assert_eq!(partial_decoder.size_held(), input_handle.size_held()); // zstd partial decoder does not hold bytes
         let decoded_partial_chunk = partial_decoder
             .partial_decode_many(
                 Box::new(decoded_regions.into_iter()),

--- a/zarrs/src/array/codec/codec_partial_default.rs
+++ b/zarrs/src/array/codec/codec_partial_default.rs
@@ -70,8 +70,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     fn partial_decode(
@@ -188,8 +188,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     fn partial_decode(
@@ -306,8 +306,8 @@ impl<T: ?Sized> BytesPartialDecoderTraits
 where
     T: BytesPartialDecoderTraits,
 {
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     fn partial_decode_many(
@@ -397,8 +397,8 @@ impl<T: ?Sized> AsyncArrayPartialDecoderTraits
 where
     T: AsyncArrayPartialDecoderTraits,
 {
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     fn data_type(&self) -> &super::DataType {
@@ -530,8 +530,8 @@ where
         self.decoded_representation.data_type()
     }
 
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     async fn partial_decode<'a>(
@@ -655,8 +655,8 @@ impl<T: ?Sized> AsyncBytesPartialDecoderTraits
 where
     T: AsyncBytesPartialDecoderTraits,
 {
-    fn size(&self) -> usize {
-        self.input_output_handle.size()
+    fn size_held(&self) -> usize {
+        self.input_output_handle.size_held()
     }
 
     async fn partial_decode_many<'a>(

--- a/zarrs/src/array/codec/codec_partial_default.rs
+++ b/zarrs/src/array/codec/codec_partial_default.rs
@@ -397,6 +397,10 @@ impl<T: ?Sized> AsyncArrayPartialDecoderTraits
 where
     T: AsyncArrayPartialDecoderTraits,
 {
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
     fn data_type(&self) -> &super::DataType {
         self.decoded_representation.data_type()
     }
@@ -526,6 +530,10 @@ where
         self.decoded_representation.data_type()
     }
 
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
     async fn partial_decode<'a>(
         &'a self,
         indexer: &dyn crate::indexer::Indexer,
@@ -647,6 +655,10 @@ impl<T: ?Sized> AsyncBytesPartialDecoderTraits
 where
     T: AsyncBytesPartialDecoderTraits,
 {
+    fn size(&self) -> usize {
+        self.input_output_handle.size()
+    }
+
     async fn partial_decode_many<'a>(
         &'a self,
         decoded_regions: ByteRangeIterator<'a>,

--- a/zarrs/tests/array_sync.rs
+++ b/zarrs/tests/array_sync.rs
@@ -127,7 +127,7 @@ fn array_sync_read_uncompressed() -> Result<(), Box<dyn std::error::Error>> {
     array_sync_read(&array)?;
 
     // uncompressed partial decoder holds no data
-    assert_eq!(array.partial_decoder(&[0, 0])?.size(), 0);
+    assert_eq!(array.partial_decoder(&[0, 0])?.size_held(), 0);
 
     Ok(())
 }
@@ -171,11 +171,11 @@ fn array_sync_read_shard_compress() -> Result<(), Box<dyn std::error::Error>> {
 
     // sharding partial decoder holds the shard index, which has double the number of elements
     assert_eq!(
-        array.partial_decoder(&[0, 0])?.size(),
+        array.partial_decoder(&[0, 0])?.size_held(),
         size_of::<u64>() * 4 * 2
     );
     // this chunk is empty, so it has no shard index
-    assert_eq!(array.partial_decoder(&[1, 1])?.size(), 0);
+    assert_eq!(array.partial_decoder(&[1, 1])?.size_held(), 0);
 
     Ok(())
 }


### PR DESCRIPTION
- add to async traits