### PR TITLE
fix: gzip encoded representation bound can be exceeded, overflowing sharded buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use the generic `store_*` and `retrieve_*` methods with `Vec<T>` or `ndarray::Array<T, D>` instead
 
 ### Fixed
+- Fixed `GzipCodec::encoded_representation()` under-estimating the worst-case encoded size, which could cause an out-of-bounds panic or a `CodecError` when `gzip` was an inner codec of `sharding_indexed` ([#444](https://github.com/zarrs/zarrs/issues/444))
+  - The bound now matches zlib's `deflateBound()`
+- The `sharding_indexed` codec now returns a `CodecError` instead of panicking if an inner codec exceeds its reported bounded encoded size
 - `async_get_child_nodes_opt` now ignores unrecognised listed prefixes consistently with sync discovery
 - Make async sharding `partial_decode_into` use the same subchunk-aware path as sync decoding
 - The partial decode granularity potentially being incorrect with multiple array-to-array codecs

--- a/zarrs/src/array/codec/array_to_bytes/sharding.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding.rs
@@ -574,6 +574,44 @@ mod tests {
         }
     }
 
+    /// Regression test for <https://github.com/zarrs/zarrs/issues/444>.
+    ///
+    /// A DEFLATE encoder may emit more blocks than `size / 32768`, so the gzip
+    /// encoded size of poorly compressible data can exceed a bound that assumes
+    /// a minimum block size, overflowing the shard buffer.
+    /// With gzip level 0 this is deterministic: `miniz_oxide` splits a 32768
+    /// byte input into two stored blocks.
+    #[cfg(feature = "gzip")]
+    #[cfg(feature = "crc32c")]
+    #[test]
+    fn codec_sharding_gzip_stored_blocks_exceed_naive_bound() {
+        use crate::array::codec::GzipCodec;
+        let subchunk_shape = ChunkShape::from(vec![NonZeroU64::new(32768).unwrap()]);
+        let shard_shape = vec![NonZeroU64::new(65536).unwrap()];
+        let bytes: ArrayBytes = vec![1u8; 65536].into();
+        for index_at_end in [true, false] {
+            for parallel in [true, false] {
+                let options =
+                    CodecOptions::default().with_concurrent_target(get_concurrent_target(parallel));
+                let codec = Arc::new(
+                    ShardingCodecBuilder::new(subchunk_shape.clone(), &data_type::uint8())
+                        .index_location(if index_at_end {
+                            ShardingIndexLocation::End
+                        } else {
+                            ShardingIndexLocation::Start
+                        })
+                        .bytes_to_bytes_codecs(vec![Arc::new(GzipCodec::new(0).unwrap())])
+                        .build(),
+                )
+                .with_context(data_type::uint8(), FillValue::from(0u8))
+                .unwrap();
+                let encoded = codec.encode(bytes.clone(), &shard_shape, &options).unwrap();
+                let decoded = codec.decode(encoded, &shard_shape, &options).unwrap();
+                assert_eq!(bytes, decoded);
+            }
+        }
+    }
+
     #[cfg(feature = "async")]
     async fn codec_sharding_async_round_trip_impl(
         options: &CodecOptions,

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_codec.rs
@@ -1056,6 +1056,12 @@ impl ShardingCodecBound {
                         acc + chunk_len_usize
                     },
                 );
+                if total_offset > shard_size_bounded {
+                    // This is a dev error, indicates the codec bounded size is not correct
+                    return Err(CodecError::from(
+                        "Sharding did not allocate a large enough buffer",
+                    ));
+                }
                 crate::iter_concurrent_limit!(
                     shard_concurrent_limit,
                     encoded_chunk_ids_and_chunks,
@@ -1083,6 +1089,14 @@ impl ShardingCodecBound {
                 ShardingIndexLocation::Start => 0,
                 ShardingIndexLocation::End => index_encoded_size,
             };
+        if shard_length > shard_size_bounded {
+            // This is a dev error, indicates the codec bounded size is not correct.
+            // The chunks may individually fit within the bounded size while the
+            // chunks plus the shard index do not.
+            return Err(CodecError::from(
+                "Sharding did not allocate a large enough buffer",
+            ));
+        }
 
         // Encode and write array index
         let shard_index_bytes: ArrayBytesRaw = transmute_to_bytes_vec(shard_index).into();

--- a/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
+++ b/zarrs/src/array/codec/bytes_to_bytes/gzip/gzip_codec.rs
@@ -126,12 +126,12 @@ impl BytesToBytesCodecTraits for GzipCodec {
         decoded_representation
             .size()
             .map_or(BytesRepresentation::UnboundedSize, |size| {
-                // https://www.gnu.org/software/gzip/manual/gzip.pdf
+                // Conservative worst case matching zlib's `deflateBound()`.
+                // DEFLATE block boundaries are an encoder implementation detail, so the bound
+                // cannot assume a minimum block size (https://github.com/zarrs/zarrs/issues/444).
                 const HEADER_TRAILER_OVERHEAD: u64 = 10 + 8; // TODO: validate that extra headers are not populated
-                const BLOCK_SIZE: u64 = 32768;
-                const BLOCK_OVERHEAD: u64 = 5;
-                let blocks_overhead = BLOCK_OVERHEAD * size.div_ceil(BLOCK_SIZE);
-                BytesRepresentation::BoundedSize(size + HEADER_TRAILER_OVERHEAD + blocks_overhead)
+                let deflate_overhead = size.div_ceil(8) + size.div_ceil(64) + 5;
+                BytesRepresentation::BoundedSize(size + HEADER_TRAILER_OVERHEAD + deflate_overhead)
             })
     }
 }


### PR DESCRIPTION
Closes #444

### What

Two fixes for the out-of-bounds panic / `CodecError` when `gzip` is an inner `bytes_to_bytes` codec of `sharding_indexed`:

1. **`GzipCodec::encoded_representation()` now uses zlib's `deflateBound()` formula** — `size + (size + 7) / 8 + (size + 63) / 64 + 5` plus the 18-byte gzip header/trailer — instead of `size + 18 + 5 * ceil(size / 32768)`.
2. **`ShardingCodecBound::encode_bounded()` now bounds-checks the shard-index write** (the panic site in #444) **and the `SubchunkWriteOrder::C` chunk writes**, so an inner codec exceeding its reported bounded size always degrades to a `CodecError` rather than a panic, matching the existing check on the unordered chunk-write path.

### Why

The previous gzip bound assumed a DEFLATE encoder emits at most `ceil(size / 32768)` blocks. DEFLATE imposes no such constraint — block boundaries are an encoder implementation detail. `miniz_oxide` at level 0 splits a 32768-byte input into two stored blocks (10 bytes of block overhead vs. the 5 budgeted), and levels 0–1 exceed the bound on poorly-compressible data with both `miniz_oxide` and `flate2/zlib-rs` backends. `ShardingCodec::encode_bounded()` pre-allocates the shard from that bound, so exceeding it overflowed the buffer: a panic when the trailing shard-index write landed out of range, or a `CodecError` when a chunk write did.

The new bound is a genuine worst case (it is what zlib itself guarantees via `deflateBound()`), at the cost of over-allocating shard buffers by ~12.7% during encoding; the shard is truncated to its actual size afterwards, so stored data is unaffected.

### Implementation notes

- Regression test `codec_sharding_gzip_stored_blocks_exceed_naive_bound` encodes two 32768-byte inner chunks with gzip level 0 (deterministic: stored blocks, data-independent size) across both index locations and serial/parallel encoding. With the old bound it fails with `Sharding did not allocate a large enough buffer` — from the new bounds check, confirming the former panic path now errors cleanly.
- The `ArrayBuilder`-based reproducer from #444 was verified end-to-end (store + retrieve round trip).
- `ZstdCodec` is untouched: its similar-shaped bound could not be exceeded in the sweeps reported in #444, and the new sharding bounds checks now turn any such case into a clean error anyway.
- Happy to backport to `0.23.x` as discussed in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)