### PR TITLE
refactor!: remove `_opt` `Array`/`Group` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use `ChunkGridDecodedRef::as_chunk_grid()` to get the subchunk grid only if it is resolvable for the whole array
   - Add `ArrayError::MissingSubchunkGrid` for subchunk retrieval requests on arrays without a subchunk grid
 - Remove warnings from now-stable `reshape` codec
-- **Breaking**: Rename `[Array,Group]::metadata_opt()` to `metadata_to_store()`, and drop its options parameter
-  - The name now says what it returns: the metadata in the form `store_metadata` writes, with the metadata options applied
+- **Breaking**: Drop the options parameter of `[Array,Group]::metadata_opt()`, which now applies the metadata options stored on the array or group
   - `metadata()` is unchanged and still borrows the metadata as stored or constructed
 - `Array::clone()` is now cheap: the metadata document is shared behind an `Arc` rather than deep cloned
   - This makes deriving an array with different options practical on a hot path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improves the API for computing partial decoding granularity
   - Subchunk-producing codecs and partial decoders now expose ordered subchunk-grid hierarchies
     so nested sharding levels can be selected independently
+- **Breaking behavioural change**: Changing the dimensionality of an array after it has been created or opened is now invalid - the dimensionality is fixed for the lifetime of an `Array`
+  - `ArrayMutOps::set_shape()` and `Array::set_shape_and_chunk_grid()` now return the new `ArrayCreateError::ChangedDimensionality` error if the new shape has a different number of dimensions, rather than applying it
+  - `set_shape_and_chunk_grid()` previously permitted this, which stranded the dimension names and produced array metadata that could not be reopened
+  - `set_shape()` previously failed only incidentally, when the chunk grid rejected the new shape, and with an error that did not identify the cause
+  - Both are now rejected before the array is modified. Resizing an array within the same dimensionality is unaffected
+  - Create a new array to change the dimensionality
 - **Behavioural change**: Chunk grids no longer support out-of-bounds operations or unlimited dimensions - resize before extending arrays
   - Reading/writing completely out-of-bounds chunks is now an error
   - Querying completely out-of-bounds chunks always returns `None`
@@ -101,6 +107,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `vlen` index endianness handling to use actual index data type rather than `uint64`
 - Fixed a panic when retrieving an array subset spanning multiple chunks through a chunk cache with a nested optional data type (e.g. `Option<Option<u8>>`)
   - Only the outermost mask was allocated, so inner masks were also dropped
+- **Breaking**: `ArrayMutOps::set_dimension_names()` now writes through to the array metadata, and returns a `Result`
+  - It previously updated only the decoded dimension names, so `store_metadata()` silently wrote the old ones
+  - Returns `ArrayCreateError::InvalidDimensionNames` if the number of names does not match the array dimensionality
+- Dimension names set on a Zarr V2 array are now carried into the converted metadata by `Array::metadata_opt()` and `Array::to_v3()`
+  - Zarr V2 metadata has no dimension names field, so they were previously dropped even when the metadata was converted to Zarr V3
 
 ## [0.23.13](https://github.com/zarrs/zarrs/releases/tag/zarrs-v0.23.13) - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `Copy` for `GroupMetadataOptions`
 - Add `ArrayCached<TStorage, C>` — a wrapper that pairs an `Array` with a chunk cache
 - Add operation traits decoupling array methods from the `Array` type: `ArrayOps`, `ArrayReadOps`, `ArrayWriteOps`, `ArrayUpdateOps`, `ArrayMutOps`, and async variants
-  - Promote previously private methods to public: `retrieve_chunk_into`, `retrieve_chunk_subset_into`, `async_retrieve_chunk_into`, `async_retrieve_chunk_subset_into`
-  - Add `ArrayReadOps::{retrieve_subchunk_opt,retrieve_subchunks_opt}` and `_at_level` variants for interacting with nested subchunk grids
+  - Promote previously private methods to public: `[async_]retrieve_chunk_into`, `[async_]retrieve_chunk_subset_into`
+  - Add `ArrayReadOps::{retrieve_subchunk,retrieve_subchunks}` and `_at_level` variants for interacting with nested subchunk grids
   - These are implemented as inherent traits on `Array` and `ArrayCached`
+  - Operations take no options arguments. They use the options stored on the array, exposed by `ArrayOps::{codec_options,metadata_options,metadata_erase_version}`
 - Add `CodecChainBound` and `ArrayOps::codecs_bound` for data type and fill value context-bound codec runtime operations
 - Implement `Clone` for `ArrayBuilder`
 - Add `ArrayReadOps::local_subchunk_grid[_at_level]` for chunk-local subchunk grids
@@ -24,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-export `ChunkGridDecoded` and `ChunkGridDecodedRef` from `zarrs::array`
 - Expose `ShardingCodecBound` and `[Async]ShardingPartialDecoder` APIs for low-level encoded subchunk access (see `sharding` module docs)
 - Add efficient asynchronous partial encoding for the `sharding_indexed` codec
+- Add `ArrayOps::{with_codec_options,with_metadata_options,with_metadata_erase_version}()` to derive an array that uses different options, replacing the removed `_opt` method variants
+  - These are trait methods taking `&self`, so code generic over the operation traits can override options
+  - Implemented for `Array` and for `ArrayCached`, where the derived array shares the chunk cache with the original
+- Add `ArrayMutOps::set_metadata_erase_version()`
+- Add `ArrayOps::recommended_codec_concurrency()`, previously a private `Array` method
+- Add `ArrayCached::with_codec_specific_options()`; codec-specific reconfiguration was previously unreachable on a cached array
+- Add `Group::{metadata_options,with_metadata_options,metadata_erase_version,with_metadata_erase_version}()`
 
 ### Changed
 - Retrieve child-node metadata concurrently in asynchronous hierarchy discovery
@@ -62,8 +70,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use `ChunkGridDecodedRef::as_chunk_grid()` to get the subchunk grid only if it is resolvable for the whole array
   - Add `ArrayError::MissingSubchunkGrid` for subchunk retrieval requests on arrays without a subchunk grid
 - Remove warnings from now-stable `reshape` codec
+- **Breaking**: Rename `[Array,Group]::metadata_opt()` to `metadata_to_store()`, and drop its options parameter
+  - The name now says what it returns: the metadata in the form `store_metadata` writes, with the metadata options applied
+  - `metadata()` is unchanged and still borrows the metadata as stored or constructed
+- `Array::clone()` is now cheap: the metadata document is shared behind an `Arc` rather than deep cloned
+  - This makes deriving an array with different options practical on a hot path
+- **Breaking**: `Array::{with_codec_options,with_metadata_options,with_metadata_erase_version,with_codec_specific_options}()` and `Group::{with_metadata_options,with_metadata_erase_version}()` now take `&self` rather than `self`
+  - Chained forms such as `builder.build(..)?.with_codec_options(o)` are unaffected
+- Implement `Clone` for `Group`
 
 ### Removed
+- **Breaking**: Remove the `_opt` variants of the array and group operation methods
+  - Operations now use the options stored on the array or group, so `store_array_subset_opt(.., &options)` becomes `store_array_subset(..)`
+  - To use different options, derive a value that carries them: `array.clone().with_codec_options(options).store_array_subset(..)`, or `set_codec_options()` where the array is owned. `Array` and `Group` are cheap to clone
+  - Constructors keep their `_opt` variants, since they have no array or group to read options from: `[Array,Group]::[async_]open_opt`, `Group::new_with_metadata_opt`, `Hierarchy::[async_]open_opt`, `Node::[async_]open_opt`, `[async_]get_child_nodes_opt`
 - **Breaking**: Remove `ArrayShardedReadableExt`
   - Most methods have become part of `ArrayReadOps`'
   - `[async_]retrieve_encoded_subchunk` is removed; use `ShardingPartialDecoder::retrieve_subchunk_encoded` or `AsyncShardingPartialDecoder::retrieve_subchunk_encoded` for low-level encoded subchunk access
@@ -75,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use the generic `store_*` and `retrieve_*` methods with `Vec<T>` or `ndarray::Array<T, D>` instead
 
 ### Fixed
+- `Array::with_codec_specific_options()` left the subchunk grids stale, unlike `ArrayMutOps::set_codec_specific_options()`; it now delegates to it so the two cannot diverge
 - `async_get_child_nodes_opt` now ignores unrecognised listed prefixes consistently with sync discovery
 - Make async sharding `partial_decode_into` use the same subchunk-aware path as sync decoding
 - The partial decode granularity potentially being incorrect with multiple array-to-array codecs

--- a/zarrs/examples/data_type_optional.rs
+++ b/zarrs/examples/data_type_optional.rs
@@ -44,9 +44,10 @@ N marks missing (`None`=`null`) values:
         .clone(),
     )
     .build(store.clone(), "/array")?;
-    array.store_metadata_opt(
-        &zarrs::array::ArrayMetadataOptions::default().with_include_zarrs_metadata(false),
-    )?;
+    let array = array.with_metadata_options(
+        zarrs::array::ArrayMetadataOptions::default().with_include_zarrs_metadata(false),
+    );
+    array.store_metadata()?;
 
     println!("Array metadata:\n{}", array.metadata().to_string_pretty());
 

--- a/zarrs/examples/data_type_optional_nested.rs
+++ b/zarrs/examples/data_type_optional_nested.rs
@@ -38,9 +38,10 @@ N marks missing (`None`=`null`) values. SN marks `Some(None)`=`[null]` values:
         .clone(),
     )
     .build(store.clone(), "/array")?;
-    array.store_metadata_opt(
-        &zarrs::array::ArrayMetadataOptions::default().with_include_zarrs_metadata(false),
-    )?;
+    let array = array.with_metadata_options(
+        zarrs::array::ArrayMetadataOptions::default().with_include_zarrs_metadata(false),
+    );
+    array.store_metadata()?;
 
     println!("Array metadata:\n{}", array.metadata().to_string_pretty());
 

--- a/zarrs/examples/zarr_v2_to_v3.rs
+++ b/zarrs/examples/zarr_v2_to_v3.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     // println!(
     //     "The equivalent Zarr V3 group metadata is\n{}\n",
-    //     group.clone().with_metadata_options(convert_group_metadata_to_v3).metadata_to_store().to_string_pretty()
+    //     group.clone().with_metadata_options(convert_group_metadata_to_v3).metadata_opt().to_string_pretty()
     // );
 
     // Create a Zarr V2 array
@@ -100,7 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     // println!(
     //     "The equivalent Zarr V3 array metadata is\n{}\n",
-    //     array.clone().with_metadata_options(convert_array_metadata_to_v3).metadata_to_store().to_string_pretty()
+    //     array.clone().with_metadata_options(convert_array_metadata_to_v3).metadata_opt().to_string_pretty()
     // );
 
     array.store_chunk(&[0, 1], &[0.0f32; 5 * 5])?;

--- a/zarrs/examples/zarr_v2_to_v3.rs
+++ b/zarrs/examples/zarr_v2_to_v3.rs
@@ -39,7 +39,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let convert_group_metadata_to_v3 =
         GroupMetadataOptions::default().with_metadata_convert_version(MetadataConvertVersion::V3);
     group.store_metadata()?;
-    group.store_metadata_opt(&convert_group_metadata_to_v3)?;
+    group
+        .clone()
+        .with_metadata_options(convert_group_metadata_to_v3)
+        .store_metadata()?;
     println!(
         "group/.zgroup (Zarr V2 group metadata):\n{}\n",
         key_to_str(&store, "group/.zgroup")?
@@ -54,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     // println!(
     //     "The equivalent Zarr V3 group metadata is\n{}\n",
-    //     group.metadata_opt(&convert_group_metadata_to_v3).to_string_pretty()
+    //     group.clone().with_metadata_options(convert_group_metadata_to_v3).metadata_to_store().to_string_pretty()
     // );
 
     // Create a Zarr V2 array
@@ -79,7 +82,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let convert_array_metadata_to_v3 =
         ArrayMetadataOptions::default().with_metadata_convert_version(MetadataConvertVersion::V3);
     array.store_metadata()?;
-    array.store_metadata_opt(&convert_array_metadata_to_v3)?;
+    array
+        .clone()
+        .with_metadata_options(convert_array_metadata_to_v3)
+        .store_metadata()?;
     println!(
         "group/array/.zarray (Zarr V2 array metadata):\n{}\n",
         key_to_str(&store, "group/array/.zarray")?
@@ -94,7 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     // println!(
     //     "The equivalent Zarr V3 array metadata is\n{}\n",
-    //     array.metadata_opt(&convert_array_metadata_to_v3).to_string_pretty()
+    //     array.clone().with_metadata_options(convert_array_metadata_to_v3).metadata_to_store().to_string_pretty()
     // );
 
     array.store_chunk(&[0, 1], &[0.0f32; 5 * 5])?;

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -144,12 +144,22 @@ pub fn chunk_shape_to_array_shape(chunk_shape: &[std::num::NonZeroU64]) -> Array
 ///  - [`codecs`](Array::codecs)
 ///  - [`storage_transformers`](Array::storage_transformers)
 ///  - [`path`](Array::path)
+///  - [`dimensionality`](Array::dimensionality), see [Array Dimensionality](#array-dimensionality) below
 ///
 /// ### Mutable Array Metadata
 /// Do not forget to store metadata after mutation.
 ///  - [`shape`](Array::shape) / [`set_shape`](Array::set_shape) / [`set_shape_and_chunk_grid`](Array::set_shape_and_chunk_grid)
 ///  - [`attributes`](Array::attributes) / [`attributes_mut`](Array::attributes_mut)
 ///  - [`dimension_names`](Array::dimension_names) / [`set_dimension_names`](Array::set_dimension_names)
+///
+/// ### Array Dimensionality
+/// The dimensionality of an array is **fixed** for the lifetime of an [`Array`].
+/// It is established when the array is created or opened, and the data type, codec chain, chunk grid, chunk keys and dimension names are all bound to it.
+///
+/// An array can be resized within its dimensionality, but it cannot gain or lose dimensions:
+/// [`set_shape`](Array::set_shape) and [`set_shape_and_chunk_grid`](Array::set_shape_and_chunk_grid) return
+/// [`ArrayCreateError::ChangedDimensionality`] if the new shape has a different number of dimensions, and the array is left unmodified.
+/// Create a new array to change the dimensionality.
 ///
 /// ### `zarrs` Metadata
 /// By default, the `zarrs` version and a link to its source code is written to the `_zarrs` attribute in array metadata when calling [`store_metadata`](Array::store_metadata).
@@ -726,8 +736,12 @@ impl<TStorage: ?Sized> Array<TStorage> {
     /// This method allows setting both the array shape and chunk grid simultaneously.
     /// Some chunk grids depend on the array shape (e.g. `rectilinear`), so this method ensures that the chunk grid is correctly configured for the new array shape.
     ///
+    /// The dimensionality of an array is fixed once it has been created or opened, so
+    /// `array_shape` must have the same length as the current [`shape`](ArrayOps::shape).
+    ///
     /// # Errors
     /// Returns an [`ArrayCreateError`] if:
+    ///  - `array_shape` changes the array dimensionality,
     ///  - the chunk grid is not compatible with `array_shape`, or
     ///  - the chunk grid metadata is invalid.
     ///
@@ -746,6 +760,15 @@ impl<TStorage: ?Sized> Array<TStorage> {
         let chunk_grid_metadata: builder::ArrayBuilderChunkGridMetadata =
             chunk_grid_metadata.into();
         let chunk_grid_metadata = chunk_grid_metadata.to_metadata()?;
+
+        // The dimensionality of an array is fixed once it exists: the codec chain, chunk keys and
+        // dimension names are all bound to it. Checked before any mutation.
+        if array_shape.len() != self.dimensionality() {
+            return Err(ArrayCreateError::ChangedDimensionality(
+                array_shape.len(),
+                self.dimensionality(),
+            ));
+        }
 
         // Create the new chunk grid
         self.chunk_grid = ChunkGrid::from_metadata(&chunk_grid_metadata, &array_shape)
@@ -799,9 +822,11 @@ impl<TStorage: ?Sized> Array<TStorage> {
         let ArrayMetadata::V2(v2) = &*self.metadata else {
             return Ok(self);
         };
-        let metadata: ArrayMetadata = array_metadata_v2_to_v3(v2)?.into();
+        let mut v3 = array_metadata_v2_to_v3(v2)?;
+        // Zarr V2 metadata has no dimension names to convert, so take the array's
+        v3.dimension_names.clone_from(&self.dimension_names);
         Ok(Self {
-            metadata: Arc::new(metadata),
+            metadata: Arc::new(ArrayMetadata::V3(v3)),
             ..self
         })
     }
@@ -1244,6 +1269,148 @@ mod tests {
                 &serde_json::Value::String("apple".to_string())
             ))
         );
+    }
+
+    /// Setting dimension names must reach the metadata document, otherwise `store_metadata`
+    /// would silently drop them.
+    #[test]
+    fn array_set_dimension_names_reaches_metadata() {
+        use zarrs_metadata::IntoDimensionName;
+
+        let mut array = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type::uint8(), 0u8)
+            .build(Arc::new(MemoryStore::new()), "/array")
+            .unwrap();
+
+        array
+            .set_dimension_names(Some(vec![
+                "y".into_dimension_name(),
+                "x".into_dimension_name(),
+            ]))
+            .unwrap();
+        assert_eq!(
+            array.dimension_names(),
+            &Some(vec!["y".into_dimension_name(), "x".into_dimension_name()])
+        );
+        match array.metadata() {
+            ArrayMetadata::V3(metadata) => {
+                assert_eq!(
+                    metadata.dimension_names,
+                    Some(vec!["y".into_dimension_name(), "x".into_dimension_name()])
+                );
+            }
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
+
+        // Clearing them writes through too
+        array.set_dimension_names(None).unwrap();
+        match array.metadata() {
+            ArrayMetadata::V3(metadata) => assert_eq!(metadata.dimension_names, None),
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
+    }
+
+    /// Dimension names that do not match the array dimensionality are rejected on creation, so
+    /// they must not be reachable through the mutators either.
+    #[test]
+    fn array_set_dimension_names_rejects_invalid() {
+        use zarrs_metadata::IntoDimensionName;
+
+        let mut array = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type::uint8(), 0u8)
+            .dimension_names(["y", "x"].into())
+            .build(Arc::new(MemoryStore::new()), "/array")
+            .unwrap();
+
+        // Wrong number of names
+        assert_eq!(
+            array
+                .set_dimension_names(Some(vec![
+                    "z".into_dimension_name(),
+                    "y".into_dimension_name(),
+                    "x".into_dimension_name(),
+                ]))
+                .unwrap_err()
+                .to_string(),
+            "the number of dimension names 3 does not match array dimensionality 2"
+        );
+    }
+
+    /// The dimensionality of an array is fixed once it has been created or opened.
+    #[test]
+    fn array_dimensionality_is_fixed() {
+        let mut array = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type::uint8(), 0u8)
+            .dimension_names(["y", "x"].into())
+            .build(Arc::new(MemoryStore::new()), "/array")
+            .unwrap();
+
+        assert_eq!(
+            array.set_shape(vec![4, 4, 4]).unwrap_err().to_string(),
+            "cannot change the array dimensionality from 2 to 3"
+        );
+        assert_eq!(
+            unsafe { array.set_shape_and_chunk_grid(vec![4, 4, 4], vec![2, 2, 2]) }
+                .unwrap_err()
+                .to_string(),
+            "cannot change the array dimensionality from 2 to 3"
+        );
+
+        // Rejected before the array is modified
+        assert_eq!(array.shape(), &[8, 8]);
+        assert_eq!(array.dimensionality(), 2);
+        assert_eq!(array.chunk_grid_shape(), &[2, 2]);
+
+        // Resizing within the same dimensionality is still permitted
+        array.set_shape(vec![16, 16]).unwrap();
+        assert_eq!(array.shape(), &[16, 16]);
+        unsafe { array.set_shape_and_chunk_grid(vec![4, 4], vec![2, 2]) }.unwrap();
+        assert_eq!(array.shape(), &[4, 4]);
+    }
+
+    /// Zarr V2 metadata has no dimension names field, but a Zarr V2 array may still be written as
+    /// Zarr V3, so setting them must be permitted and must survive the conversion.
+    #[test]
+    fn array_v2_set_dimension_names_survives_v3_conversion() {
+        use zarrs_metadata::IntoDimensionName;
+        use zarrs_metadata::v2::{ArrayMetadataV2, DataTypeMetadataV2};
+
+        let metadata = ArrayMetadataV2::new(
+            vec![10, 10],
+            vec![std::num::NonZeroU64::new(5).unwrap(); 2],
+            DataTypeMetadataV2::Simple("<i4".to_string()),
+            FillValueMetadata::from(0),
+            None, // compressor
+            None, // filters
+        );
+        let mut array = Array::new_with_metadata(
+            Arc::new(MemoryStore::new()),
+            "/",
+            ArrayMetadata::V2(metadata),
+        )
+        .unwrap();
+
+        let names = vec!["y".into_dimension_name(), "x".into_dimension_name()];
+        array.set_dimension_names(Some(names.clone())).unwrap();
+        assert_eq!(array.dimension_names(), &Some(names.clone()));
+
+        // Written as Zarr V3, the names are carried into the converted metadata
+        let converted = array
+            .with_metadata_options(
+                ArrayMetadataOptions::default()
+                    .with_metadata_convert_version(MetadataConvertVersion::V3),
+            )
+            .metadata_opt();
+        match converted {
+            ArrayMetadata::V3(metadata) => {
+                assert_eq!(metadata.dimension_names, Some(names.clone()));
+            }
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
+
+        // As does `to_v3`
+        let array_v3 = array.to_v3().unwrap();
+        match array_v3.metadata() {
+            ArrayMetadata::V3(metadata) => assert_eq!(metadata.dimension_names, Some(names)),
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
     }
 
     #[test]

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -44,7 +44,6 @@ pub mod storage_transformer;
 mod array_dlpack_ext;
 
 use std::borrow::Cow;
-use std::num::NonZeroU64;
 use std::sync::Arc;
 
 pub use self::array_cached::ArrayCached;
@@ -128,11 +127,11 @@ pub fn chunk_shape_to_array_shape(chunk_shape: &[std::num::NonZeroU64]) -> Array
 ///  - the metadata is in invalid in some other way.
 ///
 /// ## Array Metadata
-/// Array metadata **must be explicitly stored** with [`store_metadata`](Array::store_metadata) or [`store_metadata_opt`](Array::store_metadata_opt) if an array is newly created or its metadata has been mutated.
+/// Array metadata **must be explicitly stored** with [`store_metadata`](Array::store_metadata) if an array is newly created or its metadata has been mutated.
 ///
-/// The underlying metadata of an [`Array`] can be accessed with [`metadata`](Array::metadata) or [`metadata_opt`](Array::metadata_opt).
+/// The underlying metadata of an [`Array`] can be accessed with [`metadata`](Array::metadata) or [`metadata_to_store`](Array::metadata_to_store).
 /// The latter accepts [`ArrayMetadataOptions`] that can be used to convert array metadata from Zarr V2 to V3, for example.
-/// [`metadata_opt`](Array::metadata_opt) is used internally by [`store_metadata`](Array::store_metadata) / [`store_metadata_opt`](Array::store_metadata_opt).
+/// [`metadata_to_store`](Array::metadata_to_store) is used internally by [`store_metadata`](Array::store_metadata).
 /// Use [`serde_json::to_string`] or [`serde_json::to_string_pretty`] on [`ArrayMetadata`] to convert it to a JSON string.
 ///
 /// ### Immutable Array Metadata / Properties
@@ -153,7 +152,7 @@ pub fn chunk_shape_to_array_shape(chunk_shape: &[std::num::NonZeroU64]) -> Array
 ///
 /// ### `zarrs` Metadata
 /// By default, the `zarrs` version and a link to its source code is written to the `_zarrs` attribute in array metadata when calling [`store_metadata`](Array::store_metadata).
-/// Override this behaviour globally with [`Config::set_include_zarrs_metadata`](crate::config::Config::set_include_zarrs_metadata) or call [`store_metadata_opt`](Array::store_metadata_opt) with an explicit [`ArrayMetadataOptions`].
+/// Override this behaviour globally with [`Config::set_include_zarrs_metadata`](crate::config::Config::set_include_zarrs_metadata), or per array with [`Array::with_metadata_options`] / [`ArrayMutOps::set_metadata_options`].
 ///
 /// ## Array Data
 /// Array operations are divided into several categories based on the traits implemented for the backing [storage](crate::storage).
@@ -338,8 +337,8 @@ pub fn chunk_shape_to_array_shape(chunk_shape: &[std::num::NonZeroU64]) -> Array
 /// Additionally, the *subchunk grid* can be queried, which is a [`ChunkGrid`](chunk_grid) where chunk indices refer to subchunks rather than shards.
 ///
 /// [`ArrayReadOps`] adds methods to conveniently access the data in a sharded array:
-///  - [`retrieve_subchunk_opt`](ArrayReadOps::retrieve_subchunk_opt)
-///  - [`retrieve_subchunks_opt`](ArrayReadOps::retrieve_subchunks_opt)
+///  - [`retrieve_subchunk`](ArrayReadOps::retrieve_subchunk)
+///  - [`retrieve_subchunks`](ArrayReadOps::retrieve_subchunks)
 ///
 /// For unsharded arrays, these methods gracefully fallback to referencing standard chunks.
 ///
@@ -422,8 +421,12 @@ pub struct Array<TStorage: ?Sized> {
     storage_transformers: StorageTransformerChain,
     /// An optional list of dimension names.
     dimension_names: Option<Vec<DimensionName>>,
-    /// Metadata used to create the array
-    metadata: ArrayMetadata,
+    /// Metadata used to create the array.
+    ///
+    /// Shared behind an [`Arc`] so that cloning an [`Array`] (e.g. to override its options with
+    /// [`with_codec_options`](Array::with_codec_options)) does not deep clone the metadata
+    /// document, whose size is unbounded in the user attributes it carries.
+    metadata: Arc<ArrayMetadata>,
     /// Options
     codec_options: CodecOptions,
     metadata_options: ArrayMetadataOptions,
@@ -585,7 +588,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
             codecs_bound,
             storage_transformers,
             dimension_names: v3.dimension_names.clone(),
-            metadata: ArrayMetadata::V3(v3),
+            metadata: Arc::new(ArrayMetadata::V3(v3)),
             codec_options,
             metadata_options,
             metadata_erase_version,
@@ -678,17 +681,10 @@ impl<TStorage: ?Sized> Array<TStorage> {
             storage_transformers,
             dimension_names: None,
             codec_options,
-            metadata: ArrayMetadata::V2(v2),
+            metadata: Arc::new(ArrayMetadata::V2(v2)),
             metadata_options,
             metadata_erase_version,
         })
-    }
-
-    /// Set the codec options.
-    #[must_use]
-    pub fn with_codec_options(mut self, codec_options: CodecOptions) -> Self {
-        self.codec_options = codec_options;
-        self
     }
 
     /// Reconfigure the codec chain with codec-specific options and return the updated array.
@@ -714,23 +710,14 @@ impl<TStorage: ?Sized> Array<TStorage> {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn with_codec_specific_options(
-        mut self,
+        &self,
         opts: &CodecSpecificOptions,
     ) -> Result<Self, CodecCreateError> {
-        self.codecs =
-            Arc::new(Arc::unwrap_or_clone(self.codecs).with_codec_specific_options(opts)?);
-        self.codecs_bound = self
-            .codecs
-            .clone()
-            .with_context(self.data_type.clone(), self.fill_value.clone())?;
-        Ok(self)
-    }
-
-    /// Set the metadata options.
-    #[must_use]
-    pub fn with_metadata_options(mut self, metadata_options: ArrayMetadataOptions) -> Self {
-        self.metadata_options = metadata_options;
-        self
+        // Delegate so that there is a single implementation. `set_codec_specific_options` also
+        // recomputes `subchunk_grids`, which this used to leave stale.
+        let mut array = self.clone();
+        array.set_codec_specific_options(opts)?;
+        Ok(array)
     }
 
     /// Set the array shape and chunk grid from chunk grid metadata.
@@ -767,7 +754,7 @@ impl<TStorage: ?Sized> Array<TStorage> {
             .decoded_subchunk_grids((&self.chunk_grid).into())?;
 
         // Update metadata based on version
-        match &mut self.metadata {
+        match Arc::make_mut(&mut self.metadata) {
             ArrayMetadata::V3(metadata) => {
                 metadata.shape = array_shape;
                 metadata.chunk_grid = chunk_grid_metadata;
@@ -803,42 +790,19 @@ impl<TStorage: ?Sized> Array<TStorage> {
             .expect("data type and fill value are compatible")
     }
 
-    /// Calculate the recommended codec concurrency.
-    fn recommended_codec_concurrency(
-        &self,
-        chunk_shape: &[NonZeroU64],
-    ) -> Result<RecommendedConcurrency, ArrayError> {
-        Ok(self.codecs_bound().recommended_concurrency(chunk_shape)?)
-    }
-
     /// Convert the array to Zarr V3.
     ///
     /// # Errors
     /// Returns a [`ArrayMetadataV2ToV3Error`] if the metadata is not compatible with Zarr V3 metadata.
     pub fn to_v3(self) -> Result<Self, ArrayMetadataV2ToV3Error> {
-        match self.metadata {
-            ArrayMetadata::V2(metadata) => {
-                let metadata: ArrayMetadata = array_metadata_v2_to_v3(&metadata)?.into();
-                Ok(Self {
-                    storage: self.storage,
-                    path: self.path,
-                    data_type: self.data_type,
-                    chunk_grid: self.chunk_grid,
-                    subchunk_grids: self.subchunk_grids,
-                    chunk_key_encoding: self.chunk_key_encoding,
-                    fill_value: self.fill_value,
-                    codecs: self.codecs,
-                    codecs_bound: self.codecs_bound,
-                    storage_transformers: self.storage_transformers,
-                    dimension_names: self.dimension_names,
-                    metadata,
-                    codec_options: self.codec_options,
-                    metadata_options: self.metadata_options,
-                    metadata_erase_version: self.metadata_erase_version,
-                })
-            }
-            ArrayMetadata::V3(_) => Ok(self),
-        }
+        let ArrayMetadata::V2(v2) = &*self.metadata else {
+            return Ok(self);
+        };
+        let metadata: ArrayMetadata = array_metadata_v2_to_v3(v2)?.into();
+        Ok(Self {
+            metadata: Arc::new(metadata),
+            ..self
+        })
     }
 
     /// Reject the array if it contains unsupported extensions or additional fields with `"must_understand": true`.
@@ -1194,6 +1158,8 @@ fn create_codec_chain_from_v2(
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use zarrs_filesystem::FilesystemStore;
 
     use super::*;
@@ -1210,10 +1176,41 @@ mod tests {
             .build(store.clone(), array_path)
             .unwrap();
         array.store_metadata().unwrap();
-        let stored_metadata = array.metadata_opt(&ArrayMetadataOptions::default());
+        let stored_metadata = array.metadata_to_store();
 
         let array_other = Array::open(store, array_path).unwrap();
         assert_eq!(array_other.metadata(), &stored_metadata);
+    }
+
+    /// The metadata document is shared behind an [`Arc`], so mutating a clone must not be
+    /// visible through the original. This guards against a missing [`Arc::make_mut`].
+    #[test]
+    fn array_clone_metadata_is_copy_on_write() {
+        let store = Arc::new(MemoryStore::new());
+        let array = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type::uint8(), 0u8)
+            .build(store, "/array")
+            .unwrap();
+
+        let mut clone = array.clone();
+        clone.set_shape(vec![16, 16]).unwrap();
+        clone
+            .attributes_mut()
+            .insert("test".to_string(), "apple".into());
+
+        assert_eq!(array.shape(), &[8, 8]);
+        assert!(array.attributes().is_empty());
+        assert_eq!(clone.shape(), &[16, 16]);
+        assert_eq!(clone.attributes().len(), 1);
+
+        // The shape/attribute edits must have reached the metadata document too, not just the
+        // decoded fields.
+        match array.metadata() {
+            ArrayMetadata::V3(metadata) => {
+                assert_eq!(metadata.shape, vec![8, 8]);
+                assert!(metadata.attributes.is_empty());
+            }
+            ArrayMetadata::V2(_) => panic!("expected V3 metadata"),
+        }
     }
 
     #[test]
@@ -1412,12 +1409,14 @@ mod tests {
         // Store V2 and V3 metadata
         for version in [MetadataConvertVersion::Default, MetadataConvertVersion::V3] {
             array_out
-                .store_metadata_opt(
-                    &ArrayMetadataOptions::default()
+                .clone()
+                .with_metadata_options(
+                    ArrayMetadataOptions::default()
                         .with_metadata_convert_version(version)
                         .with_include_zarrs_metadata(false)
                         .with_convert_aliased_extension_names(true),
                 )
+                .store_metadata()
                 .unwrap();
         }
     }
@@ -1542,10 +1541,13 @@ mod tests {
 
         println!(
             "{:?}",
-            array_in.metadata_opt(
-                &ArrayMetadataOptions::default()
-                    .with_metadata_convert_version(MetadataConvertVersion::V3)
-            )
+            array_in
+                .clone()
+                .with_metadata_options(
+                    ArrayMetadataOptions::default()
+                        .with_metadata_convert_version(MetadataConvertVersion::V3)
+                )
+                .metadata_to_store()
         );
 
         println!("{array_in:?}");

--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -129,9 +129,10 @@ pub fn chunk_shape_to_array_shape(chunk_shape: &[std::num::NonZeroU64]) -> Array
 /// ## Array Metadata
 /// Array metadata **must be explicitly stored** with [`store_metadata`](Array::store_metadata) if an array is newly created or its metadata has been mutated.
 ///
-/// The underlying metadata of an [`Array`] can be accessed with [`metadata`](Array::metadata) or [`metadata_to_store`](Array::metadata_to_store).
-/// The latter accepts [`ArrayMetadataOptions`] that can be used to convert array metadata from Zarr V2 to V3, for example.
-/// [`metadata_to_store`](Array::metadata_to_store) is used internally by [`store_metadata`](Array::store_metadata).
+/// The underlying metadata of an [`Array`] can be accessed with [`metadata`](Array::metadata) or [`metadata_opt`](Array::metadata_opt).
+/// The latter applies the array's [`ArrayMetadataOptions`], which can convert array metadata from Zarr V2 to V3, for example.
+/// Use [`Array::with_metadata_options`] / [`ArrayMutOps::set_metadata_options`] to control them.
+/// [`metadata_opt`](Array::metadata_opt) is used internally by [`store_metadata`](Array::store_metadata).
 /// Use [`serde_json::to_string`] or [`serde_json::to_string_pretty`] on [`ArrayMetadata`] to convert it to a JSON string.
 ///
 /// ### Immutable Array Metadata / Properties
@@ -1176,7 +1177,7 @@ mod tests {
             .build(store.clone(), array_path)
             .unwrap();
         array.store_metadata().unwrap();
-        let stored_metadata = array.metadata_to_store();
+        let stored_metadata = array.metadata_opt();
 
         let array_other = Array::open(store, array_path).unwrap();
         assert_eq!(array_other.metadata(), &stored_metadata);
@@ -1547,7 +1548,7 @@ mod tests {
                     ArrayMetadataOptions::default()
                         .with_metadata_convert_version(MetadataConvertVersion::V3)
                 )
-                .metadata_to_store()
+                .metadata_opt()
         );
 
         println!("{array_in:?}");

--- a/zarrs/src/array/array_cached.rs
+++ b/zarrs/src/array/array_cached.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use super::Array;
+use zarrs_codec::{CodecCreateError, CodecSpecificOptions};
 
 /// A cached array wrapper.
 ///
@@ -79,6 +80,33 @@ impl<TStorage: ?Sized, C> ArrayCached<TStorage, C> {
     #[must_use]
     pub fn cache(&self) -> &C {
         self.cache.as_ref()
+    }
+
+    /// Reconfigure the codec chain with codec-specific options.
+    ///
+    /// Refer to [`Array::with_codec_specific_options`] for details. The chunk cache is shared
+    /// with the original.
+    ///
+    /// # Errors
+    /// Returns a [`CodecCreateError`] if a codec cannot be reconfigured or rebound.
+    pub fn with_codec_specific_options(
+        &self,
+        opts: &CodecSpecificOptions,
+    ) -> Result<Self, CodecCreateError> {
+        Ok(Self {
+            array: Arc::new(self.array.with_codec_specific_options(opts)?),
+            cache: self.cache.clone(),
+        })
+    }
+
+    /// Derive a new cached array from a transformed inner array, sharing the cache.
+    ///
+    /// `f` is expected to clone internally, so this does not clone the inner [`Array`] itself.
+    pub(crate) fn map_array(&self, f: impl FnOnce(&Array<TStorage>) -> Array<TStorage>) -> Self {
+        Self {
+            array: Arc::new(f(&self.array)),
+            cache: self.cache.clone(),
+        }
     }
 
     /// Split into the inner array and shared cache.

--- a/zarrs/src/array/array_dlpack_ext.rs
+++ b/zarrs/src/array/array_dlpack_ext.rs
@@ -79,7 +79,6 @@ mod tests {
     // use dlpark::{IntoDLPack, ManagedTensor};
 
     use crate::array::{ArrayBuilder, ArraySubset, Tensor, data_type, transmute_to_bytes};
-    use zarrs_codec::CodecOptions;
     use zarrs_storage::store::MemoryStore;
 
     #[test]
@@ -92,10 +91,7 @@ mod tests {
             .store_chunk(&[0, 0], &[0.0f32, 1.0, 2.0, 3.0])
             .unwrap();
         let tensor: Tensor = array
-            .retrieve_chunks_opt(
-                &ArraySubset::new_with_shape(vec![1, 2]),
-                &CodecOptions::default(),
-            )
+            .retrieve_chunks(&ArraySubset::new_with_shape(vec![1, 2]))
             .unwrap();
 
         let managed_tensor = dlpark::versioned::SafeManagedTensorVersioned::new(tensor).unwrap();

--- a/zarrs/src/array/array_errors.rs
+++ b/zarrs/src/array/array_errors.rs
@@ -66,6 +66,9 @@ pub enum ArrayCreateError {
     /// The number of dimension names does not match the array dimensionality.
     #[error("the number of dimension names {0} does not match array dimensionality {1}")]
     InvalidDimensionNames(usize, usize),
+    /// The dimensionality of an array cannot be changed after it is created or opened.
+    #[error("cannot change the array dimensionality from {1} to {0}")]
+    ChangedDimensionality(usize, usize),
     /// Storage error.
     #[error(transparent)]
     StorageError(#[from] StorageError),

--- a/zarrs/src/array/array_ops.rs
+++ b/zarrs/src/array/array_ops.rs
@@ -1,3 +1,51 @@
+//! Array operation traits.
+//!
+//! These traits decouple the array operations from the [`Array`] type, so that they can also be
+//! implemented by wrappers such as [`ArrayCached`].
+//!
+//! # Codec and metadata options
+//!
+//! Operations do not take options as arguments. They use the options stored on the array:
+//! [`codec_options`](ArrayOps::codec_options), [`metadata_options`](ArrayOps::metadata_options)
+//! and [`metadata_erase_version`](ArrayOps::metadata_erase_version).
+//!
+//! To use different options, derive an array that carries them with
+//! [`with_codec_options`](ArrayOps::with_codec_options),
+//! [`with_metadata_options`](ArrayOps::with_metadata_options) or
+//! [`with_metadata_erase_version`](ArrayOps::with_metadata_erase_version). [`Array`] is cheap to
+//! clone: the storage, data type, chunk grid, codec chain and metadata are all shared behind an
+//! [`Arc`], and [`ArrayCached`] additionally shares its chunk cache.
+//!
+//! ```rust,no_run
+//! # use std::sync::Arc;
+//! # use zarrs::array::{Array, ArrayOps, ArrayReadOps, CodecOptions};
+//! # let store = Arc::new(zarrs::storage::store::MemoryStore::new());
+//! # let array = Array::open(store, "/group/array")?;
+//! // Default options
+//! let chunk: Vec<f32> = array.retrieve_chunk(&[0, 0])?;
+//!
+//! // Overridden options. Derive once and reuse, rather than per operation.
+//! let tuned = array.with_codec_options(CodecOptions::default().with_concurrent_target(1));
+//! let chunk: Vec<f32> = tuned.retrieve_chunk(&[0, 0])?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+//!
+//! Because these are [`ArrayOps`] methods, code generic over the operation traits can override
+//! options too:
+//!
+//! ```rust
+//! # use zarrs::array::{ArrayOps, ArrayWriteOps};
+//! # use zarrs::config::MetadataEraseVersion;
+//! fn erase_all_metadata<A: ArrayWriteOps>(array: &A) -> Result<(), zarrs::storage::StorageError> {
+//!     array
+//!         .with_metadata_erase_version(MetadataEraseVersion::All)
+//!         .erase_metadata()
+//! }
+//! ```
+//!
+//! Where the array is owned, [`ArrayMutOps::set_codec_options`] mutates it in place instead,
+//! avoiding the clone.
+
 use std::sync::Arc;
 
 use super::chunk_cache::ChunkCache;

--- a/zarrs/src/array/array_ops/array_mut_ops.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops.rs
@@ -33,6 +33,12 @@ pub trait ArrayMutOps: ArrayOps {
     /// Set the metadata options.
     fn set_metadata_options(&mut self, metadata_options: ArrayMetadataOptions) -> &mut Self;
 
+    /// Set the metadata erase version.
+    fn set_metadata_erase_version(
+        &mut self,
+        metadata_erase_version: MetadataEraseVersion,
+    ) -> &mut Self;
+
     /// Set the array shape.
     ///
     /// # Errors

--- a/zarrs/src/array/array_ops/array_mut_ops.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops.rs
@@ -41,13 +41,28 @@ pub trait ArrayMutOps: ArrayOps {
 
     /// Set the array shape.
     ///
+    /// The dimensionality of an array is fixed once it has been created or opened, so
+    /// `array_shape` must have the same length as the current [`shape`](super::ArrayOps::shape).
+    ///
     /// # Errors
-    /// Returns an [`ArrayCreateError`] if the chunk grid is not compatible with `array_shape`.
+    /// Returns an [`ArrayCreateError`] if `array_shape` changes the array dimensionality, or the
+    /// chunk grid is not compatible with `array_shape`.
     #[allow(clippy::missing_errors_doc)]
     fn set_shape(&mut self, array_shape: ArrayShape) -> Result<&mut Self, super::ArrayCreateError>;
 
     /// Set the dimension names.
-    fn set_dimension_names(&mut self, dimension_names: Option<Vec<DimensionName>>) -> &mut Self;
+    ///
+    /// Zarr V2 metadata has no dimension names field, so for a Zarr V2 array these are only
+    /// written on store if the metadata options convert the metadata to Zarr V3.
+    ///
+    /// # Errors
+    /// Returns an [`ArrayCreateError`](super::ArrayCreateError) if `dimension_names` is `Some` and
+    /// its length does not match the array dimensionality.
+    #[allow(clippy::missing_errors_doc)]
+    fn set_dimension_names(
+        &mut self,
+        dimension_names: Option<Vec<DimensionName>>,
+    ) -> Result<&mut Self, super::ArrayCreateError>;
 
     /// Mutably borrow the array attributes.
     fn attributes_mut(&mut self) -> &mut serde_json::Map<String, serde_json::Value>;

--- a/zarrs/src/array/array_ops/array_mut_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops_array.rs
@@ -1,4 +1,5 @@
 use inherent::inherent;
+use std::sync::Arc;
 use zarrs_codec::ArrayToBytesCodecSubchunkingTraits;
 
 use super::{ArrayMutOps, *};
@@ -36,13 +37,21 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
         self
     }
 
+    pub fn set_metadata_erase_version(
+        &mut self,
+        metadata_erase_version: MetadataEraseVersion,
+    ) -> &mut Self {
+        self.metadata_erase_version = metadata_erase_version;
+        self
+    }
+
     pub fn set_shape(&mut self, array_shape: ArrayShape) -> Result<&mut Self, ArrayCreateError> {
         self.chunk_grid = ChunkGrid::from_metadata(&self.chunk_grid.metadata(), &array_shape)
             .map_err(ArrayCreateError::ChunkGridCreateError)?;
         self.subchunk_grids = self
             .codecs_bound
             .decoded_subchunk_grids((&self.chunk_grid).into())?;
-        match &mut self.metadata {
+        match Arc::make_mut(&mut self.metadata) {
             ArrayMetadata::V3(metadata) => {
                 metadata.shape = array_shape;
             }
@@ -62,7 +71,7 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
     }
 
     pub fn attributes_mut(&mut self) -> &mut serde_json::Map<String, serde_json::Value> {
-        match &mut self.metadata {
+        match Arc::make_mut(&mut self.metadata) {
             ArrayMetadata::V3(metadata) => &mut metadata.attributes,
             ArrayMetadata::V2(metadata) => &mut metadata.attributes,
         }

--- a/zarrs/src/array/array_ops/array_mut_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_mut_ops_array.rs
@@ -46,6 +46,15 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
     }
 
     pub fn set_shape(&mut self, array_shape: ArrayShape) -> Result<&mut Self, ArrayCreateError> {
+        // The dimensionality of an array is fixed once it exists. Most chunk grids would reject
+        // this anyway, but not with a consistent error. Checked before any mutation.
+        if array_shape.len() != self.dimensionality() {
+            return Err(ArrayCreateError::ChangedDimensionality(
+                array_shape.len(),
+                self.dimensionality(),
+            ));
+        }
+
         self.chunk_grid = ChunkGrid::from_metadata(&self.chunk_grid.metadata(), &array_shape)
             .map_err(ArrayCreateError::ChunkGridCreateError)?;
         self.subchunk_grids = self
@@ -62,12 +71,33 @@ impl<TStorage: ?Sized> ArrayMutOps for Array<TStorage> {
         Ok(self)
     }
 
+    /// Set the dimension names.
+    ///
+    /// # Errors
+    /// Returns an [`ArrayCreateError`] if `dimension_names` is `Some` and its length does not
+    /// match the array dimensionality.
     pub fn set_dimension_names(
         &mut self,
         dimension_names: Option<Vec<DimensionName>>,
-    ) -> &mut Self {
+    ) -> Result<&mut Self, ArrayCreateError> {
+        // Matches the validation performed when an array is created
+        if let Some(dimension_names) = &dimension_names
+            && dimension_names.len() != self.dimensionality()
+        {
+            return Err(ArrayCreateError::InvalidDimensionNames(
+                dimension_names.len(),
+                self.dimensionality(),
+            ));
+        }
+
+        // Write through to the metadata document, otherwise `store_metadata` would not see the
+        // change. Zarr V2 metadata has no dimension names field; they are carried into the
+        // converted metadata by `metadata_opt` when it converts to Zarr V3.
+        if let ArrayMetadata::V3(metadata) = Arc::make_mut(&mut self.metadata) {
+            metadata.dimension_names.clone_from(&dimension_names);
+        }
         self.dimension_names = dimension_names;
-        self
+        Ok(self)
     }
 
     pub fn attributes_mut(&mut self) -> &mut serde_json::Map<String, serde_json::Value> {

--- a/zarrs/src/array/array_ops/array_ops.rs
+++ b/zarrs/src/array/array_ops/array_ops.rs
@@ -1,4 +1,5 @@
 use super::*;
+use zarrs_codec::{ArrayCodecTraits, RecommendedConcurrency};
 
 /// Core array operations.
 pub trait ArrayOps {
@@ -38,14 +39,55 @@ pub trait ArrayOps {
     /// Get the storage transformers.
     fn storage_transformers(&self) -> &StorageTransformerChain;
 
-    /// Get the default codec options for no-options methods.
+    /// Get the codec options used by the array operations.
+    ///
+    /// Override them with [`with_codec_options`](ArrayOps::with_codec_options), or
+    /// [`ArrayMutOps::set_codec_options`] where the array is owned.
     fn codec_options(&self) -> &CodecOptions;
 
-    /// Get the default array metadata options for no-options methods.
+    /// Get the array metadata options used by the array operations.
+    ///
+    /// Override them with [`with_metadata_options`](ArrayOps::with_metadata_options), or
+    /// [`ArrayMutOps::set_metadata_options`] where the array is owned.
     fn metadata_options(&self) -> &ArrayMetadataOptions;
 
-    /// Get the default metadata erase version for no-options methods.
+    /// Get the metadata erase version used by the array operations.
+    ///
+    /// Override it with
+    /// [`with_metadata_erase_version`](ArrayOps::with_metadata_erase_version), or
+    /// [`ArrayMutOps::set_metadata_erase_version`] where the array is owned.
     fn metadata_erase_version(&self) -> MetadataEraseVersion;
+
+    /// Return a copy of this array that uses `codec_options` for its operations.
+    ///
+    /// Prefer deriving once and reusing the result over deriving per operation.
+    #[must_use]
+    fn with_codec_options(&self, codec_options: CodecOptions) -> Self
+    where
+        Self: Sized;
+
+    /// Return a copy of this array that uses `metadata_options` for its operations.
+    #[must_use]
+    fn with_metadata_options(&self, metadata_options: ArrayMetadataOptions) -> Self
+    where
+        Self: Sized;
+
+    /// Return a copy of this array that uses `metadata_erase_version` for its operations.
+    #[must_use]
+    fn with_metadata_erase_version(&self, metadata_erase_version: MetadataEraseVersion) -> Self
+    where
+        Self: Sized;
+
+    /// Calculate the recommended codec concurrency.
+    ///
+    /// # Errors
+    /// Returns an [`ArrayError`] if the codec chain cannot report its recommended concurrency.
+    fn recommended_codec_concurrency(
+        &self,
+        chunk_shape: &[std::num::NonZeroU64],
+    ) -> Result<RecommendedConcurrency, ArrayError> {
+        Ok(self.codecs_bound().recommended_concurrency(chunk_shape)?)
+    }
 
     /// Get the dimension names.
     fn dimension_names(&self) -> &Option<Vec<DimensionName>>;
@@ -56,10 +98,13 @@ pub trait ArrayOps {
     /// Return the underlying array metadata.
     fn metadata(&self) -> &ArrayMetadata;
 
-    /// Return a new [`ArrayMetadata`] with [`ArrayMetadataOptions`] applied.
+    /// Return the array metadata in the form that [`Array::store_metadata`] writes.
     ///
-    /// This method is used internally by [`Array::store_metadata`] and [`Array::store_metadata_opt`].
-    fn metadata_opt(&self, options: &ArrayMetadataOptions) -> ArrayMetadata;
+    /// Unlike [`metadata`](ArrayOps::metadata), which borrows the metadata as it was stored or
+    /// constructed, this applies [`metadata_options`](ArrayOps::metadata_options): it may inject
+    /// `zarrs` provenance attributes, convert between Zarr versions, and rewrite aliased
+    /// extension names.
+    fn metadata_to_store(&self) -> ArrayMetadata;
 
     /// Create an array builder matching the parameters of this array.
     fn builder(&self) -> ArrayBuilder;

--- a/zarrs/src/array/array_ops/array_ops.rs
+++ b/zarrs/src/array/array_ops/array_ops.rs
@@ -104,7 +104,7 @@ pub trait ArrayOps {
     /// constructed, this applies [`metadata_options`](ArrayOps::metadata_options): it may inject
     /// `zarrs` provenance attributes, convert between Zarr versions, and rewrite aliased
     /// extension names.
-    fn metadata_to_store(&self) -> ArrayMetadata;
+    fn metadata_opt(&self) -> ArrayMetadata;
 
     /// Create an array builder matching the parameters of this array.
     fn builder(&self) -> ArrayBuilder;

--- a/zarrs/src/array/array_ops/array_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_ops_array.rs
@@ -120,7 +120,7 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
     }
 
     #[allow(clippy::missing_panics_doc, clippy::too_many_lines)]
-    pub fn metadata_to_store(&self) -> ArrayMetadata {
+    pub fn metadata_opt(&self) -> ArrayMetadata {
         let options = self.metadata_options();
         use ArrayMetadata as AM;
         use MetadataConvertVersion as V;

--- a/zarrs/src/array/array_ops/array_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_ops_array.rs
@@ -154,8 +154,11 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
             (AM::V3(metadata), V::Default | V::V3) => ArrayMetadata::V3(metadata),
             (AM::V2(metadata), V::Default) => ArrayMetadata::V2(metadata),
             (AM::V2(metadata), V::V3) => {
-                let metadata = array_metadata_v2_to_v3(&metadata)
+                let mut metadata = array_metadata_v2_to_v3(&metadata)
                     .expect("conversion succeeded on array creation");
+                // Zarr V2 metadata has no dimension names to convert, so take the array's. They
+                // are only representable once converted to Zarr V3.
+                metadata.dimension_names.clone_from(&self.dimension_names);
                 AM::V3(metadata)
             }
         };

--- a/zarrs/src/array/array_ops/array_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_ops_array.rs
@@ -74,12 +74,42 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
         self.metadata_erase_version
     }
 
+    // `#[must_use]` is on the `ArrayOps` declaration; rustc rejects it on a trait method
+    // impl, and `#[inherent]` does not propagate it to the generated inherent method.
+    #[allow(clippy::return_self_not_must_use)]
+    pub fn with_codec_options(&self, codec_options: CodecOptions) -> Self {
+        let mut array = self.clone();
+        array.codec_options = codec_options;
+        array
+    }
+
+    // `#[must_use]` is on the `ArrayOps` declaration; rustc rejects it on a trait method
+    // impl, and `#[inherent]` does not propagate it to the generated inherent method.
+    #[allow(clippy::return_self_not_must_use)]
+    pub fn with_metadata_options(&self, metadata_options: ArrayMetadataOptions) -> Self {
+        let mut array = self.clone();
+        array.metadata_options = metadata_options;
+        array
+    }
+
+    // `#[must_use]` is on the `ArrayOps` declaration; rustc rejects it on a trait method
+    // impl, and `#[inherent]` does not propagate it to the generated inherent method.
+    #[allow(clippy::return_self_not_must_use)]
+    pub fn with_metadata_erase_version(
+        &self,
+        metadata_erase_version: MetadataEraseVersion,
+    ) -> Self {
+        let mut array = self.clone();
+        array.metadata_erase_version = metadata_erase_version;
+        array
+    }
+
     pub fn dimension_names(&self) -> &Option<Vec<DimensionName>> {
         &self.dimension_names
     }
 
     pub fn attributes(&self) -> &serde_json::Map<String, serde_json::Value> {
-        match &self.metadata {
+        match &*self.metadata {
             ArrayMetadata::V3(metadata) => &metadata.attributes,
             ArrayMetadata::V2(metadata) => &metadata.attributes,
         }
@@ -90,10 +120,12 @@ impl<TStorage: ?Sized> ArrayOps for Array<TStorage> {
     }
 
     #[allow(clippy::missing_panics_doc, clippy::too_many_lines)]
-    pub fn metadata_opt(&self, options: &ArrayMetadataOptions) -> ArrayMetadata {
+    pub fn metadata_to_store(&self) -> ArrayMetadata {
+        let options = self.metadata_options();
         use ArrayMetadata as AM;
         use MetadataConvertVersion as V;
-        let mut metadata = self.metadata.clone();
+        // NOTE: deliberately a deep clone of the metadata document, not of the `Arc` handle.
+        let mut metadata = (*self.metadata).clone();
 
         // Attribute manipulation
         if options.include_zarrs_metadata() {

--- a/zarrs/src/array/array_ops/array_ops_array_cached.rs
+++ b/zarrs/src/array/array_ops/array_ops_array_cached.rs
@@ -62,6 +62,30 @@ impl<TStorage: ?Sized, C> ArrayOps for ArrayCached<TStorage, C> {
         self.array().metadata_erase_version()
     }
 
+    // `#[must_use]` is on the `ArrayOps` declaration; rustc rejects it on a trait method
+    // impl, and `#[inherent]` does not propagate it to the generated inherent method.
+    #[allow(clippy::return_self_not_must_use)]
+    pub fn with_codec_options(&self, codec_options: CodecOptions) -> Self {
+        self.map_array(|array| array.with_codec_options(codec_options))
+    }
+
+    // `#[must_use]` is on the `ArrayOps` declaration; rustc rejects it on a trait method
+    // impl, and `#[inherent]` does not propagate it to the generated inherent method.
+    #[allow(clippy::return_self_not_must_use)]
+    pub fn with_metadata_options(&self, metadata_options: ArrayMetadataOptions) -> Self {
+        self.map_array(|array| array.with_metadata_options(metadata_options))
+    }
+
+    // `#[must_use]` is on the `ArrayOps` declaration; rustc rejects it on a trait method
+    // impl, and `#[inherent]` does not propagate it to the generated inherent method.
+    #[allow(clippy::return_self_not_must_use)]
+    pub fn with_metadata_erase_version(
+        &self,
+        metadata_erase_version: MetadataEraseVersion,
+    ) -> Self {
+        self.map_array(|array| array.with_metadata_erase_version(metadata_erase_version))
+    }
+
     pub fn dimension_names(&self) -> &Option<Vec<DimensionName>> {
         self.array().dimension_names()
     }
@@ -74,8 +98,8 @@ impl<TStorage: ?Sized, C> ArrayOps for ArrayCached<TStorage, C> {
         self.array().metadata()
     }
 
-    pub fn metadata_opt(&self, options: &ArrayMetadataOptions) -> ArrayMetadata {
-        self.array().metadata_opt(options)
+    pub fn metadata_to_store(&self) -> ArrayMetadata {
+        self.array().metadata_to_store()
     }
 
     pub fn builder(&self) -> ArrayBuilder {

--- a/zarrs/src/array/array_ops/array_ops_array_cached.rs
+++ b/zarrs/src/array/array_ops/array_ops_array_cached.rs
@@ -98,8 +98,8 @@ impl<TStorage: ?Sized, C> ArrayOps for ArrayCached<TStorage, C> {
         self.array().metadata()
     }
 
-    pub fn metadata_to_store(&self) -> ArrayMetadata {
-        self.array().metadata_to_store()
+    pub fn metadata_opt(&self) -> ArrayMetadata {
+        self.array().metadata_opt()
     }
 
     pub fn builder(&self) -> ArrayBuilder {

--- a/zarrs/src/array/array_ops/array_read_ops.rs
+++ b/zarrs/src/array/array_ops/array_read_ops.rs
@@ -7,8 +7,10 @@ use zarrs_codec::{ArrayBytesDecodeIntoTarget, ArrayPartialDecoderTraits, CodecEr
 use zarrs_storage::MaybeSync;
 
 /// Synchronous array read operations.
+///
+/// These operations decode with the array's [`codec_options`](ArrayOps::codec_options).
 pub trait ArrayReadOps: ArrayOps + MaybeSync {
-    /// Read and decode the chunk at `chunk_indices` into its bytes or the fill value if it does not exist with default codec options.
+    /// Read and decode the chunk at `chunk_indices` into its bytes or the fill value if it does not exist.
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if
@@ -19,18 +21,7 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
     /// # Panics
     /// Panics if the number of elements in the chunk exceeds `usize::MAX`.
     fn retrieve_chunk<T: FromArrayBytes>(&self, chunk_indices: &[u64]) -> Result<T, ArrayError> {
-        self.retrieve_chunk_opt(chunk_indices, self.codec_options())
-    }
-
-    /// Read and decode the chunk at `chunk_indices` with explicit codec options.
-    /// Explicit options version of [`retrieve_chunk`](ArrayReadOps::retrieve_chunk).
-    #[allow(clippy::missing_errors_doc)]
-    fn retrieve_chunk_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
-        if let Some(chunk) = self.retrieve_chunk_if_exists_opt::<T>(chunk_indices, options)? {
+        if let Some(chunk) = self.retrieve_chunk_if_exists::<T>(chunk_indices)? {
             Ok(chunk)
         } else {
             let chunk_shape = self.chunk_shape(chunk_indices)?;
@@ -64,7 +55,6 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
         &self,
         chunk_indices: &[u64],
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Read and decode the chunks at `chunks` into their bytes.
@@ -81,19 +71,8 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
         &self,
         chunks: &dyn ArraySubsetTraits,
     ) -> Result<T, ArrayError> {
-        self.retrieve_chunks_opt(chunks, self.codec_options())
-    }
-
-    /// Read and decode the chunks in `chunks` with explicit codec options.
-    /// Explicit options version of [`retrieve_chunks`](ArrayReadOps::retrieve_chunks).
-    #[allow(clippy::missing_errors_doc)]
-    fn retrieve_chunks_opt<T: FromArrayBytes>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
         let array_subset = self.chunks_subset(chunks)?;
-        self.retrieve_array_subset_opt(&array_subset, options)
+        self.retrieve_array_subset(&array_subset)
     }
 
     /// Read and decode the `chunk_subset` of the chunk at `chunk_indices` into its bytes.
@@ -111,18 +90,6 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
         &self,
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.retrieve_chunk_subset_opt(chunk_indices, chunk_subset, self.codec_options())
-    }
-
-    /// Read and decode a subset of the chunk at `chunk_indices` with explicit codec options.
-    /// Explicit options version of [`retrieve_chunk_subset`](ArrayReadOps::retrieve_chunk_subset).
-    #[allow(clippy::missing_errors_doc)]
-    fn retrieve_chunk_subset_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     /// Read and decode the `chunk_subset` of the chunk at `chunk_indices` into a preallocated `output_target`.
@@ -142,7 +109,6 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Read and decode the `array_subset` of array into its bytes.
@@ -157,23 +123,13 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
     ///
     /// # Panics
     /// Panics if attempting to reference a byte beyond `usize::MAX`.
+    #[allow(clippy::missing_panics_doc)]
     fn retrieve_array_subset<T: FromArrayBytes>(
         &self,
         array_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.retrieve_array_subset_opt(array_subset, self.codec_options())
-    }
-
-    /// Read and decode the array subset with explicit codec options.
-    /// Explicit options version of [`retrieve_array_subset`](ArrayReadOps::retrieve_array_subset).
-    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    fn retrieve_array_subset_opt<T: FromArrayBytes>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
-    /// Read and decode the chunk at `chunk_indices` into its bytes if it exists with default codec options.
+    /// Read and decode the chunk at `chunk_indices` into its bytes if it exists.
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if
@@ -186,17 +142,6 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
     fn retrieve_chunk_if_exists<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<T>, ArrayError> {
-        self.retrieve_chunk_if_exists_opt(chunk_indices, self.codec_options())
-    }
-
-    /// Read and decode the chunk at `chunk_indices` if it exists with explicit codec options.
-    /// Explicit options version of [`retrieve_chunk_if_exists`](ArrayReadOps::retrieve_chunk_if_exists).
-    #[allow(clippy::missing_errors_doc)]
-    fn retrieve_chunk_if_exists_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<T>, ArrayError>;
 
     /// Retrieve the encoded bytes of a chunk.
@@ -207,19 +152,6 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
     fn retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<Vec<u8>>, StorageError> {
-        self.retrieve_encoded_chunk_opt(chunk_indices, self.codec_options())
-    }
-
-    /// Retrieve the encoded bytes of a chunk with explicit codec options.
-    ///
-    /// # Errors
-    /// Returns an [`StorageError`] if there is an underlying store error.
-    #[allow(clippy::missing_panics_doc)]
-    fn retrieve_encoded_chunk_opt(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<Vec<u8>>, StorageError>;
 
     /// Retrieve the encoded bytes of the chunks in `chunks`.
@@ -232,54 +164,38 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
         &self,
         chunks: &dyn ArraySubsetTraits,
     ) -> Result<Vec<Option<Vec<u8>>>, StorageError> {
-        self.retrieve_encoded_chunks_opt(chunks, self.codec_options())
-    }
-
-    /// Retrieve the encoded bytes of the chunks in `chunks` with explicit codec options.
-    ///
-    /// The chunks are in order of the chunk indices returned by `chunks.indices().into_iter()`.
-    ///
-    /// # Errors
-    /// Returns a [`StorageError`] if there is an underlying store error.
-    fn retrieve_encoded_chunks_opt(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<Vec<u8>>>, StorageError> {
         iter_concurrent_limit!(
-            options.concurrent_target(),
+            self.codec_options().concurrent_target(),
             chunks.indices(),
             map,
-            |chunk_indices| self.retrieve_encoded_chunk_opt(&chunk_indices, options)
+            |chunk_indices| self.retrieve_encoded_chunk(&chunk_indices)
         )
         .collect()
     }
 
-    /// Read and decode the subchunk at `subchunk_indices` with explicit codec options.
+    /// Read and decode the subchunk at `subchunk_indices`.
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if the array does not have a subchunk grid, the subchunk indices
     /// are invalid, there is a codec decoding error, or there is an underlying store error.
-    fn retrieve_subchunk_opt<T: FromArrayBytes>(
+    fn retrieve_subchunk<T: FromArrayBytes>(
         &self,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
-        self.retrieve_subchunk_at_level_opt(0, subchunk_indices, options)
+        self.retrieve_subchunk_at_level(0, subchunk_indices)
     }
 
-    /// Read and decode the subchunk at `subchunk_indices` from `level` with explicit codec options.
+    /// Read and decode the subchunk at `subchunk_indices` from `level`.
     ///
     /// Level zero is the outermost subchunk grid and increasing levels move inward.
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if the selected level does not have a globally resolvable grid,
     /// the subchunk indices are invalid, a codec fails, or there is an underlying store error.
-    fn retrieve_subchunk_at_level_opt<T: FromArrayBytes>(
+    fn retrieve_subchunk_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
         let subchunk_grid = self
             .subchunk_grid_at_level(level)
@@ -288,34 +204,32 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
         let array_subset = subchunk_grid
             .subset(subchunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(subchunk_indices.to_vec()))?;
-        self.retrieve_array_subset_opt(&array_subset, options)
+        self.retrieve_array_subset(&array_subset)
     }
 
-    /// Read and decode the subchunks at `subchunks` with explicit codec options.
+    /// Read and decode the subchunks at `subchunks`.
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if the array does not have a subchunk grid, any subchunk indices
     /// are invalid, there is a codec decoding error, or there is an underlying store error.
-    fn retrieve_subchunks_opt<T: FromArrayBytes>(
+    fn retrieve_subchunks<T: FromArrayBytes>(
         &self,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
-        self.retrieve_subchunks_at_level_opt(0, subchunks, options)
+        self.retrieve_subchunks_at_level(0, subchunks)
     }
 
-    /// Read and decode subchunks from `level` with explicit codec options.
+    /// Read and decode subchunks from `level`.
     ///
     /// Level zero is the outermost subchunk grid and increasing levels move inward.
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if the selected level does not have a globally resolvable grid,
     /// any subchunk indices are invalid, a codec fails, or there is an underlying store error.
-    fn retrieve_subchunks_at_level_opt<T: FromArrayBytes>(
+    fn retrieve_subchunks_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
         let subchunk_grid = self
             .subchunk_grid_at_level(level)
@@ -327,7 +241,7 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
                 subchunk_grid.grid_shape().to_vec(),
             )
         })?;
-        self.retrieve_array_subset_opt(&array_subset, options)
+        self.retrieve_array_subset(&array_subset)
     }
 
     /// Read and decode the `array_subset` of array into a preallocated `output_target`.
@@ -343,22 +257,11 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
     ///  - the number of elements in `output_target` does not match `array_subset`,
     ///  - there is a codec decoding error, or
     ///  - an underlying store error.
+    #[allow(clippy::missing_panics_doc)]
     fn retrieve_array_subset_into(
         &self,
         array_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-    ) -> Result<(), ArrayError> {
-        self.retrieve_array_subset_into_opt(array_subset, output_target, self.codec_options())
-    }
-
-    /// Read and decode an array subset into a preallocated target with explicit codec options.
-    /// Explicit options version of [`retrieve_array_subset_into`](ArrayReadOps::retrieve_array_subset_into).
-    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    fn retrieve_array_subset_into_opt(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Initialises a partial decoder for the chunk at `chunk_indices`.
@@ -368,17 +271,6 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
     fn partial_decoder(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
-        self.partial_decoder_opt(chunk_indices, self.codec_options())
-    }
-
-    /// Initialises a partial decoder for the chunk at `chunk_indices` with explicit codec options.
-    /// Explicit options version of [`partial_decoder`](ArrayReadOps::partial_decoder).
-    #[allow(clippy::missing_errors_doc)]
-    fn partial_decoder_opt(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError>;
 
     /// Return the chunk-local subchunk grid for a chunk, if available.
@@ -387,12 +279,8 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
     ///
     /// # Errors
     /// Returns an [`ArrayError`] if the chunk indices are invalid or the local grid cannot be resolved.
-    fn local_subchunk_grid(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<Option<ChunkGrid>, ArrayError> {
-        self.local_subchunk_grid_at_level(0, chunk_indices, options)
+    fn local_subchunk_grid(&self, chunk_indices: &[u64]) -> Result<Option<ChunkGrid>, ArrayError> {
+        self.local_subchunk_grid_at_level(0, chunk_indices)
     }
 
     /// Return the chunk-local subchunk grid at `level` for a chunk, if available.
@@ -406,11 +294,10 @@ pub trait ArrayReadOps: ArrayOps + MaybeSync {
         &self,
         level: usize,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<ChunkGrid>, ArrayError> {
         Ok(self
-            .partial_decoder_opt(chunk_indices, options)?
-            .local_subchunk_grids(options)
+            .partial_decoder(chunk_indices)?
+            .local_subchunk_grids(self.codec_options())
             .map_err(ArrayError::CodecError)?
             .into_iter()
             .nth(level)

--- a/zarrs/src/array/array_ops/array_read_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_read_ops_array.rs
@@ -27,19 +27,12 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunk_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_into(
         &self,
         chunk_indices: &[u64],
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         if chunk_indices.len() != self.dimensionality() {
             return Err(ArrayError::InvalidChunkGridIndicesError(
                 chunk_indices.to_vec(),
@@ -74,26 +67,12 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunks_opt<T: FromArrayBytes>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
     pub fn retrieve_chunk_subset<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunk_subset_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
+        let options = self.codec_options();
         let chunk_shape = self.chunk_shape(chunk_indices)?;
         let chunk_shape_u64 = bytemuck::must_cast_slice(&chunk_shape);
         if !chunk_subset.inbounds_shape(chunk_shape_u64) {
@@ -107,7 +86,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
             && chunk_subset.shape() == chunk_shape_u64
         {
             // Fast path if `chunk_subset` encompasses the whole chunk
-            return self.retrieve_chunk_opt(chunk_indices, options);
+            return self.retrieve_chunk(chunk_indices);
         } else {
             let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
@@ -129,8 +108,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let chunk_shape = self.chunk_shape(chunk_indices)?;
         let chunk_shape_u64 = bytemuck::must_cast_slice(&chunk_shape);
         if !chunk_subset.inbounds_shape(chunk_shape_u64) {
@@ -141,7 +120,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
         }
 
         if chunk_subset.start().iter().all(|&o| o == 0) && chunk_subset.shape() == chunk_shape_u64 {
-            self.retrieve_chunk_into(chunk_indices, output_target, options)
+            self.retrieve_chunk_into(chunk_indices, output_target)
         } else {
             let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
@@ -159,14 +138,8 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     pub fn retrieve_array_subset<T: FromArrayBytes>(
         &self,
         array_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    pub fn retrieve_array_subset_opt<T: FromArrayBytes>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
+        let options = self.codec_options();
         if array_subset.dimensionality() != self.dimensionality() {
             return Err(ArrayError::InvalidArraySubset(
                 array_subset.to_array_subset(),
@@ -201,15 +174,11 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
                 let chunk_subset = self.chunk_subset(chunk_indices)?;
                 if chunk_subset == array_subset {
                     // Single chunk fast path if the array subset domain matches the chunk domain
-                    self.retrieve_chunk_opt(chunk_indices, options)
+                    self.retrieve_chunk(chunk_indices)
                 } else {
                     let array_subset_in_chunk_subset =
                         array_subset.relative_to(chunk_subset.start())?;
-                    self.retrieve_chunk_subset_opt(
-                        chunk_indices,
-                        &array_subset_in_chunk_subset,
-                        options,
-                    )
+                    self.retrieve_chunk_subset(chunk_indices, &array_subset_in_chunk_subset)
                 }
             }
             _ => {
@@ -247,24 +216,13 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
             }
         }
     }
-    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    pub fn retrieve_chunk_if_exists<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-    ) -> Result<Option<T>, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<Vec<u8>>, StorageError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_encoded_chunk_opt(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<Vec<u8>>, StorageError> {
+        let options = self.codec_options();
         let _ = options;
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
@@ -283,65 +241,54 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_encoded_chunks_opt(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_subchunk_opt<T: FromArrayBytes>(
+    pub fn retrieve_subchunk<T: FromArrayBytes>(
         &self,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_subchunk_at_level_opt<T: FromArrayBytes>(
+    pub fn retrieve_subchunk_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_subchunks_opt<T: FromArrayBytes>(
+    pub fn retrieve_subchunks<T: FromArrayBytes>(
         &self,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_subchunks_at_level_opt<T: FromArrayBytes>(
+    pub fn retrieve_subchunks_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
-    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    pub fn retrieve_array_subset_into(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        output_target: ArrayBytesDecodeIntoTarget<'_>,
-    ) -> Result<(), ArrayError>;
-
     #[allow(clippy::missing_errors_doc)]
-    pub fn partial_decoder(
+    pub fn local_subchunk_grid(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError>;
+    ) -> Result<Option<ChunkGrid>, ArrayError>;
+
+    #[allow(clippy::missing_errors_doc)]
+    pub fn local_subchunk_grid_at_level(
+        &self,
+        level: usize,
+        chunk_indices: &[u64],
+    ) -> Result<Option<ChunkGrid>, ArrayError>;
 
     /////////////////////////////////////////////////////////////////////////////
     // Advanced methods
     /////////////////////////////////////////////////////////////////////////////
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunk_if_exists_opt<T: FromArrayBytes>(
+    pub fn retrieve_chunk_if_exists<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<T>, ArrayError> {
+        let options = self.codec_options();
         if chunk_indices.len() != self.dimensionality() {
             return Err(ArrayError::InvalidChunkGridIndicesError(
                 chunk_indices.to_vec(),
@@ -371,32 +318,20 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> ArrayReadOps for Array<
     }
 
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    pub fn retrieve_array_subset_into_opt(
+    pub fn retrieve_array_subset_into(
         &self,
         array_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        super::array_read_ops_common::retrieve_array_subset_into(
-            self,
-            array_subset,
-            output_target,
-            options,
-            |chunk_indices, output_target, options| {
-                self.retrieve_chunk_into(chunk_indices, output_target, options)
-            },
-            |chunk_indices, chunk_subset, output_target, options| {
-                self.retrieve_chunk_subset_into(chunk_indices, chunk_subset, output_target, options)
-            },
-        )
+        super::array_read_ops_common::retrieve_array_subset_into(self, array_subset, output_target)
     }
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn partial_decoder_opt(
+    pub fn partial_decoder(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
+        let options = self.codec_options();
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
@@ -421,6 +356,10 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         chunk_concurrent_limit: usize,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'_>, ArrayError> {
+        // Per-chunk retrieval must use the concurrency-adjusted options, so operate
+        // through an array carrying them. Cloned once, outside the loop.
+        let tuned_array = self.with_codec_options(*options);
+
         let nesting_depth = optional_nesting_depth(data_type);
 
         let chunk_indices = chunks.indices();
@@ -432,12 +371,12 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
                 let chunk_subset = self.chunk_subset(&chunk_indices)?;
                 let chunk_subset_overlap = chunk_subset.overlap(array_subset)?;
                 Ok((
-                    self.retrieve_chunk_subset_opt::<ArrayBytes<'static>>(
-                        &chunk_indices,
-                        &chunk_subset_overlap.relative_to(chunk_subset.start())?,
-                        options,
-                    )?
-                    .into_optional()?,
+                    tuned_array
+                        .retrieve_chunk_subset::<ArrayBytes<'static>>(
+                            &chunk_indices,
+                            &chunk_subset_overlap.relative_to(chunk_subset.start())?,
+                        )?
+                        .into_optional()?,
                     chunk_subset_overlap.relative_to(&array_subset.start())?,
                 ))
             };
@@ -457,12 +396,12 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
                 let chunk_subset = self.chunk_subset(&chunk_indices)?;
                 let chunk_subset_overlap = chunk_subset.overlap(array_subset)?;
                 Ok((
-                    self.retrieve_chunk_subset_opt::<ArrayBytes<'static>>(
-                        &chunk_indices,
-                        &chunk_subset_overlap.relative_to(chunk_subset.start())?,
-                        options,
-                    )?
-                    .into_variable()?,
+                    tuned_array
+                        .retrieve_chunk_subset::<ArrayBytes<'static>>(
+                            &chunk_indices,
+                            &chunk_subset_overlap.relative_to(chunk_subset.start())?,
+                        )?
+                        .into_variable()?,
                     chunk_subset_overlap.relative_to(&array_subset.start())?,
                 ))
             };
@@ -486,6 +425,10 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
         chunk_concurrent_limit: usize,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'_>, ArrayError> {
+        // Per-chunk retrieval must use the concurrency-adjusted options, so operate
+        // through an array carrying them. Cloned once, outside the loop.
+        let tuned_array = self.with_codec_options(*options);
+
         let data_type_size = data_type
             .fixed_size()
             .expect("data_type must have fixed size");
@@ -538,11 +481,10 @@ impl<TStorage: ?Sized + ReadableStorageTraits + 'static> Array<TStorage> {
                 let target =
                     build_nested_optional_target(&mut data_view, mask_views.as_mut_slice());
 
-                self.retrieve_chunk_subset_into(
+                tuned_array.retrieve_chunk_subset_into(
                     &chunk_indices,
                     &chunk_subset_overlap.relative_to(chunk_subset.start())?,
                     target,
-                    options,
                 )?;
                 Ok::<_, ArrayError>(())
             };
@@ -601,12 +543,10 @@ mod tests {
             assert_eq!(subchunk_grid.grid_shape(), &[4, 4]);
 
             let compare = array.retrieve_array_subset::<Vec<u16>>(&[4..6, 6..8])?;
-            let test =
-                array.retrieve_subchunk_opt::<Vec<u16>>(&[2, 3], &CodecOptions::default())?;
+            let test = array.retrieve_subchunk::<Vec<u16>>(&[2, 3])?;
             assert_eq!(compare, test);
 
-            let local_subchunk_grid =
-                array.local_subchunk_grid(&[0, 0], &CodecOptions::default())?;
+            let local_subchunk_grid = array.local_subchunk_grid(&[0, 0])?;
             assert_eq!(
                 local_subchunk_grid.unwrap().chunk_shape(&[0, 0])?.unwrap(),
                 vec![NonZeroU64::new(2).unwrap(); 2]
@@ -615,58 +555,39 @@ mod tests {
             #[cfg(feature = "ndarray")]
             {
                 let compare = array.retrieve_array_subset::<ndarray::ArrayD<u16>>(&[4..6, 6..8])?;
-                let test = array.retrieve_subchunk_opt::<ndarray::ArrayD<u16>>(
-                    &[2, 3],
-                    &CodecOptions::default(),
-                )?;
+                let test = array.retrieve_subchunk::<ndarray::ArrayD<u16>>(&[2, 3])?;
                 assert_eq!(compare, test);
             }
 
             let subset = ArraySubset::new_with_ranges(&[2..6, 2..6]);
             let subchunks = ArraySubset::new_with_ranges(&[1..3, 1..3]);
             let compare = array.retrieve_array_subset::<Vec<u16>>(&subset)?;
-            let test =
-                array.retrieve_subchunks_opt::<Vec<u16>>(&subchunks, &CodecOptions::default())?;
+            let test = array.retrieve_subchunks::<Vec<u16>>(&subchunks)?;
             assert_eq!(compare, test);
 
             #[cfg(feature = "ndarray")]
             {
                 let compare = array.retrieve_array_subset::<ndarray::ArrayD<u16>>(&subset)?;
-                let test = array.retrieve_subchunks_opt::<ndarray::ArrayD<u16>>(
-                    &subchunks,
-                    &CodecOptions::default(),
-                )?;
+                let test = array.retrieve_subchunks::<ndarray::ArrayD<u16>>(&subchunks)?;
                 assert_eq!(compare, test);
             }
         } else {
             assert!(matches!(array.subchunk_grid(), ChunkGridDecodedRef::None));
-            assert!(
-                array
-                    .local_subchunk_grid(&[0, 0], &CodecOptions::default())?
-                    .is_none()
-            );
+            assert!(array.local_subchunk_grid(&[0, 0])?.is_none());
 
             let chunks = ArraySubset::new_with_ranges(&[0..2, 0..2]);
             assert!(matches!(
-                array.retrieve_subchunk_opt::<Vec<u16>>(&[1, 1], &CodecOptions::default()),
+                array.retrieve_subchunk::<Vec<u16>>(&[1, 1]),
                 Err(ArrayError::MissingSubchunkGrid)
             ));
             assert!(matches!(
-                array.retrieve_subchunks_opt::<Vec<u16>>(&chunks, &CodecOptions::default()),
+                array.retrieve_subchunks::<Vec<u16>>(&chunks),
                 Err(ArrayError::MissingSubchunkGrid)
             ));
         }
 
-        assert!(
-            array
-                .retrieve_subchunk_opt::<Vec<u16>>(&[0], &CodecOptions::default())
-                .is_err()
-        );
-        assert!(
-            array
-                .retrieve_subchunks_opt::<Vec<u16>>(&[0..1], &CodecOptions::default())
-                .is_err()
-        );
+        assert!(array.retrieve_subchunk::<Vec<u16>>(&[0]).is_err());
+        assert!(array.retrieve_subchunks::<Vec<u16>>(&[0..1]).is_err());
 
         Ok(())
     }

--- a/zarrs/src/array/array_ops/array_read_ops_array_cached.rs
+++ b/zarrs/src/array/array_ops/array_read_ops_array_cached.rs
@@ -246,15 +246,11 @@ where
     C: ChunkCache,
 {
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunk<T: FromArrayBytes>(&self, chunk_indices: &[u64])
-    -> Result<T, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunk_opt<T: FromArrayBytes>(
+    pub fn retrieve_chunk<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
+        let options = self.codec_options();
         let bytes = retrieve_chunk_bytes(self.cache(), self.array(), chunk_indices, options)?;
         let shape = self.array().chunk_shape(chunk_indices)?;
         T::from_array_bytes_arc(
@@ -269,8 +265,8 @@ where
         &self,
         chunk_indices: &[u64],
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let bytes = retrieve_chunk_bytes(self.cache(), self.array(), chunk_indices, options)?;
         decode_into_array_bytes_target(&bytes, output_target).map_err(ArrayError::CodecError)
     }
@@ -282,26 +278,12 @@ where
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunks_opt<T: FromArrayBytes>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
     pub fn retrieve_chunk_subset<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunk_subset_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
+        let options = self.codec_options();
         let bytes = C::Value::retrieve_chunk_subset_bytes(
             self.cache(),
             self.array(),
@@ -318,8 +300,8 @@ where
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let bytes = C::Value::retrieve_chunk_subset_bytes(
             self.cache(),
             self.array(),
@@ -334,14 +316,8 @@ where
     pub fn retrieve_array_subset<T: FromArrayBytes>(
         &self,
         array_subset: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_array_subset_opt<T: FromArrayBytes>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
+        let options = self.codec_options();
         let bytes = retrieve_array_subset_bytes(self.cache(), self.array(), array_subset, options)?;
         T::from_array_bytes_arc(bytes, &array_subset.shape(), self.array().data_type())
     }
@@ -350,14 +326,8 @@ where
     pub fn retrieve_chunk_if_exists<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<T>, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_chunk_if_exists_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<T>, ArrayError> {
+        let options = self.codec_options();
         let Some(bytes) = C::Value::retrieve_chunk_bytes_if_exists(
             self.cache(),
             self.array(),
@@ -380,16 +350,8 @@ where
     pub fn retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<Vec<u8>>, StorageError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_encoded_chunk_opt(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<Vec<u8>>, StorageError> {
-        self.array()
-            .retrieve_encoded_chunk_opt(chunk_indices, options)
+        self.array().retrieve_encoded_chunk(chunk_indices)
     }
 
     #[allow(clippy::missing_errors_doc)]
@@ -399,40 +361,29 @@ where
     ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_encoded_chunks_opt(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<Vec<u8>>>, StorageError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_subchunk_opt<T: FromArrayBytes>(
+    pub fn retrieve_subchunk<T: FromArrayBytes>(
         &self,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_subchunk_at_level_opt<T: FromArrayBytes>(
+    pub fn retrieve_subchunk_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_subchunks_opt<T: FromArrayBytes>(
+    pub fn retrieve_subchunks<T: FromArrayBytes>(
         &self,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_subchunks_at_level_opt<T: FromArrayBytes>(
+    pub fn retrieve_subchunks_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
@@ -440,43 +391,31 @@ where
         &self,
         array_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-    ) -> Result<(), ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn retrieve_array_subset_into_opt(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        super::array_read_ops_common::retrieve_array_subset_into(
-            self.array(),
-            array_subset,
-            output_target,
-            options,
-            |chunk_indices, output_target, options| {
-                self.retrieve_chunk_into(chunk_indices, output_target, options)
-            },
-            |chunk_indices, chunk_subset, output_target, options| {
-                self.retrieve_chunk_subset_into(chunk_indices, chunk_subset, output_target, options)
-            },
-        )
+        super::array_read_ops_common::retrieve_array_subset_into(self, array_subset, output_target)
     }
 
     #[allow(clippy::missing_errors_doc)]
     pub fn partial_decoder(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn partial_decoder_opt(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialDecoderTraits>, ArrayError> {
+        let options = self.codec_options();
         C::Value::partial_decoder(self.cache(), self.array(), chunk_indices, options)
     }
+
+    #[allow(clippy::missing_errors_doc)]
+    pub fn local_subchunk_grid(
+        &self,
+        chunk_indices: &[u64],
+    ) -> Result<Option<ChunkGrid>, ArrayError>;
+
+    #[allow(clippy::missing_errors_doc)]
+    pub fn local_subchunk_grid_at_level(
+        &self,
+        level: usize,
+        chunk_indices: &[u64],
+    ) -> Result<Option<ChunkGrid>, ArrayError>;
 }
 
 #[cfg(test)]
@@ -536,27 +475,15 @@ mod tests {
             vec![2, 0]
         );
         assert!(matches!(
-            cached
-                .retrieve_subchunk_opt::<Vec<u8>>(&[0], &CodecOptions::default())
-                .unwrap_err(),
+            cached.retrieve_subchunk::<Vec<u8>>(&[0]).unwrap_err(),
             ArrayError::MissingSubchunkGrid
         ));
         assert!(matches!(
-            cached
-                .retrieve_subchunks_opt::<Vec<u8>>(&[0..2], &CodecOptions::default())
-                .unwrap_err(),
+            cached.retrieve_subchunks::<Vec<u8>>(&[0..2]).unwrap_err(),
             ArrayError::MissingSubchunkGrid
         ));
-        assert!(
-            cached
-                .retrieve_subchunk_opt::<Vec<u8>>(&[0, 0], &CodecOptions::default())
-                .is_err()
-        );
-        assert!(
-            cached
-                .retrieve_subchunks_opt::<Vec<u8>>(&[0..1, 0..1], &CodecOptions::default())
-                .is_err()
-        );
+        assert!(cached.retrieve_subchunk::<Vec<u8>>(&[0, 0]).is_err());
+        assert!(cached.retrieve_subchunks::<Vec<u8>>(&[0..1, 0..1]).is_err());
         assert!(cached.retrieve_chunk::<Vec<u8>>(&[2]).is_err());
         assert!(!cached.cache().is_empty());
         assert!(cached.cache().invalidate_chunk(&[0]));
@@ -578,32 +505,24 @@ mod tests {
             .store_array_subset(&array.subset_all(), &data)
             .unwrap();
 
-        let cached = ArrayCached::new(array, cache);
-        let options = CodecOptions::default().with_concurrent_target(1);
+        // Exercise the cached reads under a non-default concurrency target. The derived
+        // array shares the cache, so the assertions below still observe it.
+        let cached = ArrayCached::new(array, cache)
+            .with_codec_options(CodecOptions::default().with_concurrent_target(1));
         assert_eq!(
-            cached
-                .retrieve_subchunk_opt::<Vec<u16>>(&[2, 3], &options)
-                .unwrap(),
+            cached.retrieve_subchunk::<Vec<u16>>(&[2, 3]).unwrap(),
             vec![38, 39, 46, 47]
         );
         assert_eq!(
             cached
-                .retrieve_subchunks_opt::<Vec<u16>>(&[1..3, 1..3], &options)
+                .retrieve_subchunks::<Vec<u16>>(&[1..3, 1..3])
                 .unwrap(),
             vec![
                 18, 19, 20, 21, 26, 27, 28, 29, 34, 35, 36, 37, 42, 43, 44, 45,
             ]
         );
-        assert!(
-            cached
-                .retrieve_subchunk_opt::<Vec<u16>>(&[0], &options)
-                .is_err()
-        );
-        assert!(
-            cached
-                .retrieve_subchunks_opt::<Vec<u16>>(&[0..1], &options)
-                .is_err()
-        );
+        assert!(cached.retrieve_subchunk::<Vec<u16>>(&[0]).is_err());
+        assert!(cached.retrieve_subchunks::<Vec<u16>>(&[0..1]).is_err());
         assert!(!cached.cache().is_empty());
     }
 

--- a/zarrs/src/array/array_ops/array_read_ops_common.rs
+++ b/zarrs/src/array/array_ops/array_read_ops_common.rs
@@ -1,40 +1,26 @@
 use crate::array::{
-    Array, ArrayBytesFixedDisjointView, ArrayError, ArrayIndicesTinyVec, ArraySubset,
-    ArraySubsetTraits,
+    ArrayBytesFixedDisjointView, ArrayError, ArrayIndicesTinyVec, ArraySubset, ArraySubsetTraits,
 };
 use crate::iter_concurrent_limit;
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, CodecError, CodecOptions, InvalidNumberOfElementsError,
-    copy_fill_value_into,
+    ArrayBytesDecodeIntoTarget, CodecError, InvalidNumberOfElementsError, copy_fill_value_into,
 };
-use zarrs_storage::{MaybeSend, MaybeSync, ReadableStorageTraits};
 
 use super::super::array_bytes_internal::{build_nested_optional_target, extract_target_views};
 use super::super::concurrency::concurrency_chunks_and_codec;
+use super::ArrayReadOps;
 
-pub(super) fn retrieve_array_subset_into<TStorage, RetrieveChunkInto, RetrieveChunkSubsetInto>(
-    array: &Array<TStorage>,
+/// Shared implementation of [`ArrayReadOps::retrieve_array_subset_into`].
+///
+/// Generic over the receiver so that `Array` and `ArrayCached` share it: the per-chunk work
+/// dispatches back through [`ArrayReadOps`], which for a cached array goes through its cache.
+pub(super) fn retrieve_array_subset_into<A: ArrayReadOps>(
+    array: &A,
     array_subset: &dyn ArraySubsetTraits,
     output_target: ArrayBytesDecodeIntoTarget<'_>,
-    options: &CodecOptions,
-    retrieve_chunk_into: RetrieveChunkInto,
-    retrieve_chunk_subset_into: RetrieveChunkSubsetInto,
-) -> Result<(), ArrayError>
-where
-    TStorage: ?Sized + ReadableStorageTraits + 'static,
-    RetrieveChunkInto:
-        for<'a> Fn(&[u64], ArrayBytesDecodeIntoTarget<'a>, &CodecOptions) -> Result<(), ArrayError>,
-    RetrieveChunkSubsetInto: for<'a> Fn(
-            &[u64],
-            &dyn ArraySubsetTraits,
-            ArrayBytesDecodeIntoTarget<'a>,
-            &CodecOptions,
-        ) -> Result<(), ArrayError>
-        + MaybeSend
-        + MaybeSync,
-{
+) -> Result<(), ArrayError> {
     if array_subset.dimensionality() != array.dimensionality() {
         return Err(ArrayError::InvalidArraySubset(
             array_subset.to_array_subset(),
@@ -73,13 +59,12 @@ where
             let chunk_indices = chunks.start();
             let chunk_subset = array.chunk_subset(chunk_indices)?;
             if chunk_subset == array_subset {
-                retrieve_chunk_into(chunk_indices, output_target, options)
+                array.retrieve_chunk_into(chunk_indices, output_target)
             } else {
-                retrieve_chunk_subset_into(
+                array.retrieve_chunk_subset_into(
                     chunk_indices,
                     &array_subset.relative_to(chunk_subset.start())?,
                     output_target,
-                    options,
                 )
             }
         }
@@ -87,44 +72,32 @@ where
             let chunk_shape = array.chunk_shape(chunks.start())?;
             let codec_concurrency = array.recommended_codec_concurrency(&chunk_shape)?;
             let (chunk_concurrent_limit, options) = concurrency_chunks_and_codec(
-                options.concurrent_target(),
+                array.codec_options().concurrent_target(),
                 num_chunks,
-                options,
+                array.codec_options(),
                 &codec_concurrency,
             );
+            // Per-chunk retrieval must use the concurrency-adjusted options, so operate through
+            // an array carrying them. Derived once, outside the loop.
+            let tuned_array = array.with_codec_options(options);
             retrieve_multi_chunk_fixed_into(
-                array,
+                &tuned_array,
                 array_subset,
                 &chunks,
                 chunk_concurrent_limit,
                 &output_target,
-                &options,
-                &retrieve_chunk_subset_into,
             )
         }
     }
 }
 
-fn retrieve_multi_chunk_fixed_into<TStorage, RetrieveChunkSubsetInto>(
-    array: &Array<TStorage>,
+fn retrieve_multi_chunk_fixed_into<A: ArrayReadOps>(
+    array: &A,
     array_subset: &dyn ArraySubsetTraits,
     chunks: &dyn ArraySubsetTraits,
     chunk_concurrent_limit: usize,
     output_target: &ArrayBytesDecodeIntoTarget<'_>,
-    options: &CodecOptions,
-    retrieve_chunk_subset_into: &RetrieveChunkSubsetInto,
-) -> Result<(), ArrayError>
-where
-    TStorage: ?Sized + ReadableStorageTraits + 'static,
-    RetrieveChunkSubsetInto: for<'a> Fn(
-            &[u64],
-            &dyn ArraySubsetTraits,
-            ArrayBytesDecodeIntoTarget<'a>,
-            &CodecOptions,
-        ) -> Result<(), ArrayError>
-        + MaybeSend
-        + MaybeSync,
-{
+) -> Result<(), ArrayError> {
     let (data_view_ref, mask_view_refs) = extract_target_views(output_target);
     let parent_start = data_view_ref.subset().start().to_vec();
 
@@ -158,11 +131,10 @@ where
             .collect::<Result<Vec<_>, _>>()?;
 
         let target = build_nested_optional_target(&mut data_sub, mask_subs.as_mut_slice());
-        retrieve_chunk_subset_into(
+        array.retrieve_chunk_subset_into(
             &chunk_indices,
             &chunk_subset_overlap.relative_to(chunk_subset.start())?,
             target,
-            options,
         )?;
         Ok::<_, ArrayError>(())
     };

--- a/zarrs/src/array/array_ops/array_update_ops.rs
+++ b/zarrs/src/array/array_ops/array_update_ops.rs
@@ -2,10 +2,12 @@ use super::*;
 use zarrs_codec::ArrayPartialEncoderTraits;
 
 /// Synchronous array read/write update operations.
+///
+/// These operations encode and decode with the array's
+/// [`codec_options`](ArrayOps::codec_options).
 pub trait ArrayUpdateOps: ArrayReadOps + ArrayWriteOps {
-    /// Encode `chunk_subset_data` and store in `chunk_subset` of the chunk at `chunk_indices` with default codec options.
+    /// Encode `chunk_subset_data` and store in `chunk_subset` of the chunk at `chunk_indices`.
     ///
-    /// Use [`store_chunk_subset_opt`](ArrayUpdateOps::store_chunk_subset_opt) to control codec options.
     /// Prefer to use [`store_chunk`](crate::array::ArrayWriteOps::store_chunk) where possible, since this function may decode the chunk before updating it and reencoding it.
     ///
     /// # Errors
@@ -21,27 +23,10 @@ pub trait ArrayUpdateOps: ArrayReadOps + ArrayWriteOps {
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         chunk_subset_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunk_subset_opt(
-            chunk_indices,
-            chunk_subset,
-            chunk_subset_data,
-            self.codec_options(),
-        )
-    }
-
-    /// Explicit options version of [`store_chunk_subset`](ArrayUpdateOps::store_chunk_subset).
-    fn store_chunk_subset_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        chunk_subset_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Encode `subset_data` and store in `array_subset`.
     ///
-    /// Use [`store_array_subset_opt`](ArrayUpdateOps::store_array_subset_opt) to control codec options.
     /// Prefer to use [`store_chunk`](crate::array::ArrayWriteOps::store_chunk) or [`store_chunks`](crate::array::ArrayWriteOps::store_chunks) where possible, since this will decode and encode each chunk intersecting `array_subset`.
     ///
     /// # Errors
@@ -54,16 +39,6 @@ pub trait ArrayUpdateOps: ArrayReadOps + ArrayWriteOps {
         &self,
         array_subset: &dyn ArraySubsetTraits,
         subset_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_array_subset_opt(array_subset, subset_data, self.codec_options())
-    }
-
-    /// Explicit options version of [`store_array_subset`](ArrayUpdateOps::store_array_subset).
-    fn store_array_subset_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        subset_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Retrieve the chunk at `chunk_indices`, compact it if possible, and store the compacted chunk back.
@@ -74,11 +49,7 @@ pub trait ArrayUpdateOps: ArrayReadOps + ArrayWriteOps {
     /// Returns an [`ArrayError`] if
     ///  - there is a codec error, or
     ///  - an underlying store error.
-    fn compact_chunk(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<bool, ArrayError>;
+    fn compact_chunk(&self, chunk_indices: &[u64]) -> Result<bool, ArrayError>;
 
     /// Return a read-only instantiation of the array.
     fn readable(&self) -> Array<dyn ReadableStorageTraits>;
@@ -96,6 +67,5 @@ pub trait ArrayUpdateOps: ArrayReadOps + ArrayWriteOps {
     fn partial_encoder(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, ArrayError>;
 }

--- a/zarrs/src/array/array_ops/array_update_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_update_ops_array.rs
@@ -21,16 +21,8 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         chunk_subset_data: T,
-    ) -> Result<(), ArrayError>;
-
-    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    pub fn store_chunk_subset_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        chunk_subset_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let chunk_shape = self
             .chunk_grid()
             .chunk_shape_u64(chunk_indices)?
@@ -47,7 +39,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
 
         if chunk_subset.shape() == chunk_shape && chunk_subset.start().iter().all(|&x| x == 0) {
             // The subset spans the whole chunk, so store the bytes directly and skip decoding
-            self.store_chunk_opt(chunk_indices, chunk_subset_data, options)
+            self.store_chunk(chunk_indices, chunk_subset_data)
         } else {
             let chunk_subset_bytes = chunk_subset_data.into_array_bytes(self.data_type())?;
             chunk_subset_bytes.validate(chunk_subset.num_elements(), self.data_type())?;
@@ -61,7 +53,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
                 && self.codecs.partial_encoder_capability().partial_encode
                 && self.storage.supports_set_partial()
             {
-                let partial_encoder = self.partial_encoder(chunk_indices, options)?;
+                let partial_encoder = self.partial_encoder(chunk_indices)?;
                 debug_assert!(
                     partial_encoder.supports_partial_encode(),
                     "partial encoder is misrepresenting its capabilities"
@@ -69,8 +61,7 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
                 Ok(partial_encoder.partial_encode(chunk_subset, &chunk_subset_bytes, options)?)
             } else {
                 // Decode the entire chunk
-                let chunk_bytes_old: ArrayBytes<'static> =
-                    self.retrieve_chunk_opt(chunk_indices, options)?;
+                let chunk_bytes_old: ArrayBytes<'static> = self.retrieve_chunk(chunk_indices)?;
                 chunk_bytes_old.validate(chunk_shape.iter().product(), self.data_type())?;
 
                 // Update the chunk
@@ -83,26 +74,19 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
                 )?;
 
                 // Store the updated chunk
-                self.store_chunk_opt(chunk_indices, chunk_bytes_new, options)
+                self.store_chunk(chunk_indices, chunk_bytes_new)
             }
         }
     }
 
     #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+    #[allow(clippy::too_many_lines)]
     pub fn store_array_subset<'a, T: IntoArrayBytes<'a>>(
         &self,
         array_subset: &dyn ArraySubsetTraits,
         subset_data: T,
-    ) -> Result<(), ArrayError>;
-
-    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
-    #[allow(clippy::too_many_lines)]
-    pub fn store_array_subset_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        subset_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         // Validation
         if array_subset.dimensionality() != self.shape().len() {
             return Err(ArrayError::InvalidArraySubset(
@@ -126,14 +110,13 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
             if array_subset == chunk_subset {
                 // A fast path if the array subset matches the chunk subset
                 // This skips the internal decoding occurring in store_chunk_subset
-                self.store_chunk_opt(chunk_indices, subset_data, options)?;
+                self.store_chunk(chunk_indices, subset_data)?;
             } else {
                 // Store the chunk subset
-                self.store_chunk_subset_opt(
+                self.store_chunk_subset(
                     chunk_indices,
                     &array_subset.relative_to(chunk_subset.start())?,
                     subset_data,
-                    options,
                 )?;
             }
         } else {
@@ -149,6 +132,10 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
                 &codec_concurrency,
             );
 
+            // Per-chunk stores must use the concurrency-adjusted options, so operate through
+            // an array carrying them. Cloned once, outside the loop.
+            let tuned_array = self.with_codec_options(options);
+
             let store_chunk = |chunk_indices: ArrayIndicesTinyVec| -> Result<(), ArrayError> {
                 let chunk_subset_in_array = self.chunk_subset(&chunk_indices)?;
                 let overlap = array_subset.overlap(&chunk_subset_in_array)?;
@@ -159,11 +146,10 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
                     self.data_type(),
                 )?;
                 let chunk_subset_in_chunk = overlap.relative_to(chunk_subset_in_array.start())?;
-                self.store_chunk_subset_opt(
+                tuned_array.store_chunk_subset(
                     &chunk_indices,
                     &chunk_subset_in_chunk,
                     chunk_subset_bytes,
-                    &options,
                 )
             };
 
@@ -174,11 +160,8 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
         Ok(())
     }
 
-    pub fn compact_chunk(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<bool, ArrayError> {
+    pub fn compact_chunk(&self, chunk_indices: &[u64]) -> Result<bool, ArrayError> {
+        let options = self.codec_options();
         let chunk_bytes = self.retrieve_encoded_chunk(chunk_indices)?;
         if let Some(chunk_bytes) = chunk_bytes {
             if let Some(compacted_bytes) = self.codecs_bound.compact(
@@ -206,15 +189,11 @@ impl<TStorage: ?Sized + ReadableWritableStorageTraits + 'static> ArrayUpdateOps
         self.with_storage(self.storage.clone().readable())
     }
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Advanced methods
-    /////////////////////////////////////////////////////////////////////////////
-
     pub fn partial_encoder(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, ArrayError> {
+        let options = self.codec_options();
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
 
         // Input/output

--- a/zarrs/src/array/array_ops/array_update_ops_array_cached.rs
+++ b/zarrs/src/array/array_ops/array_update_ops_array_cached.rs
@@ -98,22 +98,9 @@ where
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         chunk_subset_data: T,
-    ) -> Result<(), ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn store_chunk_subset_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        chunk_subset_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        self.array().store_chunk_subset_opt(
-            chunk_indices,
-            chunk_subset,
-            chunk_subset_data,
-            options,
-        )?;
+        self.array()
+            .store_chunk_subset(chunk_indices, chunk_subset, chunk_subset_data)?;
         self.cache().invalidate_chunk(chunk_indices);
         Ok(())
     }
@@ -123,17 +110,8 @@ where
         &self,
         array_subset: &dyn ArraySubsetTraits,
         subset_data: T,
-    ) -> Result<(), ArrayError>;
-
-    #[allow(clippy::missing_errors_doc)]
-    pub fn store_array_subset_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        subset_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        self.array()
-            .store_array_subset_opt(array_subset, subset_data, options)?;
+        self.array().store_array_subset(array_subset, subset_data)?;
         if let Some(chunks) = self.array().chunks_in_array_subset(array_subset)? {
             self.cache().invalidate_chunks(&chunks);
         } else {
@@ -143,12 +121,8 @@ where
     }
 
     #[allow(clippy::missing_errors_doc)]
-    pub fn compact_chunk(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<bool, ArrayError> {
-        let compacted = self.array().compact_chunk(chunk_indices, options)?;
+    pub fn compact_chunk(&self, chunk_indices: &[u64]) -> Result<bool, ArrayError> {
+        let compacted = self.array().compact_chunk(chunk_indices)?;
         if compacted {
             self.cache().invalidate_chunk(chunk_indices);
         }
@@ -163,9 +137,8 @@ where
     pub fn partial_encoder(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn ArrayPartialEncoderTraits>, ArrayError> {
-        let encoder = self.array().partial_encoder(chunk_indices, options)?;
+        let encoder = self.array().partial_encoder(chunk_indices)?;
         Ok(Arc::new(CachedArrayPartialEncoder {
             encoder,
             cache: self.cache_arc(),
@@ -199,13 +172,12 @@ mod tests {
         assert_eq!(cached.retrieve_chunk::<Vec<u8>>(&[0]).unwrap(), vec![1, 2]);
         assert_eq!(cached.cache().len(), 1);
 
-        let options = CodecOptions::default();
-        let encoder = cached.partial_encoder(&[0], &options).unwrap();
+        let encoder = cached.partial_encoder(&[0]).unwrap();
         encoder
             .partial_encode(
                 &ArraySubset::new_with_ranges(&[1..2]),
                 &vec![3u8].into(),
-                &options,
+                &CodecOptions::default(),
             )
             .unwrap();
         assert!(cached.cache().is_empty());
@@ -232,14 +204,13 @@ mod tests {
         assert_eq!(cached.retrieve_chunk::<Vec<u8>>(&[0]).unwrap(), vec![1, 2]);
         assert_eq!(cached.cache().len(), 1);
 
-        let options = CodecOptions::default();
-        let encoder = cached.partial_encoder(&[0], &options).unwrap();
+        let encoder = cached.partial_encoder(&[0]).unwrap();
         assert!(
             encoder
                 .partial_encode(
                     &ArraySubset::new_with_ranges(&[2..3]),
                     &vec![3u8].into(),
-                    &options,
+                    &CodecOptions::default(),
                 )
                 .is_err()
         );

--- a/zarrs/src/array/array_ops/array_write_ops.rs
+++ b/zarrs/src/array/array_ops/array_write_ops.rs
@@ -1,46 +1,29 @@
 use super::*;
 
 /// Synchronous array write operations.
+///
+/// These operations encode with the array's [`codec_options`](ArrayOps::codec_options) and write
+/// metadata according to its [`metadata_options`](ArrayOps::metadata_options) and
+/// [`metadata_erase_version`](ArrayOps::metadata_erase_version).
 pub trait ArrayWriteOps: ArrayOps {
-    /// Store metadata with default [`ArrayMetadataOptions`].
+    /// Store the array metadata.
     ///
-    /// The metadata is created with [`Array::metadata_opt`].
-    ///
-    /// # Errors
-    /// Returns [`StorageError`] if there is an underlying store error.
-    fn store_metadata(&self) -> Result<(), StorageError> {
-        self.store_metadata_opt(self.metadata_options())
-    }
-
-    /// Store metadata with non-default [`ArrayMetadataOptions`].
-    ///
-    /// The metadata is created with [`Array::metadata_opt`].
+    /// The metadata is created with [`ArrayOps::metadata_to_store`].
     ///
     /// # Errors
     /// Returns [`StorageError`] if there is an underlying store error.
-    fn store_metadata_opt(&self, options: &ArrayMetadataOptions) -> Result<(), StorageError>;
+    fn store_metadata(&self) -> Result<(), StorageError>;
 
-    /// Erase the metadata with default [`MetadataEraseVersion`] options.
+    /// Erase the array metadata.
     ///
     /// Succeeds if the metadata does not exist.
     ///
     /// # Errors
     /// Returns a [`StorageError`] if there is an underlying store error.
-    fn erase_metadata(&self) -> Result<(), StorageError> {
-        self.erase_metadata_opt(self.metadata_erase_version())
-    }
-
-    /// Erase the metadata with non-default [`MetadataEraseVersion`] options.
-    ///
-    /// Succeeds if the metadata does not exist.
-    ///
-    /// # Errors
-    /// Returns a [`StorageError`] if there is an underlying store error.
-    fn erase_metadata_opt(&self, options: MetadataEraseVersion) -> Result<(), StorageError>;
+    fn erase_metadata(&self) -> Result<(), StorageError>;
 
     /// Encode `chunk_data` and store at `chunk_indices`.
     ///
-    /// Use [`store_chunk_opt`](ArrayWriteOps::store_chunk_opt) to control codec options.
     /// A chunk composed entirely of the fill value will not be written to the store.
     ///
     /// # Errors
@@ -53,21 +36,10 @@ pub trait ArrayWriteOps: ArrayOps {
         &self,
         chunk_indices: &[u64],
         chunk_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunk_opt(chunk_indices, chunk_data, self.codec_options())
-    }
-
-    /// Explicit options version of [`store_chunk`](ArrayWriteOps::store_chunk).
-    fn store_chunk_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Encode `chunks_data` and store at the chunks with indices represented by the `chunks` array subset.
     ///
-    /// Use [`store_chunks_opt`](ArrayWriteOps::store_chunks_opt) to control codec options.
     /// A chunk composed entirely of the fill value will not be written to the store.
     ///
     /// # Errors
@@ -80,16 +52,6 @@ pub trait ArrayWriteOps: ArrayOps {
         &self,
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
-    ) -> Result<(), ArrayError> {
-        self.store_chunks_opt(chunks, chunks_data, self.codec_options())
-    }
-
-    /// Explicit options version of [`store_chunks`](ArrayWriteOps::store_chunks).
-    fn store_chunks_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        chunks_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Erase the chunk at `chunk_indices`.

--- a/zarrs/src/array/array_ops/array_write_ops.rs
+++ b/zarrs/src/array/array_ops/array_write_ops.rs
@@ -8,7 +8,7 @@ use super::*;
 pub trait ArrayWriteOps: ArrayOps {
     /// Store the array metadata.
     ///
-    /// The metadata is created with [`ArrayOps::metadata_to_store`].
+    /// The metadata is created with [`ArrayOps::metadata_opt`].
     ///
     /// # Errors
     /// Returns [`StorageError`] if there is an underlying store error.

--- a/zarrs/src/array/array_ops/array_write_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_write_ops_array.rs
@@ -14,16 +14,14 @@ use zarrs_storage::{Bytes, StorageHandle};
 
 #[inherent]
 impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array<TStorage> {
-    pub fn store_metadata(&self) -> Result<(), StorageError>;
-
-    pub fn store_metadata_opt(&self, options: &ArrayMetadataOptions) -> Result<(), StorageError> {
+    pub fn store_metadata(&self) -> Result<(), StorageError> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
             .create_writable_transformer(storage_handle)?;
 
         // Get the metadata with options applied and store
-        let metadata = self.metadata_opt(options);
+        let metadata = self.metadata_to_store();
 
         // Store the metadata
         let path = self.path();
@@ -57,12 +55,11 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
         }
     }
 
-    pub fn erase_metadata(&self) -> Result<(), StorageError>;
-
-    pub fn erase_metadata_opt(&self, options: MetadataEraseVersion) -> Result<(), StorageError> {
+    pub fn erase_metadata(&self) -> Result<(), StorageError> {
+        let options = self.metadata_erase_version();
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
-            MetadataEraseVersion::Default => match self.metadata {
+            MetadataEraseVersion::Default => match *self.metadata {
                 ArrayMetadata::V3(_) => storage_handle.erase(&meta_key_v3(self.path())),
                 ArrayMetadata::V2(_) => {
                     storage_handle.erase(&meta_key_v2_array(self.path()))?;
@@ -86,14 +83,8 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
         &self,
         chunk_indices: &[u64],
         chunk_data: T,
-    ) -> Result<(), ArrayError>;
-
-    pub fn store_chunk_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let chunk_bytes = chunk_data.into_array_bytes(self.data_type())?;
 
         // Validation
@@ -119,14 +110,8 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
         &self,
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
-    ) -> Result<(), ArrayError>;
-
-    pub fn store_chunks_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        chunks_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let num_chunks = chunks.num_elements_usize();
         match num_chunks {
             0 => {
@@ -135,7 +120,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
             }
             1 => {
                 let chunk_indices = chunks.start();
-                self.store_chunk_opt(&chunk_indices, chunks_data, options)?;
+                self.store_chunk(&chunk_indices, chunks_data)?;
             }
             _ => {
                 let chunks_bytes = chunks_data.into_array_bytes(self.data_type())?;
@@ -152,6 +137,10 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
                     &codec_concurrency,
                 );
 
+                // Per-chunk stores must use the concurrency-adjusted options, so operate
+                // through an array carrying them. Cloned once, outside the loop.
+                let tuned_array = self.with_codec_options(options);
+
                 let store_chunk = |chunk_indices: ArrayIndicesTinyVec| -> Result<(), ArrayError> {
                     let chunk_subset = self.chunk_subset(&chunk_indices)?;
                     let chunk_bytes = chunks_bytes.extract_array_subset(
@@ -159,7 +148,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
                         array_subset.shape(),
                         self.data_type(),
                     )?;
-                    self.store_chunk_opt(&chunk_indices, chunk_bytes, &options)
+                    tuned_array.store_chunk(&chunk_indices, chunk_bytes)
                 };
 
                 let indices = chunks.indices();

--- a/zarrs/src/array/array_ops/array_write_ops_array.rs
+++ b/zarrs/src/array/array_ops/array_write_ops_array.rs
@@ -21,7 +21,7 @@ impl<TStorage: ?Sized + WritableStorageTraits + 'static> ArrayWriteOps for Array
             .create_writable_transformer(storage_handle)?;
 
         // Get the metadata with options applied and store
-        let metadata = self.metadata_to_store();
+        let metadata = self.metadata_opt();
 
         // Store the metadata
         let path = self.path();

--- a/zarrs/src/array/array_ops/array_write_ops_array_cached.rs
+++ b/zarrs/src/array/array_ops/array_write_ops_array_cached.rs
@@ -8,18 +8,14 @@ where
     TStorage: ?Sized + WritableStorageTraits + 'static,
     C: ChunkCache,
 {
-    pub fn store_metadata(&self) -> Result<(), StorageError>;
-
-    pub fn store_metadata_opt(&self, options: &ArrayMetadataOptions) -> Result<(), StorageError> {
-        self.array().store_metadata_opt(options)?;
+    pub fn store_metadata(&self) -> Result<(), StorageError> {
+        self.array().store_metadata()?;
         self.cache().invalidate();
         Ok(())
     }
 
-    pub fn erase_metadata(&self) -> Result<(), StorageError>;
-
-    pub fn erase_metadata_opt(&self, options: MetadataEraseVersion) -> Result<(), StorageError> {
-        self.array().erase_metadata_opt(options)?;
+    pub fn erase_metadata(&self) -> Result<(), StorageError> {
+        self.array().erase_metadata()?;
         self.cache().invalidate();
         Ok(())
     }
@@ -28,16 +24,8 @@ where
         &self,
         chunk_indices: &[u64],
         chunk_data: T,
-    ) -> Result<(), ArrayError>;
-
-    pub fn store_chunk_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        self.array()
-            .store_chunk_opt(chunk_indices, chunk_data, options)?;
+        self.array().store_chunk(chunk_indices, chunk_data)?;
         self.cache().invalidate_chunk(chunk_indices);
         Ok(())
     }
@@ -46,16 +34,8 @@ where
         &self,
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
-    ) -> Result<(), ArrayError>;
-
-    pub fn store_chunks_opt<'a, T: IntoArrayBytes<'a>>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        chunks_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
-        self.array()
-            .store_chunks_opt(chunks, chunks_data, options)?;
+        self.array().store_chunks(chunks, chunks_data)?;
         self.cache().invalidate_chunks(chunks);
         Ok(())
     }

--- a/zarrs/src/array/array_ops/async_array_read_ops.rs
+++ b/zarrs/src/array/array_ops/async_array_read_ops.rs
@@ -4,6 +4,8 @@ use zarrs_codec::{ArrayBytesDecodeIntoTarget, AsyncArrayPartialDecoderTraits};
 use zarrs_storage::Bytes;
 
 /// Asynchronous array read operations.
+///
+/// These operations decode with the array's [`codec_options`](ArrayOps::codec_options).
 #[cfg(feature = "async")]
 #[allow(async_fn_in_trait)]
 pub trait AsyncArrayReadOps: ArrayOps {
@@ -14,21 +16,12 @@ pub trait AsyncArrayReadOps: ArrayOps {
         chunk_indices: &[u64],
     ) -> Result<T, ArrayError>;
 
-    /// Async variant of [`ArrayReadOps::retrieve_chunk_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_chunk_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
-
     /// Async variant of [`ArrayReadOps::retrieve_chunk_into`].
     #[allow(clippy::missing_errors_doc)]
     async fn async_retrieve_chunk_into(
         &self,
         chunk_indices: &[u64],
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Async variant of [`ArrayReadOps::retrieve_chunks`].
@@ -36,18 +29,9 @@ pub trait AsyncArrayReadOps: ArrayOps {
     async fn async_retrieve_chunks<T: FromArrayBytes>(
         &self,
         chunks: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError>;
-
-    /// Async variant of [`ArrayReadOps::retrieve_chunks_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_chunks_opt<T: FromArrayBytes>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
         let array_subset = self.chunks_subset(chunks)?;
-        self.async_retrieve_array_subset_opt(&array_subset, options)
-            .await
+        self.async_retrieve_array_subset(&array_subset).await
     }
 
     /// Async variant of [`ArrayReadOps::retrieve_chunk_subset`].
@@ -58,15 +42,6 @@ pub trait AsyncArrayReadOps: ArrayOps {
         chunk_subset: &dyn ArraySubsetTraits,
     ) -> Result<T, ArrayError>;
 
-    /// Async variant of [`ArrayReadOps::retrieve_chunk_subset_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_chunk_subset_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
-
     /// Async variant of [`ArrayReadOps::retrieve_chunk_subset_into`].
     #[allow(clippy::missing_errors_doc)]
     async fn async_retrieve_chunk_subset_into(
@@ -74,7 +49,6 @@ pub trait AsyncArrayReadOps: ArrayOps {
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Async variant of [`ArrayReadOps::retrieve_array_subset`].
@@ -84,27 +58,11 @@ pub trait AsyncArrayReadOps: ArrayOps {
         array_subset: &dyn ArraySubsetTraits,
     ) -> Result<T, ArrayError>;
 
-    /// Async variant of [`ArrayReadOps::retrieve_array_subset_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_array_subset_opt<T: FromArrayBytes>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError>;
-
     /// Async variant of [`ArrayReadOps::retrieve_chunk_if_exists`].
     #[allow(clippy::missing_errors_doc)]
     async fn async_retrieve_chunk_if_exists<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<T>, ArrayError>;
-
-    /// Async variant of [`ArrayReadOps::retrieve_chunk_if_exists_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_chunk_if_exists_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<T>, ArrayError>;
 
     /// Async variant of [`ArrayReadOps::retrieve_encoded_chunk`].
@@ -117,17 +75,6 @@ pub trait AsyncArrayReadOps: ArrayOps {
     async fn async_retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<Bytes>, StorageError> {
-        self.async_retrieve_encoded_chunk_opt(chunk_indices, self.codec_options())
-            .await
-    }
-
-    /// Async variant of [`ArrayReadOps::retrieve_encoded_chunk_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_encoded_chunk_opt(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<Bytes>, StorageError>;
 
     /// Async variant of [`ArrayReadOps::retrieve_encoded_chunks`].
@@ -142,37 +89,24 @@ pub trait AsyncArrayReadOps: ArrayOps {
     async fn async_retrieve_encoded_chunks(
         &self,
         chunks: &dyn ArraySubsetTraits,
-    ) -> Result<Vec<Option<Bytes>>, StorageError> {
-        self.async_retrieve_encoded_chunks_opt(chunks, self.codec_options())
-            .await
-    }
-
-    /// Async variant of [`ArrayReadOps::retrieve_encoded_chunks_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_encoded_chunks_opt(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<Vec<Option<Bytes>>, StorageError>;
 
-    /// Async variant of [`ArrayReadOps::retrieve_subchunk_opt`].
+    /// Async variant of [`ArrayReadOps::retrieve_subchunk`].
     #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_subchunk_opt<T: FromArrayBytes>(
+    async fn async_retrieve_subchunk<T: FromArrayBytes>(
         &self,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_subchunk_at_level_opt(0, subchunk_indices, options)
+        self.async_retrieve_subchunk_at_level(0, subchunk_indices)
             .await
     }
 
-    /// Read and decode a subchunk from `level` asynchronously with explicit codec options.
+    /// Async variant of [`ArrayReadOps::retrieve_subchunk_at_level`].
     #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_subchunk_at_level_opt<T: FromArrayBytes>(
+    async fn async_retrieve_subchunk_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
         let subchunk_grid = self
             .subchunk_grid_at_level(level)
@@ -181,28 +115,24 @@ pub trait AsyncArrayReadOps: ArrayOps {
         let array_subset = subchunk_grid
             .subset(subchunk_indices)?
             .ok_or_else(|| ArrayError::InvalidChunkGridIndicesError(subchunk_indices.to_vec()))?;
-        self.async_retrieve_array_subset_opt(&array_subset, options)
-            .await
+        self.async_retrieve_array_subset(&array_subset).await
     }
 
-    /// Async variant of [`ArrayReadOps::retrieve_subchunks_opt`].
+    /// Async variant of [`ArrayReadOps::retrieve_subchunks`].
     #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_subchunks_opt<T: FromArrayBytes>(
+    async fn async_retrieve_subchunks<T: FromArrayBytes>(
         &self,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_subchunks_at_level_opt(0, subchunks, options)
-            .await
+        self.async_retrieve_subchunks_at_level(0, subchunks).await
     }
 
-    /// Read and decode subchunks from `level` asynchronously with explicit codec options.
+    /// Async variant of [`ArrayReadOps::retrieve_subchunks_at_level`].
     #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_subchunks_at_level_opt<T: FromArrayBytes>(
+    async fn async_retrieve_subchunks_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError> {
         let subchunk_grid = self
             .subchunk_grid_at_level(level)
@@ -214,8 +144,7 @@ pub trait AsyncArrayReadOps: ArrayOps {
                 subchunk_grid.grid_shape().to_vec(),
             )
         })?;
-        self.async_retrieve_array_subset_opt(&array_subset, options)
-            .await
+        self.async_retrieve_array_subset(&array_subset).await
     }
 
     /// Async variant of [`ArrayReadOps::retrieve_array_subset_into`].
@@ -226,15 +155,6 @@ pub trait AsyncArrayReadOps: ArrayOps {
         output_target: ArrayBytesDecodeIntoTarget<'_>,
     ) -> Result<(), ArrayError>;
 
-    /// Async variant of [`ArrayReadOps::retrieve_array_subset_into_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_retrieve_array_subset_into_opt(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError>;
-
     /// Async variant of [`ArrayReadOps::partial_decoder`].
     #[allow(clippy::missing_errors_doc)]
     async fn async_partial_decoder(
@@ -242,22 +162,13 @@ pub trait AsyncArrayReadOps: ArrayOps {
         chunk_indices: &[u64],
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, ArrayError>;
 
-    /// Async variant of [`ArrayReadOps::partial_decoder_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_partial_decoder_opt(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, ArrayError>;
-
     /// Async variant of [`ArrayReadOps::local_subchunk_grid`].
     #[allow(clippy::missing_errors_doc)]
     async fn async_local_subchunk_grid(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<ChunkGrid>, ArrayError> {
-        self.async_local_subchunk_grid_at_level(0, chunk_indices, options)
+        self.async_local_subchunk_grid_at_level(0, chunk_indices)
             .await
     }
 
@@ -267,12 +178,11 @@ pub trait AsyncArrayReadOps: ArrayOps {
         &self,
         level: usize,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<ChunkGrid>, ArrayError> {
         Ok(self
-            .async_partial_decoder_opt(chunk_indices, options)
+            .async_partial_decoder(chunk_indices)
             .await?
-            .local_subchunk_grids(options)
+            .local_subchunk_grids(self.codec_options())
             .await
             .map_err(ArrayError::CodecError)?
             .into_iter()

--- a/zarrs/src/array/array_ops/async_array_read_ops_array.rs
+++ b/zarrs/src/array/array_ops/async_array_read_ops_array.rs
@@ -28,17 +28,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         chunk_indices: &[u64],
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_chunk_opt(chunk_indices, self.codec_options())
-            .await
-    }
-
-    pub async fn async_retrieve_chunk_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
         if let Some(chunk) = self
-            .async_retrieve_chunk_if_exists_opt::<T>(chunk_indices, options)
+            .async_retrieve_chunk_if_exists::<T>(chunk_indices)
             .await?
         {
             Ok(chunk)
@@ -63,8 +54,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         chunk_indices: &[u64],
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         if chunk_indices.len() != self.dimensionality() {
             return Err(ArrayError::InvalidChunkGridIndicesError(
                 chunk_indices.to_vec(),
@@ -98,15 +89,6 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
     pub async fn async_retrieve_chunks<T: FromArrayBytes>(
         &self,
         chunks: &dyn ArraySubsetTraits,
-    ) -> Result<T, ArrayError> {
-        self.async_retrieve_chunks_opt(chunks, self.codec_options())
-            .await
-    }
-
-    pub async fn async_retrieve_chunks_opt<T: FromArrayBytes>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     pub async fn async_retrieve_chunk_subset<T: FromArrayBytes>(
@@ -114,16 +96,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_chunk_subset_opt(chunk_indices, chunk_subset, self.codec_options())
-            .await
-    }
-
-    pub async fn async_retrieve_chunk_subset_opt<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
+        let options = self.codec_options();
         let chunk_shape = self.chunk_shape(chunk_indices)?;
         let chunk_shape_u64 = bytemuck::must_cast_slice(&chunk_shape);
         if !chunk_subset.inbounds_shape(chunk_shape_u64) {
@@ -137,7 +110,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         if chunk_subset.start().iter().all(|&o| o == 0)
             && chunk_subset_shape.as_ref() == chunk_shape_u64
         {
-            self.async_retrieve_chunk_opt(chunk_indices, options).await
+            self.async_retrieve_chunk(chunk_indices).await
         } else {
             let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
             let storage_transformer = self
@@ -162,8 +135,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         chunk_indices: &[u64],
         chunk_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let chunk_shape = self.chunk_shape(chunk_indices)?;
         let chunk_shape_u64 = bytemuck::must_cast_slice(&chunk_shape);
         if !chunk_subset.inbounds_shape(chunk_shape_u64) {
@@ -176,7 +149,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         if chunk_subset.start().iter().all(|&o| o == 0)
             && chunk_subset.shape().as_ref() == chunk_shape_u64
         {
-            self.async_retrieve_chunk_into(chunk_indices, output_target, options)
+            self.async_retrieve_chunk_into(chunk_indices, output_target)
                 .await
         } else {
             let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
@@ -198,15 +171,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         &self,
         array_subset: &dyn ArraySubsetTraits,
     ) -> Result<T, ArrayError> {
-        self.async_retrieve_array_subset_opt(array_subset, self.codec_options())
-            .await
-    }
-
-    pub async fn async_retrieve_array_subset_opt<T: FromArrayBytes>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
-    ) -> Result<T, ArrayError> {
+        let options = self.codec_options();
         if array_subset.dimensionality() != self.dimensionality() {
             return Err(ArrayError::InvalidArraySubset(
                 array_subset.to_array_subset(),
@@ -239,16 +204,12 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
                 let chunk_indices = chunks.start();
                 let chunk_subset = self.chunk_subset(chunk_indices)?;
                 if chunk_subset == array_subset {
-                    self.async_retrieve_chunk_opt(chunk_indices, options).await
+                    self.async_retrieve_chunk(chunk_indices).await
                 } else {
                     let array_subset_in_chunk_subset =
                         array_subset.relative_to(chunk_subset.start())?;
-                    self.async_retrieve_chunk_subset_opt(
-                        chunk_indices,
-                        &array_subset_in_chunk_subset,
-                        options,
-                    )
-                    .await
+                    self.async_retrieve_chunk_subset(chunk_indices, &array_subset_in_chunk_subset)
+                        .await
                 }
             }
             _ => {
@@ -285,24 +246,11 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         }
     }
 
-    pub async fn async_retrieve_chunk_if_exists<T: FromArrayBytes>(
-        &self,
-        chunk_indices: &[u64],
-    ) -> Result<Option<T>, ArrayError> {
-        self.async_retrieve_chunk_if_exists_opt(chunk_indices, self.codec_options())
-            .await
-    }
-
     pub async fn async_retrieve_encoded_chunk(
         &self,
         chunk_indices: &[u64],
-    ) -> Result<Option<Bytes>, StorageError>;
-
-    pub async fn async_retrieve_encoded_chunk_opt(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<Bytes>, StorageError> {
+        let options = self.codec_options();
         let _ = options;
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
@@ -315,32 +263,15 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
             .await
     }
 
-    pub async fn async_retrieve_array_subset_into(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        output_target: ArrayBytesDecodeIntoTarget<'_>,
-    ) -> Result<(), ArrayError> {
-        self.async_retrieve_array_subset_into_opt(array_subset, output_target, self.codec_options())
-            .await
-    }
-
-    pub async fn async_partial_decoder(
-        &self,
-        chunk_indices: &[u64],
-    ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, ArrayError> {
-        self.async_partial_decoder_opt(chunk_indices, self.codec_options())
-            .await
-    }
-
     /////////////////////////////////////////////////////////////////////////////
     // Advanced methods
     /////////////////////////////////////////////////////////////////////////////
 
-    pub async fn async_retrieve_chunk_if_exists_opt<T: FromArrayBytes>(
+    pub async fn async_retrieve_chunk_if_exists<T: FromArrayBytes>(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Option<T>, ArrayError> {
+        let options = self.codec_options();
         if chunk_indices.len() != self.dimensionality() {
             return Err(ArrayError::InvalidChunkGridIndicesError(
                 chunk_indices.to_vec(),
@@ -375,13 +306,8 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
     pub async fn async_retrieve_encoded_chunks(
         &self,
         chunks: &dyn ArraySubsetTraits,
-    ) -> Result<Vec<Option<Bytes>>, StorageError>;
-
-    pub async fn async_retrieve_encoded_chunks_opt(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<Vec<Option<Bytes>>, StorageError> {
+        let options = self.codec_options();
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
@@ -405,40 +331,36 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
             .await
     }
 
-    pub async fn async_retrieve_subchunk_opt<T: FromArrayBytes>(
+    pub async fn async_retrieve_subchunk<T: FromArrayBytes>(
         &self,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub async fn async_retrieve_subchunk_at_level_opt<T: FromArrayBytes>(
+    pub async fn async_retrieve_subchunk_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
-    pub async fn async_retrieve_subchunks_opt<T: FromArrayBytes>(
+    pub async fn async_retrieve_subchunks<T: FromArrayBytes>(
         &self,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
     #[allow(clippy::missing_errors_doc)]
-    pub async fn async_retrieve_subchunks_at_level_opt<T: FromArrayBytes>(
+    pub async fn async_retrieve_subchunks_at_level<T: FromArrayBytes>(
         &self,
         level: usize,
         subchunks: &dyn ArraySubsetTraits,
-        options: &CodecOptions,
     ) -> Result<T, ArrayError>;
 
-    pub async fn async_retrieve_array_subset_into_opt(
+    pub async fn async_retrieve_array_subset_into(
         &self,
         array_subset: &dyn ArraySubsetTraits,
         output_target: ArrayBytesDecodeIntoTarget<'_>,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         if array_subset.dimensionality() != self.dimensionality() {
             return Err(ArrayError::InvalidArraySubset(
                 array_subset.to_array_subset(),
@@ -479,7 +401,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
                 let chunk_indices = chunks.start();
                 let chunk_subset = self.chunk_subset(chunk_indices)?;
                 if chunk_subset == array_subset {
-                    self.async_retrieve_chunk_into(chunk_indices, output_target, options)
+                    self.async_retrieve_chunk_into(chunk_indices, output_target)
                         .await
                 } else {
                     let array_subset_in_chunk_subset =
@@ -488,7 +410,6 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
                         chunk_indices,
                         &array_subset_in_chunk_subset,
                         output_target,
-                        options,
                     )
                     .await
                 }
@@ -515,11 +436,11 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
         }
     }
 
-    pub async fn async_partial_decoder_opt(
+    pub async fn async_partial_decoder(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialDecoderTraits>, ArrayError> {
+        let options = self.codec_options();
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
@@ -531,6 +452,17 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> AsyncArrayReadOps
             .async_partial_decoder(input_handle, &self.chunk_shape(chunk_indices)?, options)
             .await?)
     }
+
+    pub async fn async_local_subchunk_grid(
+        &self,
+        chunk_indices: &[u64],
+    ) -> Result<Option<ChunkGrid>, ArrayError>;
+
+    pub async fn async_local_subchunk_grid_at_level(
+        &self,
+        level: usize,
+        chunk_indices: &[u64],
+    ) -> Result<Option<ChunkGrid>, ArrayError>;
 }
 
 impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
@@ -544,6 +476,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         chunk_concurrent_limit: usize,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'_>, ArrayError> {
+        // Per-chunk retrieval must use the concurrency-adjusted options, so operate
+        // through an array carrying them. Cloned once, outside the loop.
+        let tuned_array = self.with_codec_options(*options);
+
         let nesting_depth = optional_nesting_depth(data_type);
         let array_subset_start = array_subset.start();
         let array_subset_shape = array_subset.shape();
@@ -551,17 +487,18 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         if nesting_depth > 0 {
             let retrieve_chunk = |chunk_indices: ArrayIndicesTinyVec| {
                 let array_subset_start = &array_subset_start;
+                let tuned_array = &tuned_array;
                 async move {
                     let chunk_subset = self.chunk_subset(&chunk_indices)?;
                     let chunk_subset_overlap = chunk_subset.overlap(array_subset)?;
                     Ok::<_, ArrayError>((
-                        self.async_retrieve_chunk_subset_opt::<ArrayBytes>(
-                            &chunk_indices,
-                            &chunk_subset_overlap.relative_to(chunk_subset.start())?,
-                            options,
-                        )
-                        .await?
-                        .into_optional()?,
+                        tuned_array
+                            .async_retrieve_chunk_subset::<ArrayBytes>(
+                                &chunk_indices,
+                                &chunk_subset_overlap.relative_to(chunk_subset.start())?,
+                            )
+                            .await?
+                            .into_optional()?,
                         chunk_subset_overlap.relative_to(array_subset_start)?,
                     ))
                 }
@@ -581,17 +518,18 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         } else {
             let retrieve_chunk = |chunk_indices: ArrayIndicesTinyVec| {
                 let array_subset_start = &array_subset_start;
+                let tuned_array = &tuned_array;
                 async move {
                     let chunk_subset = self.chunk_subset(&chunk_indices)?;
                     let chunk_subset_overlap = chunk_subset.overlap(array_subset)?;
                     Ok::<_, ArrayError>((
-                        self.async_retrieve_chunk_subset_opt::<ArrayBytes>(
-                            &chunk_indices,
-                            &chunk_subset_overlap.relative_to(chunk_subset.start())?,
-                            options,
-                        )
-                        .await?
-                        .into_variable()?,
+                        tuned_array
+                            .async_retrieve_chunk_subset::<ArrayBytes>(
+                                &chunk_indices,
+                                &chunk_subset_overlap.relative_to(chunk_subset.start())?,
+                            )
+                            .await?
+                            .into_variable()?,
                         chunk_subset_overlap.relative_to(array_subset_start)?,
                     ))
                 }
@@ -620,6 +558,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         chunk_concurrent_limit: usize,
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'_>, ArrayError> {
+        // Per-chunk retrieval must use the concurrency-adjusted options, so operate
+        // through an array carrying them. Cloned once, outside the loop.
+        let tuned_array = self.with_codec_options(*options);
+
         let data_type_size = data_type
             .fixed_size()
             .expect("data_type must have fixed size");
@@ -645,6 +587,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             let retrieve_chunk = |chunk_indices: ArrayIndicesTinyVec| {
                 let array_subset_start = &array_subset_start;
                 let array_subset_shape = &array_subset_shape;
+                let tuned_array = &tuned_array;
                 async move {
                     let chunk_subset = self.chunk_subset(&chunk_indices)?;
                     let chunk_subset_overlap = chunk_subset.overlap(array_subset)?;
@@ -677,13 +620,13 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
                     let target =
                         build_nested_optional_target(&mut data_view, mask_views.as_mut_slice());
 
-                    self.async_retrieve_chunk_subset_into(
-                        &chunk_indices,
-                        &chunk_subset_overlap.relative_to(chunk_subset.start())?,
-                        target,
-                        options,
-                    )
-                    .await?;
+                    tuned_array
+                        .async_retrieve_chunk_subset_into(
+                            &chunk_indices,
+                            &chunk_subset_overlap.relative_to(chunk_subset.start())?,
+                            target,
+                        )
+                        .await?;
                     Ok::<_, ArrayError>(())
                 }
             };
@@ -714,6 +657,10 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
         output_target: &ArrayBytesDecodeIntoTarget<'_>,
         options: &CodecOptions,
     ) -> Result<(), ArrayError> {
+        // Per-chunk retrieval must use the concurrency-adjusted options, so operate
+        // through an array carrying them. Cloned once, outside the loop.
+        let tuned_array = self.with_codec_options(*options);
+
         let (data_view_ref, mask_view_refs) = extract_target_views(output_target);
         let parent_start = data_view_ref.subset().start().to_vec();
         let array_subset_start = array_subset.start();
@@ -722,6 +669,7 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
             let array_subset_start = &array_subset_start;
             let parent_start = &parent_start;
             let mask_view_refs = &mask_view_refs;
+            let tuned_array = &tuned_array;
             async move {
                 let chunk_subset = self.chunk_subset(&chunk_indices)?;
                 let chunk_subset_overlap = chunk_subset.overlap(array_subset)?;
@@ -753,13 +701,13 @@ impl<TStorage: ?Sized + AsyncReadableStorageTraits + 'static> Array<TStorage> {
 
                 let target = build_nested_optional_target(&mut data_sub, mask_subs.as_mut_slice());
 
-                self.async_retrieve_chunk_subset_into(
-                    &chunk_indices,
-                    &chunk_subset_overlap.relative_to(chunk_subset.start())?,
-                    target,
-                    options,
-                )
-                .await?;
+                tuned_array
+                    .async_retrieve_chunk_subset_into(
+                        &chunk_indices,
+                        &chunk_subset_overlap.relative_to(chunk_subset.start())?,
+                        target,
+                    )
+                    .await?;
                 Ok::<_, ArrayError>(())
             }
         };

--- a/zarrs/src/array/array_ops/async_array_update_ops.rs
+++ b/zarrs/src/array/array_ops/async_array_update_ops.rs
@@ -3,6 +3,9 @@ use std::sync::Arc;
 use zarrs_codec::AsyncArrayPartialEncoderTraits;
 
 /// Asynchronous array read/write update operations.
+///
+/// These operations encode and decode with the array's
+/// [`codec_options`](ArrayOps::codec_options).
 #[cfg(feature = "async")]
 #[allow(async_fn_in_trait)]
 pub trait AsyncArrayUpdateOps: AsyncArrayReadOps + AsyncArrayWriteOps {
@@ -15,16 +18,6 @@ pub trait AsyncArrayUpdateOps: AsyncArrayReadOps + AsyncArrayWriteOps {
         chunk_subset_data: T,
     ) -> Result<(), ArrayError>;
 
-    /// Async variant of [`ArrayUpdateOps::store_chunk_subset_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_store_chunk_subset_opt<'a, T: IntoArrayBytes<'a> + MaybeSend>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        chunk_subset_data: T,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError>;
-
     /// Async variant of [`ArrayUpdateOps::store_array_subset`].
     #[allow(clippy::missing_errors_doc)]
     async fn async_store_array_subset<'a, T: IntoArrayBytes<'a> + MaybeSend>(
@@ -33,22 +26,9 @@ pub trait AsyncArrayUpdateOps: AsyncArrayReadOps + AsyncArrayWriteOps {
         subset_data: T,
     ) -> Result<(), ArrayError>;
 
-    /// Async variant of [`ArrayUpdateOps::store_array_subset_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_store_array_subset_opt<'a, T: IntoArrayBytes<'a> + MaybeSend>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        subset_data: T,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError>;
-
     /// Async variant of [`ArrayUpdateOps::compact_chunk`].
     #[allow(clippy::missing_errors_doc)]
-    async fn async_compact_chunk(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<bool, ArrayError>;
+    async fn async_compact_chunk(&self, chunk_indices: &[u64]) -> Result<bool, ArrayError>;
 
     /// Return a read-only instantiation of the array.
     fn async_readable(&self) -> Array<dyn AsyncReadableStorageTraits>;
@@ -58,6 +38,5 @@ pub trait AsyncArrayUpdateOps: AsyncArrayReadOps + AsyncArrayWriteOps {
     async fn async_partial_encoder(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, ArrayError>;
 }

--- a/zarrs/src/array/array_ops/async_array_update_ops_array.rs
+++ b/zarrs/src/array/array_ops/async_array_update_ops_array.rs
@@ -20,22 +20,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
         chunk_subset: &dyn ArraySubsetTraits,
         chunk_subset_data: T,
     ) -> Result<(), ArrayError> {
-        self.async_store_chunk_subset_opt(
-            chunk_indices,
-            chunk_subset,
-            chunk_subset_data,
-            self.codec_options(),
-        )
-        .await
-    }
-
-    pub async fn async_store_chunk_subset_opt<'a, T: IntoArrayBytes<'a> + MaybeSend>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_subset: &dyn ArraySubsetTraits,
-        chunk_subset_data: T,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let chunk_shape = self
             .chunk_grid()
             .chunk_shape_u64(chunk_indices)?
@@ -54,7 +39,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
             && chunk_subset.start().iter().all(|&x| x == 0)
         {
             // The subset spans the whole chunk, so store the bytes directly and skip decoding
-            self.async_store_chunk_opt(chunk_indices, chunk_subset_data, options)
+            self.async_store_chunk(chunk_indices, chunk_subset_data)
                 .await
         } else {
             let chunk_subset_bytes = chunk_subset_data.into_array_bytes(self.data_type())?;
@@ -64,7 +49,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
                 && self.codecs.partial_encoder_capability().partial_encode
                 && self.storage.supports_set_partial()
             {
-                let partial_encoder = self.async_partial_encoder(chunk_indices, options).await?;
+                let partial_encoder = self.async_partial_encoder(chunk_indices).await?;
                 debug_assert!(
                     partial_encoder.supports_partial_encode(),
                     "partial encoder is misrepresenting its capabilities"
@@ -75,9 +60,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
                 Ok(())
             } else {
                 // Decode the entire chunk
-                let chunk_bytes_old = self
-                    .async_retrieve_chunk_opt(chunk_indices, options)
-                    .await?;
+                let chunk_bytes_old = self.async_retrieve_chunk(chunk_indices).await?;
 
                 // Update the chunk
                 let chunk_bytes_new = update_array_bytes(
@@ -89,8 +72,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
                 )?;
 
                 // Store the updated chunk
-                self.async_store_chunk_opt(chunk_indices, chunk_bytes_new, options)
-                    .await
+                self.async_store_chunk(chunk_indices, chunk_bytes_new).await
             }
         }
     }
@@ -100,16 +82,7 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
         array_subset: &dyn ArraySubsetTraits,
         subset_data: T,
     ) -> Result<(), ArrayError> {
-        self.async_store_array_subset_opt(array_subset, subset_data, self.codec_options())
-            .await
-    }
-
-    pub async fn async_store_array_subset_opt<'a, T: IntoArrayBytes<'a> + MaybeSend>(
-        &self,
-        array_subset: &dyn ArraySubsetTraits,
-        subset_data: T,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         // Validation
         if array_subset.dimensionality() != self.shape().len() {
             return Err(ArrayError::InvalidArraySubset(
@@ -133,15 +106,13 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
             if chunk_subset == array_subset {
                 // A fast path if the array subset matches the chunk subset
                 // This skips the internal decoding occurring in store_chunk_subset
-                self.async_store_chunk_opt(chunk_indices, subset_data, options)
-                    .await?;
+                self.async_store_chunk(chunk_indices, subset_data).await?;
             } else {
                 // Store the chunk subset
-                self.async_store_chunk_subset_opt(
+                self.async_store_chunk_subset(
                     chunk_indices,
                     &array_subset.relative_to(chunk_subset.start())?,
                     subset_data,
-                    options,
                 )
                 .await?;
             }
@@ -159,6 +130,10 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
                 &codec_concurrency,
             );
 
+            // Per-chunk stores must use the concurrency-adjusted options, so operate through
+            // an array carrying them. Cloned once, outside the loop.
+            let tuned_array = self.with_codec_options(options);
+
             let array_subset_start = array_subset.start();
             let array_subset_shape = array_subset.shape();
             let store_chunk = |chunk_indices: ArrayIndicesTinyVec| {
@@ -175,14 +150,15 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
                         self.data_type(),
                     )
                     .unwrap(); // FIXME: unwrap
+                let tuned_array = &tuned_array;
                 async move {
-                    self.async_store_chunk_subset_opt(
-                        &chunk_indices,
-                        &array_subset_in_chunk_subset,
-                        chunk_subset_bytes,
-                        &options,
-                    )
-                    .await
+                    tuned_array
+                        .async_store_chunk_subset(
+                            &chunk_indices,
+                            &array_subset_in_chunk_subset,
+                            chunk_subset_bytes,
+                        )
+                        .await
                 }
             };
 
@@ -194,11 +170,8 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
         Ok(())
     }
 
-    pub async fn async_compact_chunk(
-        &self,
-        chunk_indices: &[u64],
-        options: &CodecOptions,
-    ) -> Result<bool, ArrayError> {
+    pub async fn async_compact_chunk(&self, chunk_indices: &[u64]) -> Result<bool, ArrayError> {
+        let options = self.codec_options();
         let chunk_bytes = self.async_retrieve_encoded_chunk(chunk_indices).await?;
         if let Some(chunk_bytes) = chunk_bytes {
             let chunk_bytes: Vec<u8> = chunk_bytes.into();
@@ -226,15 +199,11 @@ impl<TStorage: ?Sized + AsyncReadableWritableStorageTraits + 'static> AsyncArray
         self.with_storage(self.storage.clone().readable())
     }
 
-    /////////////////////////////////////////////////////////////////////////////
-    // Advanced methods
-    /////////////////////////////////////////////////////////////////////////////
-
     pub async fn async_partial_encoder(
         &self,
         chunk_indices: &[u64],
-        options: &CodecOptions,
     ) -> Result<Arc<dyn AsyncArrayPartialEncoderTraits>, ArrayError> {
+        let options = self.codec_options();
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
 
         let chunk_shape = self.chunk_shape(chunk_indices)?;

--- a/zarrs/src/array/array_ops/async_array_write_ops.rs
+++ b/zarrs/src/array/array_ops/async_array_write_ops.rs
@@ -1,6 +1,10 @@
 use super::*;
 
 /// Asynchronous array write operations.
+///
+/// These operations encode with the array's [`codec_options`](ArrayOps::codec_options) and write
+/// metadata according to its [`metadata_options`](ArrayOps::metadata_options) and
+/// [`metadata_erase_version`](ArrayOps::metadata_erase_version).
 #[cfg(feature = "async")]
 #[allow(async_fn_in_trait)]
 pub trait AsyncArrayWriteOps: ArrayOps {
@@ -8,23 +12,9 @@ pub trait AsyncArrayWriteOps: ArrayOps {
     #[allow(clippy::missing_errors_doc)]
     async fn async_store_metadata(&self) -> Result<(), StorageError>;
 
-    /// Async variant of [`ArrayWriteOps::store_metadata_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_store_metadata_opt(
-        &self,
-        options: &ArrayMetadataOptions,
-    ) -> Result<(), StorageError>;
-
     /// Async variant of [`ArrayWriteOps::erase_metadata`].
     #[allow(clippy::missing_errors_doc)]
     async fn async_erase_metadata(&self) -> Result<(), StorageError>;
-
-    /// Async variant of [`ArrayWriteOps::erase_metadata_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_erase_metadata_opt(
-        &self,
-        options: MetadataEraseVersion,
-    ) -> Result<(), StorageError>;
 
     /// Async variant of [`ArrayWriteOps::store_chunk`].
     #[allow(clippy::missing_errors_doc)]
@@ -34,30 +24,12 @@ pub trait AsyncArrayWriteOps: ArrayOps {
         chunk_data: T,
     ) -> Result<(), ArrayError>;
 
-    /// Async variant of [`ArrayWriteOps::store_chunk_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_store_chunk_opt<'a, T: IntoArrayBytes<'a> + MaybeSend>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_data: T,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError>;
-
     /// Async variant of [`ArrayWriteOps::store_chunks`].
     #[allow(clippy::missing_errors_doc)]
     async fn async_store_chunks<'a, T: IntoArrayBytes<'a> + MaybeSend>(
         &self,
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
-    ) -> Result<(), ArrayError>;
-
-    /// Async variant of [`ArrayWriteOps::store_chunks_opt`].
-    #[allow(clippy::missing_errors_doc)]
-    async fn async_store_chunks_opt<'a, T: IntoArrayBytes<'a> + MaybeSend>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        chunks_data: T,
-        options: &CodecOptions,
     ) -> Result<(), ArrayError>;
 
     /// Async variant of [`ArrayWriteOps::erase_chunk`].

--- a/zarrs/src/array/array_ops/async_array_write_ops_array.rs
+++ b/zarrs/src/array/array_ops/async_array_write_ops_array.rs
@@ -16,13 +16,6 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
     for Array<TStorage>
 {
     pub async fn async_store_metadata(&self) -> Result<(), StorageError> {
-        self.async_store_metadata_opt(self.metadata_options()).await
-    }
-
-    pub async fn async_store_metadata_opt(
-        &self,
-        options: &ArrayMetadataOptions,
-    ) -> Result<(), StorageError> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
         let storage_transformer = self
             .storage_transformers()
@@ -30,7 +23,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
             .await?;
 
         // Get the metadata with options applied and store
-        let metadata = self.metadata_opt(options);
+        let metadata = self.metadata_to_store();
 
         // Store the metadata
         let path = self.path();
@@ -67,17 +60,10 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
     }
 
     pub async fn async_erase_metadata(&self) -> Result<(), StorageError> {
-        self.async_erase_metadata_opt(self.metadata_erase_version())
-            .await
-    }
-
-    pub async fn async_erase_metadata_opt(
-        &self,
-        options: MetadataEraseVersion,
-    ) -> Result<(), StorageError> {
+        let options = self.metadata_erase_version();
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
-            MetadataEraseVersion::Default => match self.metadata {
+            MetadataEraseVersion::Default => match *self.metadata {
                 ArrayMetadata::V3(_) => storage_handle.erase(&meta_key_v3(self.path())).await,
                 ArrayMetadata::V2(_) => {
                     storage_handle
@@ -114,16 +100,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
         chunk_indices: &[u64],
         chunk_data: T,
     ) -> Result<(), ArrayError> {
-        self.async_store_chunk_opt(chunk_indices, chunk_data, self.codec_options())
-            .await
-    }
-
-    pub async fn async_store_chunk_opt<'a, T: IntoArrayBytes<'a> + MaybeSend>(
-        &self,
-        chunk_indices: &[u64],
-        chunk_data: T,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let chunk_bytes = chunk_data.into_array_bytes(self.data_type())?;
 
         // Validation
@@ -150,16 +127,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
         chunks: &dyn ArraySubsetTraits,
         chunks_data: T,
     ) -> Result<(), ArrayError> {
-        self.async_store_chunks_opt(chunks, chunks_data, self.codec_options())
-            .await
-    }
-
-    pub async fn async_store_chunks_opt<'a, T: IntoArrayBytes<'a> + MaybeSend>(
-        &self,
-        chunks: &dyn ArraySubsetTraits,
-        chunks_data: T,
-        options: &CodecOptions,
-    ) -> Result<(), ArrayError> {
+        let options = self.codec_options();
         let num_chunks = chunks.num_elements_usize();
         match num_chunks {
             0 => {
@@ -168,8 +136,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
             }
             1 => {
                 let chunk_indices = chunks.start();
-                self.async_store_chunk_opt(&chunk_indices, chunks_data, options)
-                    .await?;
+                self.async_store_chunk(&chunk_indices, chunks_data).await?;
             }
             _ => {
                 let chunks_bytes = chunks_data.into_array_bytes(self.data_type())?;
@@ -186,6 +153,10 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
                     &codec_concurrency,
                 );
 
+                // Per-chunk stores must use the concurrency-adjusted options, so operate
+                // through an array carrying them. Cloned once, outside the loop.
+                let tuned_array = self.with_codec_options(options);
+
                 let store_chunk = |chunk_indices: ArrayIndicesTinyVec| {
                     let chunk_subset = self.chunk_subset(&chunk_indices).unwrap(); // FIXME: unwrap
                     let chunk_bytes = chunks_bytes
@@ -195,8 +166,10 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
                             self.data_type(),
                         )
                         .unwrap(); // FIXME: unwrap
+                    let tuned_array = &tuned_array;
                     async move {
-                        self.async_store_chunk_opt(&chunk_indices, chunk_bytes, &options)
+                        tuned_array
+                            .async_store_chunk(&chunk_indices, chunk_bytes)
                             .await
                     }
                 };

--- a/zarrs/src/array/array_ops/async_array_write_ops_array.rs
+++ b/zarrs/src/array/array_ops/async_array_write_ops_array.rs
@@ -23,7 +23,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits + 'static> AsyncArrayWriteOps
             .await?;
 
         // Get the metadata with options applied and store
-        let metadata = self.metadata_to_store();
+        let metadata = self.metadata_opt();
 
         // Store the metadata
         let path = self.path();

--- a/zarrs/src/array/builder.rs
+++ b/zarrs/src/array/builder.rs
@@ -591,12 +591,12 @@ impl ArrayBuilder {
         let path: NodePath = path.try_into()?;
         let codec_chain = Arc::new(self.build_codec_chain()?);
         let array_metadata_v3 = self.build_metadata_with_codec_chain(&codec_chain)?;
-        Ok(
-            Array::new_with_codec_chain(storage, path, array_metadata_v3, codec_chain)?
-                .with_metadata_options(self.metadata_options)
-                .with_codec_options(self.codec_options)
-                .with_codec_specific_options(&self.codec_specific_options)?,
-        )
+        // The array is owned here, so set the options in place rather than deriving copies.
+        let mut array = Array::new_with_codec_chain(storage, path, array_metadata_v3, codec_chain)?;
+        array.set_metadata_options(self.metadata_options);
+        array.set_codec_options(self.codec_options);
+        array.set_codec_specific_options(&self.codec_specific_options)?;
+        Ok(array)
     }
 
     /// Build into an [`Arc<Array>`].

--- a/zarrs/src/array/chunk_cache/chunk_cache_type/decoded.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_type/decoded.rs
@@ -99,7 +99,8 @@ impl ChunkCacheType for ChunkCacheTypeDecoded {
         cache
             .try_get_or_insert_with(chunk_indices.to_vec(), || {
                 Ok(array
-                    .retrieve_chunk_if_exists_opt::<ArrayBytes<'static>>(chunk_indices, options)?
+                    .with_codec_options(*options)
+                    .retrieve_chunk_if_exists::<ArrayBytes<'static>>(chunk_indices)?
                     .map(Arc::new))
             })
             .map_err(cache_error)

--- a/zarrs/src/array/chunk_cache/chunk_cache_type/partial_decoder.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_type/partial_decoder.rs
@@ -27,7 +27,9 @@ impl ChunkCacheType for ChunkCacheTypePartialDecoder {
         validate_chunk_indices(array, chunk_indices)?;
         cache
             .try_get_or_insert_with(chunk_indices.to_vec(), || {
-                array.partial_decoder_opt(chunk_indices, options)
+                array
+                    .with_codec_options(*options)
+                    .partial_decoder(chunk_indices)
             })
             .map_err(cache_error)
     }

--- a/zarrs/src/config.rs
+++ b/zarrs/src/config.rs
@@ -79,7 +79,7 @@ use zarrs_codec::{CodecMetadataOptions, CodecOptions};
 /// ### Metadata Convert Version
 /// > default: [`MetadataConvertVersion::Default`] (keep existing version)
 ///
-/// Determines the Zarr version of metadata created with [`Array::metadata_to_store`](crate::array::Array::metadata_to_store) and [`Group::metadata_to_store`](crate::group::Group::metadata_to_store).
+/// Determines the Zarr version of metadata created with [`Array::metadata_opt`](crate::array::Array::metadata_opt) and [`Group::metadata_opt`](crate::group::Group::metadata_opt).
 /// These methods are used internally by the `store_metadata` methods of [`crate::array::Array`] and [`crate::group::Group`].
 ///
 /// ### Metadata Erase Version
@@ -93,7 +93,7 @@ use zarrs_codec::{CodecMetadataOptions, CodecOptions};
 ///
 /// [`ArrayMetadataOptions::include_zarrs_metadata`](crate::array::ArrayMetadataOptions::include_zarrs_metadata) defaults to [`Config::include_zarrs_metadata`].
 ///
-/// If true, array metadata generated with [`Array::metadata_to_store`](crate::array::Array::metadata_to_store) (used internally by [`Array::store_metadata`](crate::array::Array::store_metadata)) includes the `zarrs` version and a link to its source code.
+/// If true, array metadata generated with [`Array::metadata_opt`](crate::array::Array::metadata_opt) (used internally by [`Array::store_metadata`](crate::array::Array::store_metadata)) includes the `zarrs` version and a link to its source code.
 /// For example:
 /// ```json
 /// "_zarrs": {

--- a/zarrs/src/config.rs
+++ b/zarrs/src/config.rs
@@ -79,8 +79,8 @@ use zarrs_codec::{CodecMetadataOptions, CodecOptions};
 /// ### Metadata Convert Version
 /// > default: [`MetadataConvertVersion::Default`] (keep existing version)
 ///
-/// Determines the Zarr version of metadata created with [`Array::metadata_opt`](crate::array::Array::metadata_opt) and [`Group::metadata_opt`](crate::group::Group::metadata_opt).
-/// These methods are used internally by the `store_metadata` and `store_metadata_opt` methods of [`crate::array::Array`] and [`crate::group::Group`].
+/// Determines the Zarr version of metadata created with [`Array::metadata_to_store`](crate::array::Array::metadata_to_store) and [`Group::metadata_to_store`](crate::group::Group::metadata_to_store).
+/// These methods are used internally by the `store_metadata` methods of [`crate::array::Array`] and [`crate::group::Group`].
 ///
 /// ### Metadata Erase Version
 /// > default: [`MetadataEraseVersion::Default`] (erase existing version)
@@ -93,7 +93,7 @@ use zarrs_codec::{CodecMetadataOptions, CodecOptions};
 ///
 /// [`ArrayMetadataOptions::include_zarrs_metadata`](crate::array::ArrayMetadataOptions::include_zarrs_metadata) defaults to [`Config::include_zarrs_metadata`].
 ///
-/// If true, array metadata generated with [`Array::metadata_opt`](crate::array::Array::metadata_opt) (used internally by [`Array::store_metadata`](crate::array::Array::store_metadata)) includes the `zarrs` version and a link to its source code.
+/// If true, array metadata generated with [`Array::metadata_to_store`](crate::array::Array::metadata_to_store) (used internally by [`Array::store_metadata`](crate::array::Array::store_metadata)) includes the `zarrs` version and a link to its source code.
 /// For example:
 /// ```json
 /// "_zarrs": {

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -315,7 +315,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
     /// constructed, this applies the group's [`GroupMetadataOptions`], which may convert
     /// between Zarr versions. Use [`Group::with_metadata_options`] to control them.
     #[must_use]
-    pub fn metadata_to_store(&self) -> GroupMetadata {
+    pub fn metadata_opt(&self) -> GroupMetadata {
         let options = self.metadata_options();
         use GroupMetadata as GM;
         use MetadataConvertVersion as V;
@@ -863,7 +863,7 @@ impl<TStorage: ?Sized + ReadableStorageTraits> Group<TStorage> {}
 impl<TStorage: ?Sized + WritableStorageTraits> Group<TStorage> {
     /// Store the group metadata.
     ///
-    /// The metadata is created with [`Group::metadata_to_store`]. Use
+    /// The metadata is created with [`Group::metadata_opt`]. Use
     /// [`Group::with_metadata_options`] to control the options applied.
     ///
     /// # Errors
@@ -872,7 +872,7 @@ impl<TStorage: ?Sized + WritableStorageTraits> Group<TStorage> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
 
         // Get the metadata with options applied and store
-        let metadata = self.metadata_to_store();
+        let metadata = self.metadata_opt();
 
         // Write the metadata
         let path = self.path();
@@ -946,7 +946,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Group<TStorage> {
         let storage_handle = StorageHandle::new(self.storage.clone());
 
         // Get the metadata with options applied and store
-        let metadata = self.metadata_to_store();
+        let metadata = self.metadata_opt();
 
         // Write the metadata
         let path = self.path();

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -7,7 +7,7 @@
 //! Use [`GroupBuilder`] to setup a new group, or use [`Group::open`] to read and/or write an existing group.
 //!
 //! ## Group Metadata
-//! Group metadata **must be explicitly stored** with [`store_metadata`](Group::store_metadata) or [`store_metadata_opt`](Group::store_metadata_opt) if a group is newly created or its metadata has been mutated.
+//! Group metadata **must be explicitly stored** with [`store_metadata`](Group::store_metadata) if a group is newly created or its metadata has been mutated.
 //! Support for implicit groups was removed from Zarr V3 after provisional acceptance.
 //!
 //! Below is an example of a `zarr.json` file for a group:
@@ -162,7 +162,7 @@ use zarrs_storage::{
 };
 
 /// A group.
-#[derive(Clone, Debug, Display)]
+#[derive(Debug, Display)]
 #[display(
     "group at {path} with metadata {}",
     "serde_json::to_string(metadata).unwrap_or_default()"
@@ -179,6 +179,21 @@ pub struct Group<TStorage: ?Sized> {
     metadata_options: GroupMetadataOptions,
     metadata_erase_version: MetadataEraseVersion,
     use_consolidated_metadata: UseConsolidatedMetadata,
+}
+
+// A manual impl: `#[derive(Clone)]` would add a spurious `TStorage: Clone` bound, which
+// unsized storage types cannot satisfy.
+impl<TStorage: ?Sized> Clone for Group<TStorage> {
+    fn clone(&self) -> Self {
+        Self {
+            storage: self.storage.clone(),
+            path: self.path.clone(),
+            metadata: self.metadata.clone(),
+            metadata_options: self.metadata_options,
+            metadata_erase_version: self.metadata_erase_version,
+            use_consolidated_metadata: self.use_consolidated_metadata,
+        }
+    }
 }
 
 impl<TStorage: ?Sized> Group<TStorage> {
@@ -259,11 +274,45 @@ impl<TStorage: ?Sized> Group<TStorage> {
         &self.metadata
     }
 
-    /// Return a new [`GroupMetadata`] with [`GroupMetadataOptions`] applied.
-    ///
-    /// This method is used internally by [`Group::store_metadata`] and [`Group::store_metadata_opt`].
+    /// Get the [metadata options](GroupMetadataOptions) used by the group operations.
     #[must_use]
-    pub fn metadata_opt(&self, options: &GroupMetadataOptions) -> GroupMetadata {
+    pub fn metadata_options(&self) -> &GroupMetadataOptions {
+        &self.metadata_options
+    }
+
+    /// Return a copy of this group that uses `metadata_options` for its operations.
+    #[must_use]
+    pub fn with_metadata_options(&self, metadata_options: GroupMetadataOptions) -> Self {
+        let mut group = self.clone();
+        group.metadata_options = metadata_options;
+        group
+    }
+
+    /// Get the [metadata erase version](MetadataEraseVersion) used by the group operations.
+    #[must_use]
+    pub fn metadata_erase_version(&self) -> MetadataEraseVersion {
+        self.metadata_erase_version
+    }
+
+    /// Return a copy of this group that uses `metadata_erase_version` for its operations.
+    #[must_use]
+    pub fn with_metadata_erase_version(
+        &self,
+        metadata_erase_version: MetadataEraseVersion,
+    ) -> Self {
+        let mut group = self.clone();
+        group.metadata_erase_version = metadata_erase_version;
+        group
+    }
+
+    /// Return the group metadata in the form that [`Group::store_metadata`] writes.
+    ///
+    /// Unlike [`metadata`](Group::metadata), which borrows the metadata as it was stored or
+    /// constructed, this applies the group's [`GroupMetadataOptions`], which may convert
+    /// between Zarr versions. Use [`Group::with_metadata_options`] to control them.
+    #[must_use]
+    pub fn metadata_to_store(&self) -> GroupMetadata {
+        let options = self.metadata_options();
         use GroupMetadata as GM;
         use MetadataConvertVersion as V;
         let metadata = self.metadata.clone();
@@ -812,23 +861,18 @@ pub enum GroupCreateError {
 impl<TStorage: ?Sized + ReadableStorageTraits> Group<TStorage> {}
 
 impl<TStorage: ?Sized + WritableStorageTraits> Group<TStorage> {
-    /// Store metadata with default [`GroupMetadataOptions`].
+    /// Store the group metadata.
+    ///
+    /// The metadata is created with [`Group::metadata_to_store`]. Use
+    /// [`Group::with_metadata_options`] to control the options applied.
     ///
     /// # Errors
     /// Returns [`StorageError`] if there is an underlying store error.
     pub fn store_metadata(&self) -> Result<(), StorageError> {
-        self.store_metadata_opt(&self.metadata_options)
-    }
-
-    /// Store metadata with non-default [`GroupMetadataOptions`].
-    ///
-    /// # Errors
-    /// Returns [`StorageError`] if there is an underlying store error.
-    pub fn store_metadata_opt(&self, options: &GroupMetadataOptions) -> Result<(), StorageError> {
         let storage_handle = Arc::new(StorageHandle::new(self.storage.clone()));
 
         // Get the metadata with options applied and store
-        let metadata = self.metadata_opt(options);
+        let metadata = self.metadata_to_store();
 
         // Write the metadata
         let path = self.path();
@@ -870,16 +914,7 @@ impl<TStorage: ?Sized + WritableStorageTraits> Group<TStorage> {
     /// # Errors
     /// Returns a [`StorageError`] if there is an underlying store error.
     pub fn erase_metadata(&self) -> Result<(), StorageError> {
-        self.erase_metadata_opt(self.metadata_erase_version)
-    }
-
-    /// Erase the metadata with non-default [`MetadataEraseVersion`] options.
-    ///
-    /// Succeeds if the metadata does not exist.
-    ///
-    /// # Errors
-    /// Returns a [`StorageError`] if there is an underlying store error.
-    pub fn erase_metadata_opt(&self, options: MetadataEraseVersion) -> Result<(), StorageError> {
+        let options = self.metadata_erase_version();
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
             MetadataEraseVersion::Default => match self.metadata {
@@ -908,19 +943,10 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Group<TStorage> {
     /// Async variant of [`store_metadata`](Group::store_metadata).
     #[allow(clippy::missing_errors_doc)]
     pub async fn async_store_metadata(&self) -> Result<(), StorageError> {
-        self.async_store_metadata_opt(&self.metadata_options).await
-    }
-
-    /// Async variant of [`store_metadata_opt`](Group::store_metadata_opt).
-    #[allow(clippy::missing_errors_doc)]
-    pub async fn async_store_metadata_opt(
-        &self,
-        options: &GroupMetadataOptions,
-    ) -> Result<(), StorageError> {
         let storage_handle = StorageHandle::new(self.storage.clone());
 
         // Get the metadata with options applied and store
-        let metadata = self.metadata_opt(options);
+        let metadata = self.metadata_to_store();
 
         // Write the metadata
         let path = self.path();
@@ -958,16 +984,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Group<TStorage> {
     /// Async variant of [`erase_metadata`](Group::erase_metadata).
     #[allow(clippy::missing_errors_doc)]
     pub async fn async_erase_metadata(&self) -> Result<(), StorageError> {
-        self.async_erase_metadata_opt(self.metadata_erase_version)
-            .await
-    }
-
-    /// Async variant of [`erase_metadata_opt`](Group::erase_metadata_opt).
-    #[allow(clippy::missing_errors_doc)]
-    pub async fn async_erase_metadata_opt(
-        &self,
-        options: MetadataEraseVersion,
-    ) -> Result<(), StorageError> {
+        let options = self.metadata_erase_version();
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
             MetadataEraseVersion::Default => match self.metadata {

--- a/zarrs/src/group.rs
+++ b/zarrs/src/group.rs
@@ -165,7 +165,7 @@ use zarrs_storage::{
 #[derive(Debug, Display)]
 #[display(
     "group at {path} with metadata {}",
-    "serde_json::to_string(metadata).unwrap_or_default()"
+    "serde_json::to_string(&**metadata).unwrap_or_default()"
 )]
 pub struct Group<TStorage: ?Sized> {
     /// The storage.
@@ -175,7 +175,11 @@ pub struct Group<TStorage: ?Sized> {
     #[allow(dead_code)]
     path: NodePath,
     /// The metadata.
-    metadata: GroupMetadata,
+    ///
+    /// Shared behind an [`Arc`] so that cloning a [`Group`] to override its operation options
+    /// does not deep clone the metadata document. Group metadata can contain unbounded user
+    /// attributes and consolidated metadata for an entire hierarchy.
+    metadata: Arc<GroupMetadata>,
     metadata_options: GroupMetadataOptions,
     metadata_erase_version: MetadataEraseVersion,
     use_consolidated_metadata: UseConsolidatedMetadata,
@@ -231,7 +235,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
         Ok(Self {
             storage,
             path,
-            metadata,
+            metadata: Arc::new(metadata),
             metadata_options: options.metadata_options(),
             metadata_erase_version: options.metadata_erase_version(),
             use_consolidated_metadata: options.use_consolidated_metadata(),
@@ -252,8 +256,8 @@ impl<TStorage: ?Sized> Group<TStorage> {
 
     /// Get attributes.
     #[must_use]
-    pub const fn attributes(&self) -> &serde_json::Map<String, serde_json::Value> {
-        match &self.metadata {
+    pub fn attributes(&self) -> &serde_json::Map<String, serde_json::Value> {
+        match &*self.metadata {
             GroupMetadata::V3(metadata) => &metadata.attributes,
             GroupMetadata::V2(metadata) => &metadata.attributes,
         }
@@ -262,7 +266,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
     /// Mutably borrow the group attributes.
     #[must_use]
     pub fn attributes_mut(&mut self) -> &mut serde_json::Map<String, serde_json::Value> {
-        match &mut self.metadata {
+        match Arc::make_mut(&mut self.metadata) {
             GroupMetadata::V3(metadata) => &mut metadata.attributes,
             GroupMetadata::V2(metadata) => &mut metadata.attributes,
         }
@@ -315,7 +319,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
         let options = self.metadata_options();
         use GroupMetadata as GM;
         use MetadataConvertVersion as V;
-        let metadata = self.metadata.clone();
+        let metadata = (*self.metadata).clone();
 
         match (metadata, options.metadata_convert_version()) {
             (GM::V3(metadata), V::Default | V::V3) => GM::V3(metadata),
@@ -329,7 +333,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
     /// Consolidated metadata is not currently supported for Zarr V2 groups.
     #[must_use]
     pub fn consolidated_metadata(&self) -> Option<ConsolidatedMetadata> {
-        if let GroupMetadata::V3(group_metadata) = &self.metadata {
+        if let GroupMetadata::V3(group_metadata) = &*self.metadata {
             if let Some(consolidated_metadata) = group_metadata
                 .additional_fields
                 .get("consolidated_metadata")
@@ -352,7 +356,7 @@ impl<TStorage: ?Sized> Group<TStorage> {
         &mut self,
         consolidated_metadata: Option<ConsolidatedMetadata>,
     ) -> &mut Self {
-        if let GroupMetadata::V3(group_metadata) = &mut self.metadata {
+        if let GroupMetadata::V3(group_metadata) = Arc::make_mut(&mut self.metadata) {
             if let Some(consolidated_metadata) = consolidated_metadata {
                 group_metadata.additional_fields.insert(
                     "consolidated_metadata".to_string(),
@@ -372,15 +376,11 @@ impl<TStorage: ?Sized> Group<TStorage> {
     /// If the group is already Zarr V3, this is a no-op.
     #[must_use]
     pub fn to_v3(self) -> Self {
-        if let GroupMetadata::V2(metadata) = self.metadata {
-            let metadata: GroupMetadata = group_metadata_v2_to_v3(&metadata).into();
+        if let GroupMetadata::V2(metadata) = &*self.metadata {
+            let metadata: GroupMetadata = group_metadata_v2_to_v3(metadata).into();
             Self {
-                storage: self.storage,
-                path: self.path,
-                metadata,
-                metadata_options: self.metadata_options,
-                metadata_erase_version: self.metadata_erase_version,
-                use_consolidated_metadata: self.use_consolidated_metadata,
+                metadata: Arc::new(metadata),
+                ..self
             }
         } else {
             self
@@ -917,7 +917,7 @@ impl<TStorage: ?Sized + WritableStorageTraits> Group<TStorage> {
         let options = self.metadata_erase_version();
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
-            MetadataEraseVersion::Default => match self.metadata {
+            MetadataEraseVersion::Default => match *self.metadata {
                 GroupMetadata::V3(_) => storage_handle.erase(&meta_key_v3(self.path())),
                 GroupMetadata::V2(_) => {
                     storage_handle.erase(&meta_key_v2_group(self.path()))?;
@@ -987,7 +987,7 @@ impl<TStorage: ?Sized + AsyncWritableStorageTraits> Group<TStorage> {
         let options = self.metadata_erase_version();
         let storage_handle = StorageHandle::new(self.storage.clone());
         match options {
-            MetadataEraseVersion::Default => match self.metadata {
+            MetadataEraseVersion::Default => match *self.metadata {
                 GroupMetadata::V3(_) => storage_handle.erase(&meta_key_v3(self.path())).await,
                 GroupMetadata::V2(_) => {
                     storage_handle
@@ -1149,6 +1149,32 @@ mod tests {
         //     group.to_string(),
         //     r#"group at /group with metadata {"node_type":"group","zarr_format":3}"#
         // );
+    }
+
+    #[test]
+    fn group_option_overrides_share_metadata_copy_on_write() {
+        let metadata = serde_json::from_str(JSON_VALID1).unwrap();
+        let group = Group::new_with_metadata(Arc::new(MemoryStore::new()), "/", metadata).unwrap();
+
+        let with_metadata_options = group.with_metadata_options(GroupMetadataOptions::default());
+        let mut with_erase_version = group.with_metadata_erase_version(MetadataEraseVersion::All);
+
+        assert!(Arc::ptr_eq(
+            &group.metadata,
+            &with_metadata_options.metadata
+        ));
+        assert!(Arc::ptr_eq(&group.metadata, &with_erase_version.metadata));
+
+        with_erase_version
+            .attributes_mut()
+            .insert("new".to_string(), serde_json::Value::Bool(true));
+
+        assert!(!Arc::ptr_eq(&group.metadata, &with_erase_version.metadata));
+        assert!(!group.attributes().contains_key("new"));
+        assert_eq!(
+            with_erase_version.attributes().get("new"),
+            Some(&serde_json::Value::Bool(true))
+        );
     }
 
     #[test]

--- a/zarrs/src/lib.rs
+++ b/zarrs/src/lib.rs
@@ -169,9 +169,8 @@
 //!
 //! // Retrieve a subchunk
 // TODO: mention using a partial decoder cache
-//! let array_subchunk: ndarray::Array2<f32> = array.retrieve_subchunk_opt(
+//! let array_subchunk: ndarray::Array2<f32> = array.retrieve_subchunk(
 //!     &[0, 3], // subchunk index
-//!     &zarrs::array::CodecOptions::default(),
 //! )?;
 //! println!("{array_subchunk:4}");
 //! // [[ 0.3],

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -693,7 +693,7 @@ mod tests {
         .build(store.clone(), node_path)
         .unwrap();
         array.store_metadata().unwrap();
-        let stored_metadata = array.metadata_to_store();
+        let stored_metadata = array.metadata_opt();
 
         let node = Node::open(&store, node_path).unwrap();
         assert_eq!(node.metadata, NodeMetadata::Array(stored_metadata));

--- a/zarrs/src/node.rs
+++ b/zarrs/src/node.rs
@@ -596,7 +596,7 @@ impl Node {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::{ArrayBuilder, ArrayMetadataOptions};
+    use crate::array::ArrayBuilder;
     use crate::group::{GroupMetadata, GroupMetadataV3};
     use zarrs_storage::store::MemoryStore;
     use zarrs_storage::{StoreKey, WritableStorageTraits};
@@ -693,7 +693,7 @@ mod tests {
         .build(store.clone(), node_path)
         .unwrap();
         array.store_metadata().unwrap();
-        let stored_metadata = array.metadata_opt(&ArrayMetadataOptions::default());
+        let stored_metadata = array.metadata_to_store();
 
         let node = Node::open(&store, node_path).unwrap();
         assert_eq!(node.metadata, NodeMetadata::Array(stored_metadata));

--- a/zarrs/tests/array_async.rs
+++ b/zarrs/tests/array_async.rs
@@ -427,9 +427,7 @@ async fn array_async_read_subchunks(sharded: bool) -> Result<(), Box<dyn std::er
         let compare = array
             .async_retrieve_array_subset::<Vec<u16>>(&[4..6, 6..8])
             .await?;
-        let test = array
-            .async_retrieve_subchunk_opt::<Vec<u16>>(&[2, 3], &CodecOptions::default())
-            .await?;
+        let test = array.async_retrieve_subchunk::<Vec<u16>>(&[2, 3]).await?;
         assert_eq!(compare, test);
 
         let subset = ArraySubset::new_with_ranges(&[2..6, 2..6]);
@@ -438,35 +436,31 @@ async fn array_async_read_subchunks(sharded: bool) -> Result<(), Box<dyn std::er
             .async_retrieve_array_subset::<Vec<u16>>(&subset)
             .await?;
         let test = array
-            .async_retrieve_subchunks_opt::<Vec<u16>>(&subchunks, &CodecOptions::default())
+            .async_retrieve_subchunks::<Vec<u16>>(&subchunks)
             .await?;
         assert_eq!(compare, test);
     } else {
         assert!(matches!(array.subchunk_grid(), ChunkGridDecodedRef::None));
         let chunks = ArraySubset::new_with_ranges(&[0..2, 0..2]);
         assert!(matches!(
-            array
-                .async_retrieve_subchunk_opt::<Vec<u16>>(&[1, 1], &CodecOptions::default())
-                .await,
+            array.async_retrieve_subchunk::<Vec<u16>>(&[1, 1]).await,
             Err(ArrayError::MissingSubchunkGrid)
         ));
         assert!(matches!(
-            array
-                .async_retrieve_subchunks_opt::<Vec<u16>>(&chunks, &CodecOptions::default())
-                .await,
+            array.async_retrieve_subchunks::<Vec<u16>>(&chunks).await,
             Err(ArrayError::MissingSubchunkGrid)
         ));
     }
 
     assert!(
         array
-            .async_retrieve_subchunk_opt::<Vec<u16>>(&[0], &CodecOptions::default())
+            .async_retrieve_subchunk::<Vec<u16>>(&[0])
             .await
             .is_err()
     );
     assert!(
         array
-            .async_retrieve_subchunks_opt::<Vec<u16>>(&[0..1], &CodecOptions::default())
+            .async_retrieve_subchunks::<Vec<u16>>(&[0..1])
             .await
             .is_err()
     );

--- a/zarrs/tests/array_async_partial_encode.rs
+++ b/zarrs/tests/array_async_partial_encode.rs
@@ -52,7 +52,10 @@ async fn test_array_to_array_codec_async_partial_encoding<
     // Set the codec being tested
     builder.array_to_array_codecs(vec![codec]);
 
-    let array = builder.build(store_perf.clone(), array_path).unwrap();
+    let array = builder
+        .build(store_perf.clone(), array_path)
+        .unwrap()
+        .with_codec_options(opt);
 
     let chunk_key = array.chunk_key_encoding().encode(&[0, 0]);
 
@@ -65,7 +68,7 @@ async fn test_array_to_array_codec_async_partial_encoding<
     let subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
     let elements = vec![10.0f32, 20.0, 30.0, 40.0];
     array
-        .async_store_array_subset_opt(&subset, &elements, &opt)
+        .async_store_array_subset(&subset, &elements)
         .await
         .unwrap();
 
@@ -100,7 +103,7 @@ async fn test_array_to_array_codec_async_partial_encoding<
     let elements2 = vec![100f32, 200.0, 300.0, 400.0];
 
     array
-        .async_store_array_subset_opt(&subset2, &elements2, &opt)
+        .async_store_array_subset(&subset2, &elements2)
         .await
         .unwrap();
 
@@ -147,7 +150,7 @@ async fn test_array_to_array_codec_async_partial_encoding<
     );
 
     // Test partial encoder methods
-    let partial_encoder = array.async_partial_encoder(&[0, 0], &opt).await.unwrap();
+    let partial_encoder = array.async_partial_encoder(&[0, 0]).await.unwrap();
     assert!(partial_encoder.exists().await.unwrap());
     let encoder_size_held = partial_encoder.size_held();
     println!("Codec {codec_name} partial encoder size_held(): {encoder_size_held}");
@@ -184,7 +187,10 @@ async fn test_bytes_to_bytes_codec_async_partial_encoding<
     // Set the codec being tested
     builder.bytes_to_bytes_codecs(vec![codec]);
 
-    let array = builder.build(store_perf.clone(), array_path).unwrap();
+    let array = builder
+        .build(store_perf.clone(), array_path)
+        .unwrap()
+        .with_codec_options(opt);
 
     let chunk_key = array.chunk_key_encoding().encode(&[0, 0]);
 
@@ -199,7 +205,7 @@ async fn test_bytes_to_bytes_codec_async_partial_encoding<
     let initial_bytes_read = store_perf.bytes_read();
 
     array
-        .async_store_array_subset_opt(&subset, &elements, &opt)
+        .async_store_array_subset(&subset, &elements)
         .await
         .unwrap();
 
@@ -233,7 +239,7 @@ async fn test_bytes_to_bytes_codec_async_partial_encoding<
     let elements2 = vec![100f32, 200f32, 300f32, 400f32];
 
     array
-        .async_store_array_subset_opt(&subset2, &elements2, &opt)
+        .async_store_array_subset(&subset2, &elements2)
         .await
         .unwrap();
 
@@ -301,7 +307,7 @@ async fn test_bytes_to_bytes_codec_async_partial_encoding<
     );
 
     // Test partial encoder methods
-    let partial_encoder = array.async_partial_encoder(&[0, 0], &opt).await.unwrap();
+    let partial_encoder = array.async_partial_encoder(&[0, 0]).await.unwrap();
     assert!(partial_encoder.exists().await.unwrap());
     let encoder_size_held = partial_encoder.size_held();
     println!("Codec {codec_name} partial encoder size_held(): {encoder_size_held}");
@@ -596,14 +602,17 @@ async fn test_codec_chain_async_partial_encoding() {
         builder.bytes_to_bytes_codecs(vec![gzip_codec]);
     }
 
-    let array = builder.build(store_perf.clone(), array_path).unwrap();
+    let array = builder
+        .build(store_perf.clone(), array_path)
+        .unwrap()
+        .with_codec_options(opt);
 
     // Test storing data with the codec chain
     let subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
     let elements = vec![10f32, 20f32, 30f32, 40f32];
 
     array
-        .async_store_array_subset_opt(&subset, &elements, &opt)
+        .async_store_array_subset(&subset, &elements)
         .await
         .unwrap();
 
@@ -633,7 +642,7 @@ async fn test_codec_chain_async_partial_encoding() {
     let elements2 = vec![100f32, 200f32, 300f32, 400f32];
 
     array
-        .async_store_array_subset_opt(&subset2, &elements2, &opt)
+        .async_store_array_subset(&subset2, &elements2)
         .await
         .unwrap();
 
@@ -662,7 +671,7 @@ async fn test_codec_chain_async_partial_encoding() {
     );
 
     // Test partial encoder methods
-    let partial_encoder = array.async_partial_encoder(&[0, 0], &opt).await.unwrap();
+    let partial_encoder = array.async_partial_encoder(&[0, 0]).await.unwrap();
     assert!(partial_encoder.exists().await.unwrap());
     let encoder_size_held = partial_encoder.size_held();
     println!("Codec chain partial encoder size_held(): {encoder_size_held}");

--- a/zarrs/tests/array_future_stabilisation.rs
+++ b/zarrs/tests/array_future_stabilisation.rs
@@ -42,18 +42,22 @@ fn array_future_stabilisation_bz2() {
         ],
     );
 
-    // By default, metadata_opt() returns the original stored metadata, preserving
+    // By default, metadata_to_store() returns the original stored metadata, preserving
     // the original codec name from the file ("numcodecs.bz2").
     let mut options = ArrayMetadataOptions::default();
     assert!(
         array
-            .metadata_opt(&options)
+            .clone()
+            .with_metadata_options(options)
+            .metadata_to_store()
             .to_string()
             .contains(r#""numcodecs.bz2"#)
     );
     assert!(
         !array
-            .metadata_opt(&options)
+            .clone()
+            .with_metadata_options(options)
+            .metadata_to_store()
             .to_string()
             .contains(r#""stable.bz2"#)
     );
@@ -63,7 +67,9 @@ fn array_future_stabilisation_bz2() {
     options.set_convert_aliased_extension_names(true);
     assert!(
         array
-            .metadata_opt(&options)
+            .clone()
+            .with_metadata_options(options)
+            .metadata_to_store()
             .to_string()
             .contains(r#""stable.bz2"#)
     );

--- a/zarrs/tests/array_future_stabilisation.rs
+++ b/zarrs/tests/array_future_stabilisation.rs
@@ -42,14 +42,14 @@ fn array_future_stabilisation_bz2() {
         ],
     );
 
-    // By default, metadata_to_store() returns the original stored metadata, preserving
+    // By default, metadata_opt() returns the original stored metadata, preserving
     // the original codec name from the file ("numcodecs.bz2").
     let mut options = ArrayMetadataOptions::default();
     assert!(
         array
             .clone()
             .with_metadata_options(options)
-            .metadata_to_store()
+            .metadata_opt()
             .to_string()
             .contains(r#""numcodecs.bz2"#)
     );
@@ -57,7 +57,7 @@ fn array_future_stabilisation_bz2() {
         !array
             .clone()
             .with_metadata_options(options)
-            .metadata_to_store()
+            .metadata_opt()
             .to_string()
             .contains(r#""stable.bz2"#)
     );
@@ -69,7 +69,7 @@ fn array_future_stabilisation_bz2() {
         array
             .clone()
             .with_metadata_options(options)
-            .metadata_to_store()
+            .metadata_opt()
             .to_string()
             .contains(r#""stable.bz2"#)
     );

--- a/zarrs/tests/array_ops.rs
+++ b/zarrs/tests/array_ops.rs
@@ -47,11 +47,7 @@ fn fixture() -> (Arc<Array<TestStore>>, Arc<TestStore>) {
 
 fn populate<A: ArrayWriteOps>(array: &A) -> TestResult {
     array.store_chunk(&[0, 0], &[1u8, 2, 3, 6, 7, 8, 11, 12, 13])?;
-    array.store_chunk_opt(
-        &[0, 1],
-        &[4u8, 5, 0, 9, 10, 0, 14, 15, 0],
-        &CodecOptions::default(),
-    )?;
+    array.store_chunk(&[0, 1], &[4u8, 5, 0, 9, 10, 0, 14, 15, 0])?;
     array.store_chunks(
         &ArraySubset::new_with_ranges(&[1..2, 0..2]),
         &[
@@ -70,9 +66,14 @@ fn exercise_array_ops<A: ArrayOps>(array: &A) -> TestResult {
     assert_eq!(array.chunk_grid_shape(), &[2, 2]);
     assert_eq!(array.dimension_names().as_ref().unwrap().len(), 2);
     assert_eq!(array.attributes()["purpose"], "array_ops_test");
+    // Without the zarrs provenance attributes, the stored form matches the raw metadata.
     assert_eq!(
         array.metadata(),
-        &array.metadata_opt(&ArrayMetadataOptions::default().with_include_zarrs_metadata(false))
+        &array
+            .with_metadata_options(
+                ArrayMetadataOptions::default().with_include_zarrs_metadata(false)
+            )
+            .metadata_to_store()
     );
     let _ = array.builder().build_metadata()?;
     assert_eq!(
@@ -132,7 +133,6 @@ fn retrieve_into<A: ArrayReadOps>(
     array: &A,
     subset: &ArraySubset,
     chunk_indices: Option<&[u64]>,
-    explicit_options: bool,
 ) -> Result<Vec<u8>, Box<dyn Error>> {
     let shape = subset.shape().to_vec();
     let mut output = vec![0; subset.num_elements_usize()];
@@ -145,14 +145,7 @@ fn retrieve_into<A: ArrayReadOps>(
         };
         let target = ArrayBytesDecodeIntoTarget::Fixed(&mut view);
         if let Some(chunk_indices) = chunk_indices {
-            array.retrieve_chunk_subset_into(
-                chunk_indices,
-                subset,
-                target,
-                &CodecOptions::default(),
-            )?;
-        } else if explicit_options {
-            array.retrieve_array_subset_into_opt(subset, target, &CodecOptions::default())?;
+            array.retrieve_chunk_subset_into(chunk_indices, subset, target)?;
         } else {
             array.retrieve_array_subset_into(subset, target)?;
         }
@@ -174,18 +167,13 @@ fn retrieve_chunk_into<A: ArrayReadOps>(
             // SAFETY: this is the only view over output and covers it exactly.
             ArrayBytesFixedDisjointView::new(output_slice, 1, &shape, full_subset)?
         };
-        array.retrieve_chunk_into(
-            chunk_indices,
-            ArrayBytesDecodeIntoTarget::Fixed(&mut view),
-            &CodecOptions::default(),
-        )?;
+        array.retrieve_chunk_into(chunk_indices, ArrayBytesDecodeIntoTarget::Fixed(&mut view))?;
     }
     Ok(output)
 }
 
 fn exercise_array_read_ops<A: ArrayReadOps + ArrayWriteOps>(array: &A) -> TestResult {
     populate(array)?;
-    let options = CodecOptions::default();
     let chunk_subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
     let chunks = ArraySubset::new_with_ranges(&[0..1, 0..2]);
     let array_subset = ArraySubset::new_with_ranges(&[1..4, 1..4]);
@@ -195,7 +183,7 @@ fn exercise_array_read_ops<A: ArrayReadOps + ArrayWriteOps>(array: &A) -> TestRe
         [1, 2, 3, 6, 7, 8, 11, 12, 13]
     );
     assert_eq!(
-        array.retrieve_chunk_opt::<Vec<u8>>(&[0, 1], &options)?,
+        array.retrieve_chunk::<Vec<u8>>(&[0, 1])?,
         [4, 5, 0, 9, 10, 0, 14, 15, 0]
     );
     assert_eq!(
@@ -207,20 +195,17 @@ fn exercise_array_read_ops<A: ArrayReadOps + ArrayWriteOps>(array: &A) -> TestRe
         Some(vec![16, 17, 18, 21, 22, 23, 0, 0, 0])
     );
     array.erase_chunk(&[1, 1])?;
+    assert_eq!(array.retrieve_chunk_if_exists::<Vec<u8>>(&[1, 1])?, None);
     assert_eq!(
-        array.retrieve_chunk_if_exists_opt::<Vec<u8>>(&[1, 1], &options)?,
-        None
+        array.retrieve_chunk_subset::<Vec<u8>>(&[0, 0], &chunk_subset)?,
+        [7, 8, 12, 13]
     );
     assert_eq!(
         array.retrieve_chunk_subset::<Vec<u8>>(&[0, 0], &chunk_subset)?,
         [7, 8, 12, 13]
     );
     assert_eq!(
-        array.retrieve_chunk_subset_opt::<Vec<u8>>(&[0, 0], &chunk_subset, &options)?,
-        [7, 8, 12, 13]
-    );
-    assert_eq!(
-        retrieve_into(array, &chunk_subset, Some(&[0, 0]), true)?,
+        retrieve_into(array, &chunk_subset, Some(&[0, 0]))?,
         [7, 8, 12, 13]
     );
     assert_eq!(
@@ -228,7 +213,7 @@ fn exercise_array_read_ops<A: ArrayReadOps + ArrayWriteOps>(array: &A) -> TestRe
         [1, 2, 3, 4, 5, 0, 6, 7, 8, 9, 10, 0, 11, 12, 13, 14, 15, 0]
     );
     assert_eq!(
-        array.retrieve_chunks_opt::<Vec<u8>>(&chunks, &options)?,
+        array.retrieve_chunks::<Vec<u8>>(&chunks)?,
         [1, 2, 3, 4, 5, 0, 6, 7, 8, 9, 10, 0, 11, 12, 13, 14, 15, 0]
     );
     assert_eq!(
@@ -236,43 +221,37 @@ fn exercise_array_read_ops<A: ArrayReadOps + ArrayWriteOps>(array: &A) -> TestRe
         [7, 8, 9, 12, 13, 14, 17, 18, 0]
     );
     assert_eq!(
-        array.retrieve_array_subset_opt::<Vec<u8>>(&array_subset, &options)?,
+        array.retrieve_array_subset::<Vec<u8>>(&array_subset)?,
         [7, 8, 9, 12, 13, 14, 17, 18, 0]
     );
     assert_eq!(
-        retrieve_into(array, &array_subset, None, false)?,
+        retrieve_into(array, &array_subset, None)?,
         [7, 8, 9, 12, 13, 14, 17, 18, 0]
     );
     assert_eq!(
-        retrieve_into(array, &array_subset, None, true)?,
+        retrieve_into(array, &array_subset, None)?,
         [7, 8, 9, 12, 13, 14, 17, 18, 0]
     );
+    assert_eq!(array.retrieve_subchunk::<Vec<u8>>(&[1, 1])?, [7]);
     assert_eq!(
-        array.retrieve_subchunk_opt::<Vec<u8>>(&[1, 1], &options)?,
-        [7]
-    );
-    assert_eq!(
-        array.retrieve_subchunks_opt::<Vec<u8>>(
-            &ArraySubset::new_with_ranges(&[1..3, 1..3]),
-            &options,
-        )?,
+        array.retrieve_subchunks::<Vec<u8>>(&ArraySubset::new_with_ranges(&[1..3, 1..3]),)?,
         [7, 8, 12, 13]
     );
     assert!(array.retrieve_encoded_chunk(&[0, 0])?.is_some());
     assert_eq!(
-        array.retrieve_encoded_chunks_opt(&chunks, &options)?.len(),
+        array.retrieve_encoded_chunks(&chunks)?.len(),
         chunks.num_elements_usize()
     );
     let decoder = array.partial_decoder(&[0, 0])?;
     assert!(decoder.exists()?);
     assert_eq!(
         decoder
-            .partial_decode(&chunk_subset, &options)?
+            .partial_decode(&chunk_subset, &CodecOptions::default())?
             .into_fixed()?
             .as_ref(),
         &[7, 8, 12, 13]
     );
-    assert!(array.partial_decoder_opt(&[0, 0], &options)?.exists()?);
+    assert!(array.partial_decoder(&[0, 0])?.exists()?);
     Ok(())
 }
 
@@ -357,14 +336,13 @@ fn array_ops_subchunks_with_reshape_codec() -> TestResult {
         &[4, 2]
     );
 
-    let subchunk = array.retrieve_subchunk_opt::<Vec<u16>>(&[2, 1], &CodecOptions::default())?;
+    let subchunk = array.retrieve_subchunk::<Vec<u16>>(&[2, 1])?;
     let compare = array.retrieve_array_subset::<Vec<u16>>(&[2..3, 3..6])?;
     assert_eq!(subchunk, compare);
     assert_eq!(subchunk, [15, 16, 17]);
 
     let subchunks = ArraySubset::new_with_ranges(&[1..3, 0..2]);
-    let subchunk_range =
-        array.retrieve_subchunks_opt::<Vec<u16>>(&subchunks, &CodecOptions::default())?;
+    let subchunk_range = array.retrieve_subchunks::<Vec<u16>>(&subchunks)?;
     let compare = array.retrieve_array_subset::<Vec<u16>>(&[1..3, 0..6])?;
     assert_eq!(subchunk_range, compare);
 
@@ -394,14 +372,13 @@ fn array_ops_subchunks_with_squeeze_codec() -> TestResult {
         &[2, 2]
     );
 
-    let subchunk = array.retrieve_subchunk_opt::<Vec<u16>>(&[1, 1], &CodecOptions::default())?;
+    let subchunk = array.retrieve_subchunk::<Vec<u16>>(&[1, 1])?;
     let compare = array.retrieve_array_subset::<Vec<u16>>(&[1..2, 2..4])?;
     assert_eq!(subchunk, compare);
     assert_eq!(subchunk, [6, 7]);
 
     let subchunks = ArraySubset::new_with_ranges(&[0..2, 1..2]);
-    let subchunk_range =
-        array.retrieve_subchunks_opt::<Vec<u16>>(&subchunks, &CodecOptions::default())?;
+    let subchunk_range = array.retrieve_subchunks::<Vec<u16>>(&subchunks)?;
     let compare = array.retrieve_array_subset::<Vec<u16>>(&[0..2, 2..4])?;
     assert_eq!(subchunk_range, compare);
 
@@ -447,20 +424,18 @@ fn array_ops_nested_subchunk_grid_levels() -> TestResult {
         ChunkGridDecodedRef::None
     ));
 
-    let options = CodecOptions::default();
     assert_eq!(
-        array.retrieve_subchunk_opt::<Vec<u16>>(&[1, 0], &options)?,
-        array.retrieve_subchunk_at_level_opt::<Vec<u16>>(0, &[1, 0], &options)?
+        array.retrieve_subchunk::<Vec<u16>>(&[1, 0])?,
+        array.retrieve_subchunk_at_level::<Vec<u16>>(0, &[1, 0])?
     );
     assert_eq!(
-        array.retrieve_subchunk_at_level_opt::<Vec<u16>>(1, &[2, 3], &options)?,
+        array.retrieve_subchunk_at_level::<Vec<u16>>(1, &[2, 3])?,
         [38, 39, 46, 47]
     );
     assert_eq!(
-        array.retrieve_subchunks_at_level_opt::<Vec<u16>>(
+        array.retrieve_subchunks_at_level::<Vec<u16>>(
             1,
             &ArraySubset::new_with_ranges(&[1..3, 1..3]),
-            &options,
         )?,
         [
             18, 19, 20, 21, 26, 27, 28, 29, 34, 35, 36, 37, 42, 43, 44, 45
@@ -468,20 +443,20 @@ fn array_ops_nested_subchunk_grid_levels() -> TestResult {
     );
     assert!(
         array
-            .retrieve_subchunk_at_level_opt::<Vec<u16>>(2, &[0, 0], &options)
+            .retrieve_subchunk_at_level::<Vec<u16>>(2, &[0, 0])
             .is_err()
     );
 
     assert_eq!(
         array
-            .local_subchunk_grid_at_level(0, &[0, 0], &options)?
+            .local_subchunk_grid_at_level(0, &[0, 0])?
             .unwrap()
             .grid_shape(),
         &[2, 2]
     );
     assert_eq!(
         array
-            .local_subchunk_grid_at_level(1, &[0, 0], &options)?
+            .local_subchunk_grid_at_level(1, &[0, 0])?
             .unwrap()
             .grid_shape(),
         &[4, 4]
@@ -490,7 +465,7 @@ fn array_ops_nested_subchunk_grid_levels() -> TestResult {
     let cached = ArrayCached::new(array, ChunkCacheDecodedLruChunkLimit::new(2));
     assert_eq!(cached.subchunk_grids().len(), 2);
     assert_eq!(
-        cached.retrieve_subchunk_at_level_opt::<Vec<u16>>(1, &[2, 3], &options)?,
+        cached.retrieve_subchunk_at_level::<Vec<u16>>(1, &[2, 3])?,
         [38, 39, 46, 47]
     );
 
@@ -530,7 +505,7 @@ fn array_ops_nested_subchunk_grid_levels() -> TestResult {
     edge.store_array_subset(&edge.subset_all(), (0..100).collect::<Vec<u16>>())?;
     assert_eq!(edge.subchunk_grids().len(), 2);
     assert_eq!(
-        edge.retrieve_subchunk_at_level_opt::<Vec<u16>>(1, &[4, 4], &options)?,
+        edge.retrieve_subchunk_at_level::<Vec<u16>>(1, &[4, 4])?,
         [88, 89, 98, 99]
     );
 
@@ -548,8 +523,6 @@ fn array_ops_nested_subchunk_grid_levels() -> TestResult {
 
 #[test]
 fn nested_subchunk_grid_levels_map_through_array_codecs() -> TestResult {
-    let options = CodecOptions::default();
-
     {
         let data_type = data_type::uint16();
         let inner = ShardingCodecBuilder::new(vec![nz(4)], &data_type).build_arc();
@@ -567,7 +540,7 @@ fn nested_subchunk_grid_levels_map_through_array_codecs() -> TestResult {
         assert_eq!(array.subchunk_shape_at_level(0), Some(vec![nz(1), nz(8)]));
         assert_eq!(array.subchunk_shape_at_level(1), Some(vec![nz(1), nz(4)]));
         assert_eq!(
-            array.retrieve_subchunk_at_level_opt::<Vec<u16>>(1, &[2, 1], &options)?,
+            array.retrieve_subchunk_at_level::<Vec<u16>>(1, &[2, 1])?,
             [20, 21, 22, 23]
         );
     }
@@ -586,7 +559,7 @@ fn nested_subchunk_grid_levels_map_through_array_codecs() -> TestResult {
         assert_eq!(array.subchunk_shape_at_level(0), Some(vec![nz(1), nz(4)]));
         assert_eq!(array.subchunk_shape_at_level(1), Some(vec![nz(1), nz(2)]));
         assert_eq!(
-            array.retrieve_subchunk_at_level_opt::<Vec<u16>>(1, &[0, 2], &options)?,
+            array.retrieve_subchunk_at_level::<Vec<u16>>(1, &[0, 2])?,
             [4, 5]
         );
     }
@@ -607,7 +580,7 @@ fn nested_subchunk_grid_levels_map_through_array_codecs() -> TestResult {
         assert_eq!(array.subchunk_shape_at_level(0), Some(vec![nz(4), nz(4)]));
         assert_eq!(array.subchunk_shape_at_level(1), Some(vec![nz(2), nz(2)]));
         assert_eq!(
-            array.retrieve_subchunk_at_level_opt::<Vec<u16>>(1, &[1, 3], &options)?,
+            array.retrieve_subchunk_at_level::<Vec<u16>>(1, &[1, 3])?,
             [22, 23, 30, 31]
         );
     }
@@ -616,21 +589,20 @@ fn nested_subchunk_grid_levels_map_through_array_codecs() -> TestResult {
 }
 
 fn exercise_array_write_update_ops<A: ArrayUpdateOps>(array: &A) -> TestResult {
-    let options = CodecOptions::default();
     array.store_metadata()?;
-    array.store_metadata_opt(&ArrayMetadataOptions::default())?;
+    array
+        .with_metadata_options(ArrayMetadataOptions::default())
+        .store_metadata()?;
     array.erase_metadata()?;
     array.store_metadata()?;
-    array.erase_metadata_opt(MetadataEraseVersion::All)?;
+    array
+        .with_metadata_erase_version(MetadataEraseVersion::All)
+        .erase_metadata()?;
     array.store_metadata()?;
 
     array.store_chunk(&[0, 0], &[1u8; 9])?;
-    array.store_chunk_opt(&[0, 1], &[2u8; 9], &options)?;
-    array.store_chunks_opt(
-        &ArraySubset::new_with_ranges(&[1..2, 0..2]),
-        &[3u8; 18],
-        &options,
-    )?;
+    array.store_chunk(&[0, 1], &[2u8; 9])?;
+    array.store_chunks(&ArraySubset::new_with_ranges(&[1..2, 0..2]), &[3u8; 18])?;
     assert_eq!(array.retrieve_chunk::<Vec<u8>>(&[1, 1])?, [3u8; 9]);
 
     array.store_chunk_subset(
@@ -638,18 +610,13 @@ fn exercise_array_write_update_ops<A: ArrayUpdateOps>(array: &A) -> TestResult {
         &ArraySubset::new_with_ranges(&[1..2, 1..3]),
         &[4u8, 5],
     )?;
-    array.store_chunk_subset_opt(
+    array.store_chunk_subset(
         &[0, 0],
         &ArraySubset::new_with_ranges(&[2..3, 0..1]),
         &[6u8],
-        &options,
     )?;
     array.store_array_subset(&ArraySubset::new_with_ranges(&[0..1, 0..2]), &[7u8, 8])?;
-    array.store_array_subset_opt(
-        &ArraySubset::new_with_ranges(&[4..5, 4..5]),
-        &[9u8],
-        &options,
-    )?;
+    array.store_array_subset(&ArraySubset::new_with_ranges(&[4..5, 4..5]), &[9u8])?;
     assert_eq!(
         array.retrieve_chunk::<Vec<u8>>(&[0, 0])?,
         [7, 8, 1, 1, 4, 5, 6, 1, 1]
@@ -659,12 +626,12 @@ fn exercise_array_write_update_ops<A: ArrayUpdateOps>(array: &A) -> TestResult {
         [3, 3, 3, 3, 9, 3, 3, 3, 3]
     );
 
-    let encoder = array.partial_encoder(&[0, 0], &options)?;
+    let encoder = array.partial_encoder(&[0, 0])?;
     assert!(encoder.supports_partial_encode());
     encoder.partial_encode(
         &ArraySubset::new_with_ranges(&[0..1, 2..3]),
         &vec![10u8].into(),
-        &options,
+        &CodecOptions::default(),
     )?;
     assert_eq!(array.retrieve_chunk::<Vec<u8>>(&[0, 0])?[2], 10);
 
@@ -678,7 +645,7 @@ fn exercise_array_write_update_ops<A: ArrayUpdateOps>(array: &A) -> TestResult {
         [7, 8, 10, 1, 4, 5, 6, 1, 1]
     );
 
-    let _ = array.compact_chunk(&[0, 0], &options)?;
+    let _ = array.compact_chunk(&[0, 0])?;
     array.erase_chunk(&[0, 1])?;
     assert!(
         array
@@ -859,13 +826,13 @@ where
 
     store.reset();
     assert_eq!(
-        retrieve_into(&cached, &subset, None, true)?,
+        retrieve_into(&cached, &subset, None)?,
         [7, 8, 9, 12, 13, 14, 17, 18, 19]
     );
     let reads_after_miss = store.reads();
     assert!(reads_after_miss > 0);
     assert_eq!(
-        retrieve_into(&cached, &subset, None, true)?,
+        retrieve_into(&cached, &subset, None)?,
         [7, 8, 9, 12, 13, 14, 17, 18, 19]
     );
     assert_eq!(store.reads(), reads_after_miss);
@@ -876,6 +843,114 @@ where
 fn array_cached_array_subset_into_uses_cache() -> TestResult {
     assert_cache_hits_for_array_subset_into(ChunkCacheEncodedLruChunkLimit::new(16))?;
     assert_cache_hits_for_array_subset_into(ChunkCacheDecodedLruChunkLimit::new(16))
+}
+
+/// Deriving a cached array with different codec options must share the cache with the original,
+/// otherwise overriding options would silently discard everything cached so far.
+#[test]
+fn array_cached_with_codec_options_preserves_cache() -> TestResult {
+    let (array, store) = fixture();
+    populate(array.as_ref())?;
+    let cached = ArrayCached::new(array, ChunkCacheDecodedLruChunkLimit::new(16));
+
+    // Populate the cache.
+    store.reset();
+    let expected = [1u8, 2, 3, 6, 7, 8, 11, 12, 13];
+    assert_eq!(cached.retrieve_chunk::<Vec<u8>>(&[0, 0])?, expected);
+    let reads_after_miss = store.reads();
+    assert!(reads_after_miss > 0);
+
+    // The derived array sees the already-cached chunk: no further store reads.
+    let tuned = cached.with_codec_options(CodecOptions::default().with_concurrent_target(1));
+    assert_eq!(tuned.retrieve_chunk::<Vec<u8>>(&[0, 0])?, expected);
+    assert_eq!(store.reads(), reads_after_miss);
+
+    // The cache is shared both ways, so a write through the derived array invalidates it
+    // for the original too.
+    tuned.store_chunk(&[0, 0], &[7u8; 9])?;
+    assert_eq!(cached.retrieve_chunk::<Vec<u8>>(&[0, 0])?, [7u8; 9]);
+
+    Ok(())
+}
+
+/// `Array::with_codec_specific_options` and `ArrayMutOps::set_codec_specific_options` are
+/// documented as equivalent. `with_` used to rebuild the codec chain without recomputing
+/// `subchunk_grids`, leaving them stale; it now delegates to `set_`, so the two cannot diverge.
+#[test]
+fn codec_specific_options_with_and_set_agree() -> TestResult {
+    use zarrs::array::codec::ShardingCodecOptions;
+    use zarrs_codec::CodecSpecificOptions;
+
+    let data_type = data_type::uint16();
+    let sharding = ShardingCodecBuilder::new(vec![nz(2), nz(2)], &data_type).build_arc();
+    let mut builder = ArrayBuilder::new(vec![8, 8], vec![4, 4], data_type, 0u16);
+    builder.array_to_bytes_codec(sharding);
+    let array = builder.build(Arc::new(MemoryStore::default()), "/array")?;
+
+    let opts = CodecSpecificOptions::default().with_option(ShardingCodecOptions::default());
+
+    let derived = array.with_codec_specific_options(&opts)?;
+    let mut mutated = array.clone();
+    mutated.set_codec_specific_options(&opts)?;
+
+    assert_eq!(derived.subchunk_shape(), mutated.subchunk_shape());
+    assert_eq!(
+        derived.subchunk_grids().len(),
+        mutated.subchunk_grids().len()
+    );
+    assert_eq!(
+        derived
+            .subchunk_grid()
+            .as_chunk_grid()
+            .map(|g| g.grid_shape().to_vec()),
+        mutated
+            .subchunk_grid()
+            .as_chunk_grid()
+            .map(|g| g.grid_shape().to_vec())
+    );
+    // ... and both still match the array they were derived from, since these options do not
+    // change the grid.
+    assert_eq!(derived.subchunk_shape(), array.subchunk_shape());
+
+    Ok(())
+}
+
+/// `MetadataEraseVersion::All` must erase both Zarr V2 and V3 metadata, where the default only
+/// erases the version the array actually uses. Deriving the erase version is only expressible
+/// because `with_metadata_erase_version` is on `ArrayOps`.
+#[test]
+fn erase_metadata_version_all_erases_both_zarr_versions() -> TestResult {
+    use zarrs::node::{meta_key_v2_array, meta_key_v2_attributes, meta_key_v3};
+    use zarrs::storage::WritableStorageTraits;
+
+    let path: zarrs::node::NodePath = "/array".try_into()?;
+    let (array, store) = fixture();
+    array.store_metadata()?;
+
+    // Leftover V2 metadata alongside the array's own V3 metadata.
+    store.set(&meta_key_v2_array(&path), b"{}".to_vec().into())?;
+    store.set(&meta_key_v2_attributes(&path), b"{}".to_vec().into())?;
+
+    // The default erase version only removes the array's own (V3) metadata.
+    array.erase_metadata()?;
+    assert!(store.get(&meta_key_v3(&path))?.is_none());
+    assert!(store.get(&meta_key_v2_array(&path))?.is_some());
+    assert!(store.get(&meta_key_v2_attributes(&path))?.is_some());
+
+    // `All` removes both.
+    array
+        .with_metadata_erase_version(MetadataEraseVersion::All)
+        .erase_metadata()?;
+    assert!(store.get(&meta_key_v2_array(&path))?.is_none());
+    assert!(store.get(&meta_key_v2_attributes(&path))?.is_none());
+
+    // The original array is unaffected by the derive.
+    assert!(matches!(
+        array.metadata_erase_version(),
+        MetadataEraseVersion::Default
+    ));
+
+    Ok(())
 }
 
 // TODO: ChunkCacheType could be adjusted so that ChunkCacheEncoded could handle caching of encoded chunks, but seems low value

--- a/zarrs/tests/array_ops.rs
+++ b/zarrs/tests/array_ops.rs
@@ -73,7 +73,7 @@ fn exercise_array_ops<A: ArrayOps>(array: &A) -> TestResult {
             .with_metadata_options(
                 ArrayMetadataOptions::default().with_include_zarrs_metadata(false)
             )
-            .metadata_to_store()
+            .metadata_opt()
     );
     let _ = array.builder().build_metadata()?;
     assert_eq!(

--- a/zarrs/tests/array_ops_async.rs
+++ b/zarrs/tests/array_ops_async.rs
@@ -35,11 +35,7 @@ async fn populate<A: AsyncArrayUpdateOps>(array: &A) -> TestResult {
         .async_store_chunk(&[0, 0], &[1u8, 2, 3, 6, 7, 8, 11, 12, 13])
         .await?;
     array
-        .async_store_chunk_opt(
-            &[0, 1],
-            &[4u8, 5, 0, 9, 10, 0, 14, 15, 0],
-            &CodecOptions::default(),
-        )
+        .async_store_chunk(&[0, 1], &[4u8, 5, 0, 9, 10, 0, 14, 15, 0])
         .await?;
     array
         .async_store_chunks(
@@ -56,7 +52,6 @@ async fn retrieve_into<A: AsyncArrayReadOps>(
     array: &A,
     subset: &ArraySubset,
     chunk_indices: Option<&[u64]>,
-    explicit_options: bool,
 ) -> Result<Vec<u8>, Box<dyn Error>> {
     let shape = subset.shape().to_vec();
     let mut output = vec![0; subset.num_elements_usize()];
@@ -70,16 +65,7 @@ async fn retrieve_into<A: AsyncArrayReadOps>(
         let target = ArrayBytesDecodeIntoTarget::Fixed(&mut view);
         if let Some(chunk_indices) = chunk_indices {
             array
-                .async_retrieve_chunk_subset_into(
-                    chunk_indices,
-                    subset,
-                    target,
-                    &CodecOptions::default(),
-                )
-                .await?;
-        } else if explicit_options {
-            array
-                .async_retrieve_array_subset_into_opt(subset, target, &CodecOptions::default())
+                .async_retrieve_chunk_subset_into(chunk_indices, subset, target)
                 .await?;
         } else {
             array
@@ -105,11 +91,7 @@ async fn retrieve_chunk_into<A: AsyncArrayReadOps>(
             ArrayBytesFixedDisjointView::new(output_slice, 1, &shape, full_subset)?
         };
         array
-            .async_retrieve_chunk_into(
-                chunk_indices,
-                ArrayBytesDecodeIntoTarget::Fixed(&mut view),
-                &CodecOptions::default(),
-            )
+            .async_retrieve_chunk_into(chunk_indices, ArrayBytesDecodeIntoTarget::Fixed(&mut view))
             .await?;
     }
     Ok(output)
@@ -117,7 +99,6 @@ async fn retrieve_chunk_into<A: AsyncArrayReadOps>(
 
 async fn exercise_async_read_ops<A: AsyncArrayUpdateOps>(array: &A) -> TestResult {
     populate(array).await?;
-    let options = CodecOptions::default();
     let chunk_subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
     let chunks = ArraySubset::new_with_ranges(&[0..1, 0..2]);
     let array_subset = ArraySubset::new_with_ranges(&[1..4, 1..4]);
@@ -127,9 +108,7 @@ async fn exercise_async_read_ops<A: AsyncArrayUpdateOps>(array: &A) -> TestResul
         [1, 2, 3, 6, 7, 8, 11, 12, 13]
     );
     assert_eq!(
-        array
-            .async_retrieve_chunk_opt::<Vec<u8>>(&[0, 1], &options)
-            .await?,
+        array.async_retrieve_chunk::<Vec<u8>>(&[0, 1]).await?,
         [4, 5, 0, 9, 10, 0, 14, 15, 0]
     );
     assert_eq!(
@@ -149,7 +128,7 @@ async fn exercise_async_read_ops<A: AsyncArrayUpdateOps>(array: &A) -> TestResul
     );
     assert_eq!(
         array
-            .async_retrieve_chunk_if_exists_opt::<Vec<u8>>(&[1, 1], &options)
+            .async_retrieve_chunk_if_exists::<Vec<u8>>(&[1, 1])
             .await?,
         None
     );
@@ -161,12 +140,12 @@ async fn exercise_async_read_ops<A: AsyncArrayUpdateOps>(array: &A) -> TestResul
     );
     assert_eq!(
         array
-            .async_retrieve_chunk_subset_opt::<Vec<u8>>(&[0, 0], &chunk_subset, &options)
+            .async_retrieve_chunk_subset::<Vec<u8>>(&[0, 0], &chunk_subset)
             .await?,
         [7, 8, 12, 13]
     );
     assert_eq!(
-        retrieve_into(array, &chunk_subset, Some(&[0, 0]), true).await?,
+        retrieve_into(array, &chunk_subset, Some(&[0, 0])).await?,
         [7, 8, 12, 13]
     );
     assert_eq!(
@@ -174,9 +153,7 @@ async fn exercise_async_read_ops<A: AsyncArrayUpdateOps>(array: &A) -> TestResul
         [1, 2, 3, 4, 5, 0, 6, 7, 8, 9, 10, 0, 11, 12, 13, 14, 15, 0]
     );
     assert_eq!(
-        array
-            .async_retrieve_chunks_opt::<Vec<u8>>(&chunks, &options)
-            .await?,
+        array.async_retrieve_chunks::<Vec<u8>>(&chunks).await?,
         [1, 2, 3, 4, 5, 0, 6, 7, 8, 9, 10, 0, 11, 12, 13, 14, 15, 0]
     );
     assert_eq!(
@@ -187,58 +164,44 @@ async fn exercise_async_read_ops<A: AsyncArrayUpdateOps>(array: &A) -> TestResul
     );
     assert_eq!(
         array
-            .async_retrieve_array_subset_opt::<Vec<u8>>(&array_subset, &options)
+            .async_retrieve_array_subset::<Vec<u8>>(&array_subset)
             .await?,
         [7, 8, 9, 12, 13, 14, 17, 18, 0]
     );
     assert_eq!(
-        retrieve_into(array, &array_subset, None, false).await?,
+        retrieve_into(array, &array_subset, None).await?,
         [7, 8, 9, 12, 13, 14, 17, 18, 0]
     );
     assert_eq!(
-        retrieve_into(array, &array_subset, None, true).await?,
+        retrieve_into(array, &array_subset, None).await?,
         [7, 8, 9, 12, 13, 14, 17, 18, 0]
     );
     assert_eq!(
-        array
-            .async_retrieve_subchunk_opt::<Vec<u8>>(&[1, 1], &options)
-            .await?,
+        array.async_retrieve_subchunk::<Vec<u8>>(&[1, 1]).await?,
         [7]
     );
     assert_eq!(
         array
-            .async_retrieve_subchunks_opt::<Vec<u8>>(
-                &ArraySubset::new_with_ranges(&[1..3, 1..3]),
-                &options,
-            )
+            .async_retrieve_subchunks::<Vec<u8>>(&ArraySubset::new_with_ranges(&[1..3, 1..3]),)
             .await?,
         [7, 8, 12, 13]
     );
     assert!(array.async_retrieve_encoded_chunk(&[0, 0]).await?.is_some());
     assert_eq!(
-        array
-            .async_retrieve_encoded_chunks_opt(&chunks, &options)
-            .await?
-            .len(),
+        array.async_retrieve_encoded_chunks(&chunks).await?.len(),
         chunks.num_elements_usize()
     );
     let decoder = array.async_partial_decoder(&[0, 0]).await?;
     assert!(decoder.exists().await?);
     assert_eq!(
         decoder
-            .partial_decode(&chunk_subset, &options)
+            .partial_decode(&chunk_subset, &CodecOptions::default())
             .await?
             .into_fixed()?
             .as_ref(),
         &[7, 8, 12, 13]
     );
-    assert!(
-        array
-            .async_partial_decoder_opt(&[0, 0], &options)
-            .await?
-            .exists()
-            .await?
-    );
+    assert!(array.async_partial_decoder(&[0, 0]).await?.exists().await?);
     Ok(())
 }
 
@@ -304,28 +267,23 @@ async fn sharding_partial_decoder_retrieve_subchunk_encoded_missing() -> TestRes
 }
 
 async fn exercise_async_write_update_ops<A: AsyncArrayUpdateOps>(array: &A) -> TestResult {
-    let options = CodecOptions::default();
     array.async_store_metadata().await?;
     array
-        .async_store_metadata_opt(&ArrayMetadataOptions::default())
+        .with_metadata_options(ArrayMetadataOptions::default())
+        .async_store_metadata()
         .await?;
     array.async_erase_metadata().await?;
     array.async_store_metadata().await?;
     array
-        .async_erase_metadata_opt(MetadataEraseVersion::All)
+        .with_metadata_erase_version(MetadataEraseVersion::All)
+        .async_erase_metadata()
         .await?;
     array.async_store_metadata().await?;
 
     array.async_store_chunk(&[0, 0], &[1u8; 9]).await?;
+    array.async_store_chunk(&[0, 1], &[2u8; 9]).await?;
     array
-        .async_store_chunk_opt(&[0, 1], &[2u8; 9], &options)
-        .await?;
-    array
-        .async_store_chunks_opt(
-            &ArraySubset::new_with_ranges(&[1..2, 0..2]),
-            &[3u8; 18],
-            &options,
-        )
+        .async_store_chunks(&ArraySubset::new_with_ranges(&[1..2, 0..2]), &[3u8; 18])
         .await?;
 
     array
@@ -336,22 +294,17 @@ async fn exercise_async_write_update_ops<A: AsyncArrayUpdateOps>(array: &A) -> T
         )
         .await?;
     array
-        .async_store_chunk_subset_opt(
+        .async_store_chunk_subset(
             &[0, 0],
             &ArraySubset::new_with_ranges(&[2..3, 0..1]),
             &[6u8],
-            &options,
         )
         .await?;
     array
         .async_store_array_subset(&ArraySubset::new_with_ranges(&[0..1, 0..2]), &[7u8, 8])
         .await?;
     array
-        .async_store_array_subset_opt(
-            &ArraySubset::new_with_ranges(&[4..5, 4..5]),
-            &[9u8],
-            &options,
-        )
+        .async_store_array_subset(&ArraySubset::new_with_ranges(&[4..5, 4..5]), &[9u8])
         .await?;
     assert_eq!(
         array
@@ -361,13 +314,13 @@ async fn exercise_async_write_update_ops<A: AsyncArrayUpdateOps>(array: &A) -> T
         [3, 3, 3, 3, 9, 3, 3, 3, 3]
     );
 
-    let encoder = array.async_partial_encoder(&[0, 0], &options).await?;
+    let encoder = array.async_partial_encoder(&[0, 0]).await?;
     let _ = encoder.supports_partial_encode();
     encoder
         .partial_encode(
             &ArraySubset::new_with_ranges(&[0..1, 2..3]),
             &vec![10u8].into(),
-            &options,
+            &CodecOptions::default(),
         )
         .await?;
     assert_eq!(array.async_retrieve_chunk::<Vec<u8>>(&[0, 0]).await?[2], 10);
@@ -377,7 +330,7 @@ async fn exercise_async_write_update_ops<A: AsyncArrayUpdateOps>(array: &A) -> T
         // SAFETY: bytes were produced by the same array and chunk configuration.
         array.async_store_encoded_chunk(&[0, 1], encoded).await?;
     }
-    let _ = array.async_compact_chunk(&[0, 0], &options).await?;
+    let _ = array.async_compact_chunk(&[0, 0]).await?;
     array.async_erase_chunk(&[0, 1]).await?;
     assert!(
         array
@@ -509,16 +462,15 @@ async fn array_supports_async_nested_subchunk_grid_levels() -> TestResult {
 
     assert_eq!(array.subchunk_grids().len(), 2);
     assert_eq!(array.subchunk_shape_at_level(1), Some(vec![nz(2), nz(2)]));
-    let options = CodecOptions::default();
     assert_eq!(
         array
-            .async_retrieve_subchunk_at_level_opt::<Vec<u16>>(1, &[2, 3], &options)
+            .async_retrieve_subchunk_at_level::<Vec<u16>>(1, &[2, 3])
             .await?,
         [38, 39, 46, 47]
     );
     assert_eq!(
         array
-            .async_local_subchunk_grid_at_level(1, &[0, 0], &options)
+            .async_local_subchunk_grid_at_level(1, &[0, 0])
             .await?
             .unwrap()
             .grid_shape(),

--- a/zarrs/tests/array_partial_encode.rs
+++ b/zarrs/tests/array_partial_encode.rs
@@ -50,7 +50,10 @@ fn array_partial_encode_sharding(
         .bytes_to_bytes_codecs(vec![]);
     // .storage_transformers(vec![].into())
 
-    let array = builder.build(store_perf.clone(), array_path).unwrap();
+    let array = builder
+        .build(store_perf.clone(), array_path)
+        .unwrap()
+        .with_codec_options(opt);
 
     let get_bytes_0_0 = || {
         let key = array.chunk_key_encoding().encode(&[0, 0]);
@@ -70,7 +73,7 @@ fn array_partial_encode_sharding(
 
     // [1, 0]
     // [0, 0]
-    array.store_array_subset_opt(&[0..1, 0..1], &[1u16], &opt)?;
+    array.store_array_subset(&[0..1, 0..1], &[1u16])?;
     assert_eq!(store_perf.reads(), 1); // index
     assert_eq!(store_perf.writes(), expected_writes_per_shard);
     assert_eq!(store_perf.bytes_read(), 0);
@@ -84,7 +87,7 @@ fn array_partial_encode_sharding(
 
     // [0, 0]
     // [0, 0]
-    array.store_array_subset_opt(&[0..1, 0..1], &[0u16], &opt)?;
+    array.store_array_subset(&[0..1, 0..1], &[0u16])?;
     assert_eq!(store_perf.reads(), 1); // index
     assert_eq!(store_perf.writes(), 0);
     if inner_bytes_to_bytes_codecs.is_empty() {
@@ -95,7 +98,7 @@ fn array_partial_encode_sharding(
 
     // [1, 2]
     // [0, 0]
-    array.store_array_subset_opt(&[0..1, 0..2], &[1u16, 2], &opt)?;
+    array.store_array_subset(&[0..1, 0..2], &[1u16, 2])?;
     assert_eq!(store_perf.reads(), 1); // index
     assert_eq!(store_perf.writes(), expected_writes_per_shard);
     if inner_bytes_to_bytes_codecs.is_empty() {
@@ -110,7 +113,7 @@ fn array_partial_encode_sharding(
     // Check that the shard is entirely rewritten when possible, rather than appended
     // [3, 4]
     // [0, 0]
-    array.store_array_subset_opt(&[0..1, 0..2], &[3u16, 4], &opt)?;
+    array.store_array_subset(&[0..1, 0..2], &[3u16, 4])?;
     assert_eq!(store_perf.reads(), 1); // index + 1x subchunk
     assert_eq!(store_perf.writes(), expected_writes_per_shard);
     if inner_bytes_to_bytes_codecs.is_empty() {
@@ -127,7 +130,7 @@ fn array_partial_encode_sharding(
 
     // [99, 4]
     // [5, 0]
-    array.store_array_subset_opt(&[0..2, 0..1], &[99u16, 5], &opt)?;
+    array.store_array_subset(&[0..2, 0..1], &[99u16, 5])?;
     assert_eq!(store_perf.reads(), 1); // index
     assert_eq!(store_perf.writes(), expected_writes_per_shard);
     if inner_bytes_to_bytes_codecs.is_empty() {
@@ -145,7 +148,7 @@ fn array_partial_encode_sharding(
     // [99, 4]
     // [5, 100]
     store_perf.reset();
-    array.store_array_subset_opt(&[1..2, 1..2], &[100u16], &opt)?;
+    array.store_array_subset(&[1..2, 1..2], &[100u16])?;
     assert_eq!(store_perf.reads(), 1); // index
     assert_eq!(store_perf.writes(), expected_writes_per_shard);
     if inner_bytes_to_bytes_codecs.is_empty() {
@@ -188,14 +191,17 @@ async fn array_partial_encode_sharding_async() {
                 .index_location(index_location)
                 .build(),
         ));
-        let array = builder.build(store, "/").unwrap();
+        let array = builder
+            .build(store, "/")
+            .unwrap()
+            .with_codec_options(options);
 
         array
-            .async_store_array_subset_opt(&[0..1, 0..2], &[1u16, 2], &options)
+            .async_store_array_subset(&[0..1, 0..2], &[1u16, 2])
             .await
             .unwrap();
         array
-            .async_store_array_subset_opt(&[0..2, 0..1], &[3u16, 4], &options)
+            .async_store_array_subset(&[0..2, 0..1], &[3u16, 4])
             .await
             .unwrap();
         assert_eq!(
@@ -280,7 +286,10 @@ fn array_partial_encode_sharding_compact(
         ))
         .bytes_to_bytes_codecs(vec![]);
 
-    let array = builder.build(store_perf.clone(), array_path).unwrap();
+    let array = builder
+        .build(store_perf.clone(), array_path)
+        .unwrap()
+        .with_codec_options(opt);
 
     let get_bytes_0_0 = || {
         let key = array.chunk_key_encoding().encode(&[0, 0]);
@@ -290,7 +299,7 @@ fn array_partial_encode_sharding_compact(
     // Step 1: Write a large compressible pattern (all same values)
     // This fills multiple subchunks with highly compressible data
     let compressible_data = vec![42u16; 16]; // Fill all 16 elements of the shard
-    array.store_chunk_opt(&[0, 0], &compressible_data, &opt)?;
+    array.store_chunk(&[0, 0], &compressible_data)?;
 
     let size_after_first_write = get_bytes_0_0()?.unwrap().len();
 
@@ -298,11 +307,11 @@ fn array_partial_encode_sharding_compact(
     // This creates gaps as the old compressed data is marked stale
     // Write to subchunk [0,0] (elements [0..2, 0..2] of the shard)
     let random_data1 = vec![100u16, 101, 102, 103];
-    array.store_array_subset_opt(&[0..2, 0..2], &random_data1, &opt)?;
+    array.store_array_subset(&[0..2, 0..2], &random_data1)?;
 
     // Write to subchunk [1,0] (elements [2..4, 0..2] of the shard)
     let random_data2 = vec![200u16, 201, 202, 203];
-    array.store_array_subset_opt(&[2..4, 0..2], &random_data2, &opt)?;
+    array.store_array_subset(&[2..4, 0..2], &random_data2)?;
 
     let size_after_overwrites = get_bytes_0_0()?.unwrap().len();
 
@@ -314,7 +323,7 @@ fn array_partial_encode_sharding_compact(
 
     // Step 3: Compact the chunk
     store_perf.reset();
-    let compaction_occurred = array.compact_chunk(&[0, 0], &opt)?;
+    let compaction_occurred = array.compact_chunk(&[0, 0])?;
 
     // Verify that compaction occurred
     assert!(
@@ -354,7 +363,7 @@ fn array_partial_encode_sharding_compact(
 
     // Step 4: Verify idempotency - compacting an already-compact shard should return false
     store_perf.reset();
-    let compaction_occurred_2 = array.compact_chunk(&[0, 0], &opt)?;
+    let compaction_occurred_2 = array.compact_chunk(&[0, 0])?;
 
     assert!(
         !compaction_occurred_2,

--- a/zarrs/tests/array_sync_partial_encode.rs
+++ b/zarrs/tests/array_sync_partial_encode.rs
@@ -34,7 +34,10 @@ fn test_array_to_array_codec_sync_partial_encoding<
     // Set the codec being tested
     builder.array_to_array_codecs(vec![codec]);
 
-    let array = builder.build(store_perf.clone(), array_path).unwrap();
+    let array = builder
+        .build(store_perf.clone(), array_path)
+        .unwrap()
+        .with_codec_options(opt);
 
     let chunk_key = array.chunk_key_encoding().encode(&[0, 0]);
 
@@ -46,9 +49,7 @@ fn test_array_to_array_codec_sync_partial_encoding<
     // Store a subset of elements
     let subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
     let elements = vec![10.0f32, 20.0, 30.0, 40.0];
-    array
-        .store_array_subset_opt(&subset, &elements, &opt)
-        .unwrap();
+    array.store_array_subset(&subset, &elements).unwrap();
 
     // Verify that data was written
     let writes_after_store = store_perf.writes();
@@ -77,9 +78,7 @@ fn test_array_to_array_codec_sync_partial_encoding<
     let subset2 = ArraySubset::new_with_ranges(&[0..2, 0..2]);
     let elements2 = vec![100f32, 200.0, 300.0, 400.0];
 
-    array
-        .store_array_subset_opt(&subset2, &elements2, &opt)
-        .unwrap();
+    array.store_array_subset(&subset2, &elements2).unwrap();
 
     let writes_after_partial = store_perf.writes();
     let bytes_written_after_partial = store_perf.bytes_written();
@@ -121,7 +120,7 @@ fn test_array_to_array_codec_sync_partial_encoding<
     );
 
     // Test partial encoder methods
-    let partial_encoder = array.partial_encoder(&[0, 0], &opt).unwrap();
+    let partial_encoder = array.partial_encoder(&[0, 0]).unwrap();
     assert!(partial_encoder.exists().unwrap());
     let encoder_size_held = partial_encoder.size_held();
     println!("Codec {codec_name} partial encoder size_held(): {encoder_size_held}");
@@ -155,7 +154,10 @@ fn test_bytes_to_bytes_codec_sync_partial_encoding<
     // Set the codec being tested
     builder.bytes_to_bytes_codecs(vec![codec]);
 
-    let array = builder.build(store_perf.clone(), array_path).unwrap();
+    let array = builder
+        .build(store_perf.clone(), array_path)
+        .unwrap()
+        .with_codec_options(opt);
 
     let chunk_key = array.chunk_key_encoding().encode(&[0, 0]);
 
@@ -169,9 +171,7 @@ fn test_bytes_to_bytes_codec_sync_partial_encoding<
     let initial_reads = store_perf.reads();
     let initial_bytes_read = store_perf.bytes_read();
 
-    array
-        .store_array_subset_opt(&subset, &elements, &opt)
-        .unwrap();
+    array.store_array_subset(&subset, &elements).unwrap();
 
     let writes_after_store = store_perf.writes();
     let bytes_written_after_store = store_perf.bytes_written();
@@ -202,9 +202,7 @@ fn test_bytes_to_bytes_codec_sync_partial_encoding<
     let subset2 = ArraySubset::new_with_ranges(&[0..2, 0..2]);
     let elements2 = vec![100f32, 200f32, 300f32, 400f32];
 
-    array
-        .store_array_subset_opt(&subset2, &elements2, &opt)
-        .unwrap();
+    array.store_array_subset(&subset2, &elements2).unwrap();
 
     let writes_after_partial = store_perf.writes();
     let bytes_written_after_partial = store_perf.bytes_written();
@@ -267,7 +265,7 @@ fn test_bytes_to_bytes_codec_sync_partial_encoding<
     );
 
     // Test partial encoder methods
-    let partial_encoder = array.partial_encoder(&[0, 0], &opt).unwrap();
+    let partial_encoder = array.partial_encoder(&[0, 0]).unwrap();
     assert!(partial_encoder.exists().unwrap());
     let encoder_size_held = partial_encoder.size_held();
     println!("Codec {codec_name} partial encoder size_held(): {encoder_size_held}");
@@ -526,15 +524,16 @@ fn test_codec_chain_sync_partial_encoding() {
         builder.bytes_to_bytes_codecs(vec![gzip_codec]);
     }
 
-    let array = builder.build(store_perf.clone(), array_path).unwrap();
+    let array = builder
+        .build(store_perf.clone(), array_path)
+        .unwrap()
+        .with_codec_options(opt);
 
     // Test storing data with the codec chain
     let subset = ArraySubset::new_with_ranges(&[1..3, 1..3]);
     let elements = vec![10f32, 20f32, 30f32, 40f32];
 
-    array
-        .store_array_subset_opt(&subset, &elements, &opt)
-        .unwrap();
+    array.store_array_subset(&subset, &elements).unwrap();
 
     let writes_after_store = store_perf.writes();
     let bytes_written_after_store = store_perf.bytes_written();
@@ -558,9 +557,7 @@ fn test_codec_chain_sync_partial_encoding() {
     let subset2 = ArraySubset::new_with_ranges(&[0..2, 0..2]);
     let elements2 = vec![100f32, 200f32, 300f32, 400f32];
 
-    array
-        .store_array_subset_opt(&subset2, &elements2, &opt)
-        .unwrap();
+    array.store_array_subset(&subset2, &elements2).unwrap();
 
     let writes_after_partial = store_perf.writes();
     let bytes_written_after_partial = store_perf.bytes_written();
@@ -584,7 +581,7 @@ fn test_codec_chain_sync_partial_encoding() {
     );
 
     // Test partial encoder methods
-    let partial_encoder = array.partial_encoder(&[0, 0], &opt).unwrap();
+    let partial_encoder = array.partial_encoder(&[0, 0]).unwrap();
     assert!(partial_encoder.exists().unwrap());
     let encoder_size_held = partial_encoder.size_held();
     println!("Codec chain partial encoder size_held(): {encoder_size_held}");

--- a/zarrs/tests/cities.rs
+++ b/zarrs/tests/cities.rs
@@ -56,9 +56,10 @@ fn cities_impl(
         ]);
     }
 
-    let array = builder.build(store.clone(), "/")?;
-    array
-        .store_metadata_opt(&ArrayMetadataOptions::default().with_include_zarrs_metadata(false))?;
+    let array = builder
+        .build(store.clone(), "/")?
+        .with_metadata_options(ArrayMetadataOptions::default().with_include_zarrs_metadata(false));
+    array.store_metadata()?;
 
     let subset_all = array.subset_all();
     array.store_array_subset(&subset_all, cities)?;

--- a/zarrs/tests/codec_bitround.rs
+++ b/zarrs/tests/codec_bitround.rs
@@ -85,11 +85,12 @@ fn test_codec_bitround_float32() -> Result<(), Box<dyn std::error::Error>> {
     let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_config)?);
     builder.array_to_array_codecs(vec![codec]);
 
-    let array = builder.build(store, array_path)?;
+    let array = builder
+        .build(store, array_path)?
+        .with_metadata_options(ArrayMetadataOptions::default().with_include_zarrs_metadata(false));
 
     // Write metadata to store
-    array
-        .store_metadata_opt(&ArrayMetadataOptions::default().with_include_zarrs_metadata(false))?;
+    array.store_metadata()?;
 
     // Store the test data
     let subset = ArraySubset::new_with_ranges(&[0..test_data.len() as u64]);
@@ -164,11 +165,12 @@ fn test_codec_bitround_uint8() -> Result<(), Box<dyn std::error::Error>> {
     let codec = Arc::new(BitroundCodec::new_with_configuration(&codec_config)?);
     builder.array_to_array_codecs(vec![codec]);
 
-    let array = builder.build(store, array_path)?;
+    let array = builder
+        .build(store, array_path)?
+        .with_metadata_options(ArrayMetadataOptions::default().with_include_zarrs_metadata(false));
 
     // Write metadata to store
-    array
-        .store_metadata_opt(&ArrayMetadataOptions::default().with_include_zarrs_metadata(false))?;
+    array.store_metadata()?;
 
     // Store and retrieve
     let subset = ArraySubset::new_with_ranges(&[0..test_data_u8.len() as u64]);

--- a/zarrs/tests/codec_snapshot_tests.rs
+++ b/zarrs/tests/codec_snapshot_tests.rs
@@ -856,9 +856,12 @@ pub fn generate_array_metadata(config: &TestConfig) -> Option<serde_json::Value>
         builder.bytes_to_bytes_codecs(config.bytes_to_bytes_codecs.clone());
     }
 
-    let array = builder.build(store, "/").ok()?;
     let metadata_options = ArrayMetadataOptions::default().with_include_zarrs_metadata(false);
-    let metadata = array.metadata_opt(&metadata_options);
+    let array = builder
+        .build(store, "/")
+        .ok()?
+        .with_metadata_options(metadata_options);
+    let metadata = array.metadata_to_store();
 
     serde_json::to_value(metadata).ok()
 }
@@ -912,7 +915,8 @@ pub fn run_codec_test(config: &TestConfig, output_dir: &Path) -> CodecTestResult
 
     // Store metadata (without zarrs-specific metadata for cleaner snapshots)
     let metadata_options = ArrayMetadataOptions::default().with_include_zarrs_metadata(false);
-    if let Err(e) = array.store_metadata_opt(&metadata_options) {
+    let array = array.with_metadata_options(metadata_options);
+    if let Err(e) = array.store_metadata() {
         return CodecTestResult::Unsupported {
             reason: format!("Metadata storage failed: {e}"),
         };

--- a/zarrs/tests/codec_snapshot_tests.rs
+++ b/zarrs/tests/codec_snapshot_tests.rs
@@ -861,7 +861,7 @@ pub fn generate_array_metadata(config: &TestConfig) -> Option<serde_json::Value>
         .build(store, "/")
         .ok()?
         .with_metadata_options(metadata_options);
-    let metadata = array.metadata_to_store();
+    let metadata = array.metadata_opt();
 
     serde_json::to_value(metadata).ok()
 }

--- a/zarrs/tests/local_subchunk_grid.rs
+++ b/zarrs/tests/local_subchunk_grid.rs
@@ -9,7 +9,7 @@ use serial_test::serial;
 use zarrs::array::chunk_grid::RegularChunkGrid;
 use zarrs::array::codec::{TransposeCodec, TransposeOrder};
 use zarrs::array::{
-    Array, ArrayBuilder, ArrayBytes, ArrayBytesRaw, ArrayPartialDecoderTraits, ArrayReadOps,
+    Array, ArrayBuilder, ArrayBytes, ArrayBytesRaw, ArrayPartialDecoderTraits,
     ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesRepresentation, ChunkGrid, ChunkShape,
     ChunkShapeTraits, Codec, CodecChain, CodecChainBound, CodecCreateError, CodecError,
     CodecMetadataOptions, CodecOptions, CodecTraits, DataType, DataTypeSize, FillValue,
@@ -305,12 +305,8 @@ fn dynamic_local_subchunk_grids_can_differ_by_chunk() -> Result<(), Box<dyn std:
         ChunkGridDecodedRef::ChunkLocal
     ));
 
-    let first = reopened
-        .local_subchunk_grid_at_level(0, &[0, 0], &CodecOptions::default())?
-        .unwrap();
-    let second = reopened
-        .local_subchunk_grid(&[1, 0], &CodecOptions::default())?
-        .unwrap();
+    let first = reopened.local_subchunk_grid_at_level(0, &[0, 0])?.unwrap();
+    let second = reopened.local_subchunk_grid(&[1, 0])?.unwrap();
     assert_ne!(
         first.chunk_shape(&[0, 0])?.unwrap(),
         second.chunk_shape(&[0, 0])?.unwrap()
@@ -346,9 +342,7 @@ fn dynamic_local_subchunk_grid_transforms_through_transpose()
     array.store_array_subset(&array.subset_all(), &data)?;
 
     let reopened: Array<MemoryStore> = Array::open(store, "/array")?;
-    let local_grid = reopened
-        .local_subchunk_grid(&[0, 0], &CodecOptions::default())?
-        .unwrap();
+    let local_grid = reopened.local_subchunk_grid(&[0, 0])?.unwrap();
     assert_eq!(local_grid.array_shape(), &[4, 7]);
     assert_eq!(
         local_grid.chunk_shape(&[0, 0])?.unwrap(),


### PR DESCRIPTION
`Array` and `Group` are more cheaply clonable now, so can have their internal options easily changed. This massively reduces the API surface and doc explosion from having `[_opt]` variants and addresses various inconsistencies that existed.