### PR TITLE
chore(CI): switch to `macos-15-intel` runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ["macos-13", "macos-latest"]
+        runner: ["macos-15-intel", "macos-latest"]
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
macos-13 is closing down