### PR TITLE
fix: accept `checksum` field in Zarr V2 `zstd` compressor configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Only the outermost mask was allocated, so inner masks were also dropped
 - **Breaking**: Make `ArrayMutOps::set_dimension_names()` fallible, validate and persist names, and retain them when converting Zarr V2 arrays to V3
 - `Array::with_codec_specific_options()` now refreshes decoded subchunk grids consistently with `ArrayMutOps::set_codec_specific_options()`
+- Zarr V2 arrays with a `zstd` compressor configuration that includes a `checksum` field (as written by recent `numcodecs`/`zarr-python` releases) failed to open with an `unknown field checksum` error
 
 ## [0.23.13](https://github.com/zarrs/zarrs/releases/tag/zarrs-v0.23.13) - 2026-05-24
 

--- a/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/zstd.rs
@@ -66,8 +66,12 @@ impl CodecTraitsV3 for ZstdCodec {
 
 impl CodecTraitsV2 for ZstdCodec {
     fn create(metadata: &MetadataV2) -> Result<Codec, zarrs_codec::CodecCreateError> {
-        let configuration: ZstdCodecConfigurationNumcodecs = metadata.to_typed_configuration()?;
-        let codec = ZstdCodec::new(configuration.level.into(), false);
+        // Support both the plain `numcodecs` configuration (`{"level": ..}`) and the
+        // newer configuration with an additional `checksum` field (e.g. as written by
+        // recent `zarr-python`/`numcodecs` releases), see
+        // https://github.com/zarr-developers/numcodecs/issues/424
+        let configuration: ZstdCodecConfiguration = metadata.to_typed_configuration()?;
+        let codec = ZstdCodec::new_with_configuration(&configuration)?;
         Ok(Codec::BytesToBytes(Arc::new(codec)))
     }
 }
@@ -86,6 +90,26 @@ mod tests {
     "level": 22,
     "checksum": false
 }"#;
+
+    #[test]
+    fn codec_zstd_v2_numcodecs_level_only() {
+        // Legacy `numcodecs` configuration: no `checksum` field.
+        let metadata: MetadataV2 = serde_json::from_str(r#"{"id": "zstd", "level": 6}"#).unwrap();
+        let codec = <ZstdCodec as CodecTraitsV2>::create(&metadata).unwrap();
+        assert!(matches!(codec, Codec::BytesToBytes(_)));
+    }
+
+    #[test]
+    fn codec_zstd_v2_with_checksum() {
+        // Configuration as written by recent `numcodecs`/`zarr-python` releases, which
+        // includes an additional `checksum` field (e.g. the janelia-cosem-datasets bucket
+        // on S3). This previously failed with a "unknown field `checksum`" error because
+        // `CodecTraitsV2::create` only accepted `ZstdCodecConfigurationNumcodecs`.
+        let metadata: MetadataV2 =
+            serde_json::from_str(r#"{"id": "zstd", "checksum": false, "level": 6}"#).unwrap();
+        let codec = <ZstdCodec as CodecTraitsV2>::create(&metadata).unwrap();
+        assert!(matches!(codec, Codec::BytesToBytes(_)));
+    }
 
     #[test]
     #[cfg_attr(miri, ignore)]


### PR DESCRIPTION
## Problem

Opening real-world Zarr V2 arrays whose `zstd` compressor configuration includes a `checksum` field (as written by recent `numcodecs`/`zarr-python` releases) fails with:

```
UnsupportedZarrV2Array("configuration is unsupported: unknown field `checksum`, expected `level`")
```

For example, this affects the public [janelia-cosem-datasets S3 bucket](https://janelia-cosem-datasets.s3.amazonaws.com/jrc_mus-liver-6/jrc_mus-liver-6.zarr/recon-1/em/fibsem-uint8/s5/.zarray), whose `.zarray` contains:

```json
"compressor": {"checksum": false, "id": "zstd", "level": 6}
```

## Cause

`CodecTraitsV2::create` for `ZstdCodec` deserialized the V2 `compressor` configuration strictly as `ZstdCodecConfigurationNumcodecs` (`{"level": N}`, `deny_unknown_fields`), rejecting the additional `checksum` field. The crate already fully supports that field via `ZstdCodecConfiguration` / `ZstdCodec::new_with_configuration` — it's just not what the V2 codec plugin used.

## Fix

Use `ZstdCodecConfiguration` (the untagged enum supporting both the legacy numcodecs shape and the shape with `checksum`) and `ZstdCodec::new_with_configuration` on the V2 path too, mirroring what's already done for V3.

## Testing

- Added `codec_zstd_v2_numcodecs_level_only` and `codec_zstd_v2_with_checksum` unit tests.
- Verified end-to-end against the live S3 dataset above (both before and after the fix, using a local build): the array now opens and a full-array read of the `s5` level (265×251×250, 16,628,750 bytes) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)