### PR TITLE
fix: match chunk grid docs style to codecs

### DIFF
--- a/zarrs/doc/status/chunk_grids.md
+++ b/zarrs/doc/status/chunk_grids.md
@@ -4,8 +4,8 @@
 | 🚧[`rectangular`]            | [ZEP0003] (draft) | &check; |         |              |
 | 🚧[`zarrs.regular_bounded`]  |                   | &check; |         |              |
 
-[`regular`]: crate::array::chunk_grid::RegularChunkGrid
-[`rectangular`]: crate::array::chunk_grid::RectangularChunkGrid
-[`zarrs.regular_bounded`]: crate::array::chunk_grid::RegularBoundedChunkGrid
+[`regular`]: crate::array::chunk_grid::regular
+[`rectangular`]: crate::array::chunk_grid::rectangular
+[`zarrs.regular_bounded`]: crate::array::chunk_grid::regular_bounded
 [ZEP0001]: https://zarr.dev/zeps/accepted/ZEP0001.html
 [ZEP0003]: https://zarr.dev/zeps/draft/ZEP0003.html

--- a/zarrs/doc/status/chunk_key_encodings.md
+++ b/zarrs/doc/status/chunk_key_encodings.md
@@ -2,7 +2,7 @@
 | ------------------------ | --------- | ------- | ------- | ------------ |
 | [`default`]              | [ZEP0001] | &check; |         |              |
 | [`v2`]                   | [ZEP0001] | &check; | &check; |              |
-| [`zarrs.default_suffix`] |           | &check; | &check; |              |
+| 🚧[`zarrs.default_suffix`] |           | &check; |         |              |
 
 [`default`]: crate::array::chunk_key_encoding::DefaultChunkKeyEncoding
 [`v2`]: crate::array::chunk_key_encoding::V2ChunkKeyEncoding

--- a/zarrs/src/array/chunk_grid/rectangular.rs
+++ b/zarrs/src/array/chunk_grid/rectangular.rs
@@ -1,8 +1,29 @@
 //! The `rectangular` chunk grid.
 //!
-//! This chunk grid is considered experimental as it is based on a draft Zarr enhancement proposal.
 //!
-//! See <https://zarr.dev/zeps/draft/ZEP0003.html>.
+//! <div class="warning">
+//! This chunk grid is experimental and may be incompatible with other Zarr V3 implementations.
+//! </div>
+//!
+//! # Compatible Implementations
+//! None
+//!
+//! # Specification
+//! - <https://zarr.dev/zeps/draft/ZEP0003.html>
+//!
+//! # Chunk Grid `name` Aliases (Zarr V3)
+//! - `rectangular`
+//!
+//! ### Chunk grid `configuration` Example - [`RectangularChunkGridConfiguration`]:
+//! ```rust
+//! # let JSON = r#"
+//! {
+//!   "chunk_shape": [[5, 5, 5, 15, 15, 20, 35], 10]
+//! }
+//! # "#;
+//! # use zarrs_metadata_ext::chunk_grid::rectangular::RectangularChunkGridConfiguration;
+//! # let configuration: RectangularChunkGridConfiguration = serde_json::from_str(JSON).unwrap();
+//! ```
 
 use derive_more::From;
 use itertools::Itertools;

--- a/zarrs/src/array/chunk_grid/regular.rs
+++ b/zarrs/src/array/chunk_grid/regular.rs
@@ -1,6 +1,24 @@
 //! The `regular` chunk grid.
 //!
-//! See <https://zarr-specs.readthedocs.io/en/latest/v3/chunk-grids/regular-grid/index.html>.
+//! # Compatible Implementations
+//! - All Zarr V3 implementations
+//!
+//! ### Specification
+//! - <https://zarr-specs.readthedocs.io/en/latest/v3/chunk-grids/regular-grid/index.html>
+//!
+//! ### Chunk grid `name` Aliases (Zarr V3)
+//! - `regular`
+//!
+//! ### Chunk grid `configuration` Example - [`RegularChunkGridConfiguration`]:
+//! ```rust
+//! # let JSON = r#"
+//! {
+//!   "chunk_shape": [100, 100]
+//! }
+//! # "#;
+//! # use zarrs_metadata_ext::chunk_grid::regular::RegularChunkGridConfiguration;
+//! # let configuration: RegularChunkGridConfiguration = serde_json::from_str(JSON).unwrap();
+//! ```
 
 use std::num::NonZeroU64;
 use thiserror::Error;

--- a/zarrs/src/array/chunk_grid/regular_bounded.rs
+++ b/zarrs/src/array/chunk_grid/regular_bounded.rs
@@ -1,4 +1,30 @@
 //! The `regular_bounded` chunk grid.
+//!
+//! This chunk grid is the same as `regular`, except that chunks at the edges of the array may be smaller than the specified chunk shape.
+//!
+//! <div class="warning">
+//! This chunk grid is experimental and may be incompatible with other Zarr V3 implementations.
+//! </div>
+//!
+//! ### Compatible Implementations
+//! None
+//!
+//! ### Specification
+//! - <https://chunkgrid.zarrs.dev/regular_bounded>
+//!
+//! ### Chunk Grid `name` Aliases (Zarr V3)
+//! - `zarrs.regular_bounded`
+//!
+//! ### Chunk Grid `configuration` Example - [`RegularBoundedChunkGridConfiguration`]:
+//! ```rust
+//! # let JSON = r#"
+//! {
+//!   "chunk_shape": [100, 100]
+//! }
+//! # "#;
+//! # use zarrs::array::chunk_grid::RegularBoundedChunkGridConfiguration;
+//! # let configuration: RegularBoundedChunkGridConfiguration = serde_json::from_str(JSON).unwrap();
+//! ```
 
 use itertools::izip;
 use std::num::NonZeroU64;
@@ -51,10 +77,6 @@ pub(crate) fn create_chunk_grid_regular_bounded(
 }
 
 /// A `regular_bounded` chunk grid.
-///
-/// <div class="warning">
-/// This chunk grid is experimental and may be incompatible with other Zarr V3 implementations.
-/// </div>
 #[allow(clippy::struct_field_names)]
 #[derive(Debug, Clone)]
 pub struct RegularBoundedChunkGrid {

--- a/zarrs/src/array/chunk_grid/regular_bounded.rs
+++ b/zarrs/src/array/chunk_grid/regular_bounded.rs
@@ -51,6 +51,10 @@ pub(crate) fn create_chunk_grid_regular_bounded(
 }
 
 /// A `regular_bounded` chunk grid.
+///
+/// <div class="warning">
+/// This chunk grid is experimental and may be incompatible with other Zarr V3 implementations.
+/// </div>
 #[allow(clippy::struct_field_names)]
 #[derive(Debug, Clone)]
 pub struct RegularBoundedChunkGrid {

--- a/zarrs/src/array/chunk_key_encoding/default_suffix.rs
+++ b/zarrs/src/array/chunk_key_encoding/default_suffix.rs
@@ -62,6 +62,10 @@ pub(crate) fn create_chunk_key_encoding_default_suffix(
 
 /// A `default_suffix` chunk key encoding.
 ///
+/// <div class="warning">
+/// This chunk key encoding is experimental and may be incompatible with other Zarr V3 implementations.
+/// </div>
+///
 /// This matches the functionality of the `default` chunk key encoding, but a suffix is appended to each key.
 #[derive(Debug, Clone)]
 pub struct DefaultSuffixChunkKeyEncoding {

--- a/zarrs/src/array/codec/array_to_array/reshape.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape.rs
@@ -2,6 +2,10 @@
 //!
 //! Performs a reshaping operation.
 //!
+//! <div class="warning">
+//! This codec is experimental and may be incompatible with other Zarr V3 implementations.
+//! </div>
+//!
 //! ### Compatible Implementations
 //! None
 //!


### PR DESCRIPTION
- add experimental warning boxes for default_suffix, regular_bounded, reshape