### PR TITLE
chore: prepare zarrs 0.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.0] - 2025-09-17
 
+### Highlights
+- This release includes several **Major Breaking** changes that will certainly require changes to user code.
+- Many foundational traits have been refactored for consistency, simplicity, and to support new capabilities.
+- Initial generic indexing and WASM support
+- More partial encoding support. It remains experimental and lightly documented.
+- New experimental extensions (codecs, chunk grids, chunk key encodings).
+
 ### Added
 - Add `index_location` support to `vlen` codec
   - Add `VlenCodec::with_index_location()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.22.0] - 2025-09-17
+## [0.22.0] - 2025-09-18
 
 ### Highlights
 - This release includes several **Major Breaking** changes that will certainly require changes to user code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.22.0-beta.3] - 2025-09-17
-
-## [0.22.0-beta.2] - 2025-09-13
-
-## [0.22.0-beta.1] - 2025-09-07
-
-## [0.22.0-beta.0] - 2025-09-06
+## [0.22.0] - 2025-09-17
 
 ### Added
 - Add `index_location` support to `vlen` codec
@@ -167,6 +161,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `bitround` partial decoder needlessly rounding on decode
 
 [#245]: https://github.com/zarrs/zarrs/pull/245
+
+## [0.22.0-beta.3] - 2025-09-17
+
+## [0.22.0-beta.2] - 2025-09-13
+
+## [0.22.0-beta.1] - 2025-09-07
+
+## [0.22.0-beta.0] - 2025-09-06
 
 ## [0.21.2] - 2025-06-19
 
@@ -1565,7 +1567,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Initial public release
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs-v0.21.2...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs-v0.22.0...HEAD
+[0.22.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs-v0.22.0
 [0.22.0-beta.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs-v0.22.0-beta.3
 [0.22.0-beta.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs-v0.22.0-beta.2
 [0.22.0-beta.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs-v0.22.0-beta.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.2.2"
 path = "zarrs_plugin"
 
 [workspace.dependencies.zarrs_registry]
-version = "0.1.4"
+version = "0.1.5"
 path = "zarrs_registry"
 
 [workspace.dependencies.zarrs_storage]

--- a/zarrs/Cargo.toml
+++ b/zarrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs"
-version = "0.22.0-beta.3"
+version = "0.22.0"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.82"

--- a/zarrs_data_type/CHANGELOG.md
+++ b/zarrs_data_type/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2025-09-17
+
 ### Added
 - Implement `Clone` for `Error` structs
 
@@ -53,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - Split from the `zarrs::array::{data_type,fill_value}` modules of `zarrs` 0.20.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_data_type-v0.3.2...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_data_type-v0.3.3...HEAD
+[0.3.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_data_type-v0.3.3
 [0.3.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_data_type-v0.3.2
 [0.3.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_data_type-v0.3.1
 [0.3.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_data_type-v0.3.0

--- a/zarrs_data_type/CHANGELOG.md
+++ b/zarrs_data_type/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.3] - 2025-09-17
+## [0.3.3] - 2025-09-18
 
 ### Added
 - Implement `Clone` for `Error` structs

--- a/zarrs_filesystem/CHANGELOG.md
+++ b/zarrs_filesystem/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+## [0.3.0] - 2025-09-17
+
+### Changed
 - **Breaking**: Bump `zarrs_storage` to 0.4.0
 
 ## [0.2.3] - 2025-06-16
@@ -45,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Split from the `zarrs_storage` crate
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_filesystem-v0.2.3...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_filesystem-v0.3.0...HEAD
+[0.3.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_filesystem-v0.3.0
 [0.2.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_filesystem-v0.2.3
 [0.2.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_filesystem-v0.2.2
 [0.2.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_filesystem-v0.2.1

--- a/zarrs_filesystem/CHANGELOG.md
+++ b/zarrs_filesystem/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2025-09-17
+## [0.3.0] - 2025-09-18
 
 ### Changed
 - **Breaking**: Bump `zarrs_storage` to 0.4.0

--- a/zarrs_http/CHANGELOG.md
+++ b/zarrs_http/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+## [0.3.0] - 2025-09-17
+
+### Changed
 - **Breaking**: Bump `zarrs_storage` to 0.4.0
 
 ## [0.2.2] - 2025-05-16
@@ -36,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Split from the `zarrs_storage` crate
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_http-v0.2.2...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_http-v0.3.0...HEAD
+[0.3.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_http-v0.3.0
 [0.2.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_http-v0.2.2
 [0.2.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_http-v0.2.1
 [0.2.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_http-v0.2.0

--- a/zarrs_http/CHANGELOG.md
+++ b/zarrs_http/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2025-09-17
+## [0.3.0] - 2025-09-18
 
 ### Changed
 - **Breaking**: Bump `zarrs_storage` to 0.4.0

--- a/zarrs_metadata/CHANGELOG.md
+++ b/zarrs_metadata/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-09-17
+
 ### Added
 - Implement `Clone` for `Error` structs
 
@@ -187,7 +189,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 - Split from the `metadata` module of `zarrs` 0.17.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_metadata-v0.5.0...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_metadata-v0.6.0...HEAD
+[0.6.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.6.0
 [0.5.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.5.0
 [0.4.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.4.0
 [0.3.7]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata-v0.3.7

--- a/zarrs_metadata/CHANGELOG.md
+++ b/zarrs_metadata/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0] - 2025-09-17
+## [0.6.0] - 2025-09-18
 
 ### Added
 - Implement `Clone` for `Error` structs

--- a/zarrs_metadata_ext/CHANGELOG.md
+++ b/zarrs_metadata_ext/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-09-17
+
 ### Added
 - Add `index_location` field to `vlen` codec metadata
   - Adds `VlenIndexLocation` and `VlenCodecConfigurationV0_1` structs
@@ -41,7 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - rename `InvalidPermutationError` to `TransposeOrderError`
 - change the suffix of experimental codec configurations from V1 to V0 (`gdeflate`, `squeeze`, `vlen`, `vlen_v2`)
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_metadata_ext-v0.1.1...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_metadata_ext-v0.2.0...HEAD
+[0.2.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata_ext-v0.2.0
 [0.1.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata_ext-v0.1.1
 [0.1.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_metadata_ext-v0.1.0
 

--- a/zarrs_metadata_ext/CHANGELOG.md
+++ b/zarrs_metadata_ext/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2025-09-17
+## [0.2.0] - 2025-09-18
 
 ### Added
 - Add `index_location` field to `vlen` codec metadata

--- a/zarrs_object_store/CHANGELOG.md
+++ b/zarrs_object_store/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+## [0.5.0] - 2025-09-17
+
+### Changed
 - **Breaking**: Bump `zarrs_storage` to 0.4.0
 
 ## [0.4.3] - 2025-06-20
@@ -61,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Initial release
  - Split from the `storage` module of `zarrs` 0.17.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_object_store-v0.4.3...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_object_store-v0.5.0...HEAD
+[0.5.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_object_store-v0.5.0
 [0.4.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_object_store-v0.4.3
 [0.4.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_object_store-v0.4.2
 [0.4.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_object_store-v0.4.1

--- a/zarrs_object_store/CHANGELOG.md
+++ b/zarrs_object_store/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2025-09-17
+## [0.5.0] - 2025-09-18
 
 ### Changed
 - **Breaking**: Bump `zarrs_storage` to 0.4.0

--- a/zarrs_plugin/CHANGELOG.md
+++ b/zarrs_plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2025-09-17
+
 ### Added
 - Implement `Clone` for `Error` structs
 - Add `MaybeSend`/`MaybeSync` for WASM compatibility in dependent crates ([#245] by [@keller-mark])
@@ -43,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Initial release
  - Split from the `plugin` module of `zarrs` 0.20.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_plugin-v0.2.1...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_plugin-v0.2.2...HEAD
+[0.2.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_plugin-v0.2.2
 [0.2.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_plugin-v0.2.1
 [0.2.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_plugin-v0.2.0
 [0.1.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_plugin-v0.1.0

--- a/zarrs_plugin/CHANGELOG.md
+++ b/zarrs_plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.2] - 2025-09-17
+## [0.2.2] - 2025-09-18
 
 ### Added
 - Implement `Clone` for `Error` structs

--- a/zarrs_registry/CHANGELOG.md
+++ b/zarrs_registry/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2025.06-19
+
+### Fixed
+- Add `zarrs.squeeze` alias
+
 ## [0.1.4] - 2025-06-19
 
 ### Added

--- a/zarrs_registry/Cargo.toml
+++ b/zarrs_registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs_registry"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Lachlan Deakin <ljdgit@gmail.com>"]
 edition = "2021"
 rust-version = "1.77"

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0] - 2025-09-17
+## [0.4.0] - 2025-09-18
 
 ### Added
 - Implement `Clone` for `Error` structs

--- a/zarrs_storage/CHANGELOG.md
+++ b/zarrs_storage/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-09-17
+
 ### Added
 - Implement `Clone` for `Error` structs
 - Add `MaybeSend`/`MaybeSync` for WASM compatibility ([#245] by [@keller-mark])
@@ -132,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Initial release
  - Split from the `storage` module of `zarrs` 0.17.0-dev
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_storage-v0.3.4...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_storage-v0.4.0...HEAD
+[0.4.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_storage-v0.4.0
 [0.3.4]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_storage-v0.3.4
 [0.3.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_storage-v0.3.3
 [0.3.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_storage-v0.3.2

--- a/zarrs_zip/CHANGELOG.md
+++ b/zarrs_zip/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Changed
+## [0.3.0] - 2025-09-17
+
+### Changed
 - **Breaking**: Bump `zarrs_storage` to 0.4.0
 
-## Fixed
+### Fixed
 - Use `ZipFileSeek` instead of `ZipFile`, avoiding unnecessary reads
 
 ## [0.2.3] - 2025-06-19
@@ -43,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Split from the `zarrs_storage` crate
 
-[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_zip-v0.2.3...HEAD
+[unreleased]: https://github.com/zarrs/zarrs/compare/zarrs_zip-v0.3.0...HEAD
+[0.3.0]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_zip-v0.3.0
 [0.2.3]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_zip-v0.2.3
 [0.2.2]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_zip-v0.2.2
 [0.2.1]: https://github.com/LDeakin/zarrs/releases/tag/zarrs_zip-v0.2.1

--- a/zarrs_zip/CHANGELOG.md
+++ b/zarrs_zip/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2025-09-17
+## [0.3.0] - 2025-09-18
 
 ### Changed
 - **Breaking**: Bump `zarrs_storage` to 0.4.0


### PR DESCRIPTION
zarrs: 0.21 -> 0.22
zarrs_data_type: 0.3.2 -> 0.3.3
zarrs_filesystem: 0.2.3 -> 0.3.0
zarrs_http: 0.2.2 -> 0.3.0
zarrs_metadata: 0.5.0 -> 0.6.0
zarrs_metadata_ext: 0.1.1 -> 0.2.0
zarrs_object_store: 0.4.3 -> 0.5.0
zarrs_plugin: 0.2.1 -> 0.2.2
zarrs_registry: 0.1.4 -> 0.1.5
zarrs_storage: 0.3.4 -> 0.4.0
zarrs_zip: 0.2.3 -> 0.3.0