### PR TITLE
refactor!: split partial-decoder subchunking traits

### DIFF
--- a/zarrs/src/array.rs
+++ b/zarrs/src/array.rs
@@ -65,18 +65,19 @@ pub use zarrs_codec::{
     ArrayBytes, ArrayBytesDecodeIntoTarget, ArrayBytesError, ArrayBytesFixedDisjointView,
     ArrayBytesFixedDisjointViewCreateError, ArrayBytesOffsets, ArrayBytesOptional, ArrayBytesRaw,
     ArrayBytesRawOffsetsCreateError, ArrayBytesRawOffsetsOutOfBoundsError,
-    ArrayBytesVariableLength, ArrayCodecTraits, ArrayPartialDecoderTraits,
-    ArrayPartialEncoderTraits, ArrayToArrayCodecTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesRepresentation,
-    BytesToBytesCodecTraits, ChunkGridDecoded, ChunkGridDecodedRef, Codec, CodecCreateError,
-    CodecError, CodecMetadataOptions, CodecOptions, CodecSpecificOptions, CodecTraits,
-    CodecTraitsV2, CodecTraitsV3, RecommendedConcurrency, UnboundArrayToArrayCodecTraits,
-    UnboundArrayToBytesCodecTraits, copy_fill_value_into, update_array_bytes,
+    ArrayBytesVariableLength, ArrayCodecTraits, ArrayPartialDecoderNoSubchunkingTraits,
+    ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+    BytesPartialEncoderTraits, BytesRepresentation, BytesToBytesCodecTraits, ChunkGridDecoded,
+    ChunkGridDecodedRef, Codec, CodecCreateError, CodecError, CodecMetadataOptions, CodecOptions,
+    CodecSpecificOptions, CodecTraits, CodecTraitsV2, CodecTraitsV3, RecommendedConcurrency,
+    UnboundArrayToArrayCodecTraits, UnboundArrayToBytesCodecTraits, copy_fill_value_into,
+    update_array_bytes,
 };
 #[cfg(feature = "async")]
 pub use zarrs_codec::{
-    AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits, AsyncBytesPartialDecoderTraits,
-    AsyncBytesPartialEncoderTraits,
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncArrayPartialEncoderTraits, AsyncBytesPartialDecoderTraits, AsyncBytesPartialEncoderTraits,
 };
 pub use zarrs_data_type::{
     DataType, DataTypeTraits, DataTypeTraitsV2, DataTypeTraitsV3, FillValue,

--- a/zarrs/src/array/array_ops/array_update_ops_array_cached.rs
+++ b/zarrs/src/array/array_ops/array_update_ops_array_cached.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use super::{ArrayUpdateOps, *};
 use crate::array::{ArrayBytes, Indexer};
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError,
+    ArrayBytesDecodeIntoTarget, ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits,
+    ArrayPartialEncoderTraits, CodecError,
 };
 use zarrs_storage::StorageError;
 
@@ -12,6 +13,18 @@ struct CachedArrayPartialEncoder<C> {
     encoder: Arc<dyn ArrayPartialEncoderTraits>,
     cache: Arc<C>,
     chunk_indices: ArrayIndices,
+}
+
+impl<C> ArrayPartialDecoderSubchunkingTraits for CachedArrayPartialEncoder<C>
+where
+    C: ChunkCache + 'static,
+{
+    fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        self.encoder.local_subchunk_grids(options)
+    }
 }
 
 impl<C> ArrayPartialDecoderTraits for CachedArrayPartialEncoder<C>
@@ -28,13 +41,6 @@ where
 
     fn size_held(&self) -> usize {
         self.encoder.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        self.encoder.local_subchunk_grids(options)
     }
 
     fn partial_decode(

--- a/zarrs/src/array/array_ops/async_array_update_ops_array_cached.rs
+++ b/zarrs/src/array/array_ops/async_array_update_ops_array_cached.rs
@@ -5,8 +5,8 @@ use super::{AsyncArrayUpdateOps, *};
 use crate::array::chunk_cache::AsyncChunkCache;
 use crate::array::{ArrayBytes, Indexer};
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits,
-    CodecError,
+    ArrayBytesDecodeIntoTarget, AsyncArrayPartialDecoderSubchunkingTraits,
+    AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits, CodecError,
 };
 use zarrs_storage::StorageError;
 
@@ -14,6 +14,20 @@ struct CachedAsyncArrayPartialEncoder<C> {
     encoder: Arc<dyn AsyncArrayPartialEncoderTraits>,
     cache: Arc<C>,
     chunk_indices: ArrayIndices,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<C> AsyncArrayPartialDecoderSubchunkingTraits for CachedAsyncArrayPartialEncoder<C>
+where
+    C: AsyncChunkCache + 'static,
+{
+    async fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        self.encoder.local_subchunk_grids(options).await
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -32,13 +46,6 @@ where
 
     fn size_held(&self) -> usize {
         self.encoder.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        self.encoder.local_subchunk_grids(options).await
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/chunk_cache/chunk_cache_type.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_type.rs
@@ -100,6 +100,18 @@ pub(super) struct SyncPartialDecoderAsAsync(Arc<dyn zarrs_codec::ArrayPartialDec
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl zarrs_codec::AsyncArrayPartialDecoderSubchunkingTraits for SyncPartialDecoderAsAsync {
+    async fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
+        self.0.local_subchunk_grids(options)
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl zarrs_codec::AsyncArrayPartialDecoderTraits for SyncPartialDecoderAsAsync {
     fn data_type(&self) -> &zarrs_data_type::DataType {
         self.0.data_type()
@@ -111,13 +123,6 @@ impl zarrs_codec::AsyncArrayPartialDecoderTraits for SyncPartialDecoderAsAsync {
 
     fn size_held(&self) -> usize {
         self.0.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        self.0.local_subchunk_grids(options)
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/chunk_cache/chunk_cache_type/decoded.rs
+++ b/zarrs/src/array/chunk_cache/chunk_cache_type/decoded.rs
@@ -12,7 +12,7 @@ use crate::array::{
 };
 #[cfg(feature = "async")]
 use zarrs_codec::AsyncArrayPartialDecoderTraits;
-use zarrs_codec::{ArrayPartialDecoderTraits, CodecError};
+use zarrs_codec::{ArrayPartialDecoderNoSubchunkingTraits, ArrayPartialDecoderTraits, CodecError};
 #[cfg(feature = "async")]
 use zarrs_storage::AsyncReadableStorageTraits;
 use zarrs_storage::{ReadableStorageTraits, StorageError};
@@ -23,6 +23,9 @@ struct CachedArrayBytesPartialDecoder {
     data_type: DataType,
     fill_value: FillValue,
 }
+
+/// A cache of decoded chunk bytes cannot expose encoded subchunks.
+impl ArrayPartialDecoderNoSubchunkingTraits for CachedArrayBytesPartialDecoder {}
 
 impl ArrayPartialDecoderTraits for CachedArrayBytesPartialDecoder {
     fn data_type(&self) -> &DataType {
@@ -35,13 +38,6 @@ impl ArrayPartialDecoderTraits for CachedArrayBytesPartialDecoder {
 
     fn size_held(&self) -> usize {
         self.bytes.size()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     fn partial_decode(

--- a/zarrs/src/array/codec/array_partial_decoder_cache.rs
+++ b/zarrs/src/array/codec/array_partial_decoder_cache.rs
@@ -1,9 +1,11 @@
 //! A cache for partial decoders.
 
 use crate::array::{ArrayBytes, ArraySubset, ChunkGrid, ChunkShape, DataType};
+use zarrs_codec::{
+    ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits, CodecError, CodecOptions,
+};
 #[cfg(feature = "async")]
-use zarrs_codec::AsyncArrayPartialDecoderTraits;
-use zarrs_codec::{ArrayPartialDecoderTraits, CodecError, CodecOptions};
+use zarrs_codec::{AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits};
 use zarrs_storage::StorageError;
 
 /// A cache for an [`ArrayPartialDecoderTraits`] partial decoder.
@@ -68,6 +70,15 @@ impl ArrayPartialDecoderCache {
     }
 }
 
+impl ArrayPartialDecoderSubchunkingTraits for ArrayPartialDecoderCache {
+    fn local_subchunk_grids(
+        &self,
+        _options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        Ok(self.local_subchunk_grids.clone())
+    }
+}
+
 impl ArrayPartialDecoderTraits for ArrayPartialDecoderCache {
     fn exists(&self) -> Result<bool, StorageError> {
         Ok(true)
@@ -91,15 +102,20 @@ impl ArrayPartialDecoderTraits for ArrayPartialDecoderCache {
             .extract_array_subset(indexer, array_shape, &self.data_type)
     }
 
-    fn local_subchunk_grids(
+    fn supports_partial_decode(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl AsyncArrayPartialDecoderSubchunkingTraits for ArrayPartialDecoderCache {
+    async fn local_subchunk_grids(
         &self,
         _options: &CodecOptions,
     ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
         Ok(self.local_subchunk_grids.clone())
-    }
-
-    fn supports_partial_decode(&self) -> bool {
-        true
     }
 }
 
@@ -125,13 +141,6 @@ impl AsyncArrayPartialDecoderTraits for ArrayPartialDecoderCache {
         options: &CodecOptions,
     ) -> Result<ArrayBytes<'a>, CodecError> {
         ArrayPartialDecoderTraits::partial_decode(self, indexer, options)
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        Ok(self.local_subchunk_grids.clone())
     }
 
     fn supports_partial_decode(&self) -> bool {

--- a/zarrs/src/array/codec/array_to_array/bitround/bitround_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/bitround/bitround_codec_partial.rs
@@ -3,10 +3,14 @@ use std::sync::Arc;
 use super::{BitroundDataTypeExt, round_bytes};
 use crate::array::DataType;
 use zarrs_codec::{
-    ArrayBytes, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError, CodecOptions,
+    ArrayBytes, ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits,
+    ArrayPartialEncoderTraits, CodecError, CodecOptions,
 };
 #[cfg(feature = "async")]
-use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
+use zarrs_codec::{
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncArrayPartialEncoderTraits,
+};
 use zarrs_storage::StorageError;
 
 /// Generic partial codec for the bitround codec.
@@ -32,6 +36,18 @@ impl<T: ?Sized> BitroundCodecPartial<T> {
     }
 }
 
+impl<T: ?Sized> ArrayPartialDecoderSubchunkingTraits for BitroundCodecPartial<T>
+where
+    T: ArrayPartialDecoderSubchunkingTraits,
+{
+    fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
+        self.input_output_handle.local_subchunk_grids(options)
+    }
+}
+
 impl<T: ?Sized> ArrayPartialDecoderTraits for BitroundCodecPartial<T>
 where
     T: ArrayPartialDecoderTraits,
@@ -46,13 +62,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        self.input_output_handle.local_subchunk_grids(options)
     }
 
     fn partial_decode(
@@ -100,6 +109,21 @@ where
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T: ?Sized> AsyncArrayPartialDecoderSubchunkingTraits for BitroundCodecPartial<T>
+where
+    T: AsyncArrayPartialDecoderSubchunkingTraits,
+{
+    async fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
+        self.input_output_handle.local_subchunk_grids(options).await
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<T: ?Sized> AsyncArrayPartialDecoderTraits for BitroundCodecPartial<T>
 where
     T: AsyncArrayPartialDecoderTraits,
@@ -114,13 +138,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        self.input_output_handle.local_subchunk_grids(options).await
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_array/cast_value/cast_value_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/cast_value/cast_value_codec_partial.rs
@@ -1,10 +1,14 @@
 use std::sync::Arc;
 
 use zarrs_codec::{
-    ArrayBytes, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError, CodecOptions,
+    ArrayBytes, ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits,
+    ArrayPartialEncoderTraits, CodecError, CodecOptions,
 };
 #[cfg(feature = "async")]
-use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
+use zarrs_codec::{
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncArrayPartialEncoderTraits,
+};
 use zarrs_storage::StorageError;
 
 use super::cast_value_codec::{CastBytesContext, ScalarMap, cast_bytes};
@@ -111,6 +115,18 @@ fn require_fixed(data_type: &DataType) -> Result<(), CodecError> {
     Ok(())
 }
 
+impl<T: ?Sized> ArrayPartialDecoderSubchunkingTraits for CastValueCodecPartial<T>
+where
+    T: ArrayPartialDecoderSubchunkingTraits,
+{
+    fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
+        self.input_output_handle.local_subchunk_grids(options)
+    }
+}
+
 impl<T: ?Sized> ArrayPartialDecoderTraits for CastValueCodecPartial<T>
 where
     T: ArrayPartialDecoderTraits,
@@ -125,13 +141,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        self.input_output_handle.local_subchunk_grids(options)
     }
 
     fn partial_decode(
@@ -177,6 +186,21 @@ where
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T: ?Sized> AsyncArrayPartialDecoderSubchunkingTraits for CastValueCodecPartial<T>
+where
+    T: AsyncArrayPartialDecoderSubchunkingTraits,
+{
+    async fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
+        self.input_output_handle.local_subchunk_grids(options).await
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<T: ?Sized> AsyncArrayPartialDecoderTraits for CastValueCodecPartial<T>
 where
     T: AsyncArrayPartialDecoderTraits,
@@ -191,13 +215,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        self.input_output_handle.local_subchunk_grids(options).await
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_array/reshape.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape.rs
@@ -51,7 +51,7 @@
 //! The boxes are chunk or subchunk boundaries.
 //! A subchunk can be resolved when its linear span is an n-dimensional box in both representations.
 //! With some chunk grids, the global subchunk grid may not be fully resolvable.
-//! However, the local subchunk grid of an individual chunk can still be recovered via [`ArrayPartialDecoderTraits::local_subchunk_grid`](zarrs_codec::ArrayPartialDecoderTraits::local_subchunk_grid).
+//! However, the local subchunk grid of an individual chunk can still be recovered via [`ArrayPartialDecoderSubchunkingTraits::local_subchunk_grid`](zarrs_codec::ArrayPartialDecoderSubchunkingTraits::local_subchunk_grid).
 
 mod reshape_codec;
 mod reshape_codec_grid_mapping;

--- a/zarrs/src/array/codec/array_to_array/reshape/reshape_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/reshape/reshape_codec_partial.rs
@@ -5,10 +5,14 @@ use super::get_reshaped_indexer;
 use super::reshape_codec_grid_mapping::reshape_rectilinear_grid;
 use crate::array::{ChunkGrid, DataType};
 use zarrs_codec::{
-    ArrayBytes, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError, CodecOptions,
+    ArrayBytes, ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits,
+    ArrayPartialEncoderTraits, CodecError, CodecOptions,
 };
 #[cfg(feature = "async")]
-use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
+use zarrs_codec::{
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncArrayPartialEncoderTraits,
+};
 use zarrs_storage::StorageError;
 
 /// Partial codec for the Reshape codec.
@@ -102,6 +106,22 @@ where
     }
 }
 
+impl<T: ?Sized> ArrayPartialDecoderSubchunkingTraits for ReshapeCodecPartial<T>
+where
+    T: ArrayPartialDecoderSubchunkingTraits,
+{
+    fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        self.input_handle
+            .local_subchunk_grids(options)?
+            .into_iter()
+            .map(|grid| grid.map_or(Ok(None), |grid| self.map_local_subchunk_grid(&grid)))
+            .collect()
+    }
+}
+
 impl<T: ?Sized> ArrayPartialDecoderTraits for ReshapeCodecPartial<T>
 where
     T: ArrayPartialDecoderTraits,
@@ -116,17 +136,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        self.input_handle
-            .local_subchunk_grids(options)?
-            .into_iter()
-            .map(|grid| grid.map_or(Ok(None), |grid| self.map_local_subchunk_grid(&grid)))
-            .collect()
     }
 
     fn partial_decode(
@@ -147,18 +156,10 @@ where
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<T: ?Sized> AsyncArrayPartialDecoderTraits for ReshapeCodecPartial<T>
+impl<T: ?Sized> AsyncArrayPartialDecoderSubchunkingTraits for ReshapeCodecPartial<T>
 where
-    T: AsyncArrayPartialDecoderTraits,
+    T: AsyncArrayPartialDecoderSubchunkingTraits,
 {
-    fn data_type(&self) -> &DataType {
-        &self.data_type
-    }
-
-    async fn exists(&self) -> Result<bool, StorageError> {
-        self.input_handle.exists().await
-    }
-
     async fn local_subchunk_grids(
         &self,
         options: &CodecOptions,
@@ -169,6 +170,22 @@ where
             .into_iter()
             .map(|grid| grid.map_or(Ok(None), |grid| self.map_local_subchunk_grid(&grid)))
             .collect()
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T: ?Sized> AsyncArrayPartialDecoderTraits for ReshapeCodecPartial<T>
+where
+    T: AsyncArrayPartialDecoderTraits,
+{
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    async fn exists(&self) -> Result<bool, StorageError> {
+        self.input_handle.exists().await
     }
 
     fn size_held(&self) -> usize {

--- a/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/squeeze/squeeze_codec_partial.rs
@@ -5,10 +5,14 @@ use crate::array::chunk_grid::{ChunkEdgeLengths, RectilinearChunkGrid};
 use crate::array::{ChunkGrid, DataType, FillValue};
 use std::num::NonZeroU64;
 use zarrs_codec::{
-    ArrayBytes, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError, CodecOptions,
+    ArrayBytes, ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits,
+    ArrayPartialEncoderTraits, CodecError, CodecOptions,
 };
 #[cfg(feature = "async")]
-use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
+use zarrs_codec::{
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncArrayPartialEncoderTraits,
+};
 use zarrs_storage::StorageError;
 
 /// Generic partial codec for the Squeeze codec.
@@ -69,6 +73,25 @@ impl<T: ?Sized> SqueezeCodecPartial<T> {
     }
 }
 
+impl<T: ?Sized> ArrayPartialDecoderSubchunkingTraits for SqueezeCodecPartial<T>
+where
+    T: ArrayPartialDecoderSubchunkingTraits,
+{
+    fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        self.input_output_handle
+            .local_subchunk_grids(options)?
+            .into_iter()
+            .map(|grid| {
+                grid.map(|grid| self.map_local_subchunk_grid(&grid))
+                    .transpose()
+            })
+            .collect()
+    }
+}
+
 impl<T: ?Sized> ArrayPartialDecoderTraits for SqueezeCodecPartial<T>
 where
     T: ArrayPartialDecoderTraits,
@@ -83,20 +106,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        self.input_output_handle
-            .local_subchunk_grids(options)?
-            .into_iter()
-            .map(|grid| {
-                grid.map(|grid| self.map_local_subchunk_grid(&grid))
-                    .transpose()
-            })
-            .collect()
     }
 
     fn partial_decode(
@@ -153,18 +162,10 @@ where
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl<T: ?Sized> AsyncArrayPartialDecoderTraits for SqueezeCodecPartial<T>
+impl<T: ?Sized> AsyncArrayPartialDecoderSubchunkingTraits for SqueezeCodecPartial<T>
 where
-    T: AsyncArrayPartialDecoderTraits,
+    T: AsyncArrayPartialDecoderSubchunkingTraits,
 {
-    fn data_type(&self) -> &DataType {
-        &self.data_type
-    }
-
-    async fn exists(&self) -> Result<bool, StorageError> {
-        self.input_output_handle.exists().await
-    }
-
     async fn local_subchunk_grids(
         &self,
         options: &CodecOptions,
@@ -178,6 +179,22 @@ where
                     .transpose()
             })
             .collect()
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T: ?Sized> AsyncArrayPartialDecoderTraits for SqueezeCodecPartial<T>
+where
+    T: AsyncArrayPartialDecoderTraits,
+{
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    async fn exists(&self) -> Result<bool, StorageError> {
+        self.input_output_handle.exists().await
     }
 
     fn size_held(&self) -> usize {

--- a/zarrs/src/array/codec/array_to_array/transpose/transpose_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_array/transpose/transpose_codec_partial.rs
@@ -7,9 +7,15 @@ use super::{
 use crate::array::chunk_grid::{ChunkEdgeLengths, RectilinearChunkGrid};
 use crate::array::{ArrayBytes, ChunkGrid, ChunkShape, DataType, FillValue};
 use std::num::NonZeroU64;
-use zarrs_codec::{ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, CodecError, CodecOptions};
+use zarrs_codec::{
+    ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    CodecError, CodecOptions,
+};
 #[cfg(feature = "async")]
-use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits};
+use zarrs_codec::{
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncArrayPartialEncoderTraits,
+};
 use zarrs_storage::StorageError;
 
 /// Generic partial codec for the Transpose codec.
@@ -96,6 +102,25 @@ impl<T: ?Sized> TransposeCodecPartial<T> {
     }
 }
 
+impl<T: ?Sized> ArrayPartialDecoderSubchunkingTraits for TransposeCodecPartial<T>
+where
+    T: ArrayPartialDecoderSubchunkingTraits,
+{
+    fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        self.input_output_handle
+            .local_subchunk_grids(options)?
+            .into_iter()
+            .map(|grid| {
+                grid.map(|grid| self.map_local_subchunk_grid(&grid))
+                    .transpose()
+            })
+            .collect()
+    }
+}
+
 impl<T: ?Sized> ArrayPartialDecoderTraits for TransposeCodecPartial<T>
 where
     T: ArrayPartialDecoderTraits,
@@ -128,20 +153,6 @@ where
             self.input_output_handle
                 .partial_decode(&indexer_transposed, options)
         }
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        self.input_output_handle
-            .local_subchunk_grids(options)?
-            .into_iter()
-            .map(|grid| {
-                grid.map(|grid| self.map_local_subchunk_grid(&grid))
-                    .transpose()
-            })
-            .collect()
     }
 
     fn supports_partial_decode(&self) -> bool {
@@ -186,6 +197,29 @@ where
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T: ?Sized> AsyncArrayPartialDecoderSubchunkingTraits for TransposeCodecPartial<T>
+where
+    T: AsyncArrayPartialDecoderSubchunkingTraits,
+{
+    async fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        self.input_output_handle
+            .local_subchunk_grids(options)
+            .await?
+            .into_iter()
+            .map(|grid| {
+                grid.map(|grid| self.map_local_subchunk_grid(&grid))
+                    .transpose()
+            })
+            .collect()
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<T: ?Sized> AsyncArrayPartialDecoderTraits for TransposeCodecPartial<T>
 where
     T: AsyncArrayPartialDecoderTraits,
@@ -220,21 +254,6 @@ where
                 .partial_decode(&indexer_transposed, options)
                 .await
         }
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        self.input_output_handle
-            .local_subchunk_grids(options)
-            .await?
-            .into_iter()
-            .map(|grid| {
-                grid.map(|grid| self.map_local_subchunk_grid(&grid))
-                    .transpose()
-            })
-            .collect()
     }
 
     fn supports_partial_decode(&self) -> bool {

--- a/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec_partial.rs
+++ b/zarrs/src/array/codec/array_to_bytes/bytes/bytes_codec_partial.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use super::{BytesCodec, BytesDataTypeExt, Endianness};
 use crate::array::{ArrayBytes, DataType, FillValue, IndexerError, update_array_bytes};
 use zarrs_codec::{
-    ArrayPartialDecoderTraits, ArrayPartialEncoderTraits, BytesPartialDecoderTraits,
-    BytesPartialEncoderTraits, CodecError, CodecOptions,
+    ArrayPartialDecoderNoSubchunkingTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError, CodecOptions,
 };
 #[cfg(feature = "async")]
 use zarrs_codec::{
@@ -63,6 +63,9 @@ impl<T: ?Sized> BytesCodecPartial<T> {
     }
 }
 
+/// The `bytes` codec encodes a chunk as a whole, so it has no subchunks.
+impl<T: ?Sized> ArrayPartialDecoderNoSubchunkingTraits for BytesCodecPartial<T> {}
+
 impl<T: ?Sized> ArrayPartialDecoderTraits for BytesCodecPartial<T>
 where
     T: BytesPartialDecoderTraits,
@@ -77,13 +80,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     fn partial_decode(
@@ -144,13 +140,6 @@ where
 
     async fn exists(&self) -> Result<bool, StorageError> {
         self.input_output_handle.exists().await
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     fn size_held(&self) -> usize {

--- a/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/packbits/packbits_partial_decoder.rs
@@ -11,7 +11,10 @@ use std::num::NonZeroU64;
 use super::PackBitsCodecComponents;
 use crate::array::codec::array_to_bytes::packbits::div_rem_8bit;
 use crate::array::{ArrayBytes, ChunkShape, DataType, FillValue};
-use zarrs_codec::{ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError, CodecOptions};
+use zarrs_codec::{
+    ArrayPartialDecoderNoSubchunkingTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits,
+    CodecError, CodecOptions,
+};
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
 use zarrs_metadata_ext::codec::packbits::PackBitsPaddingEncoding;
@@ -182,6 +185,9 @@ impl PackBitsPartialDecoder {
     }
 }
 
+/// The `packbits` codec encodes a chunk as a whole, so it has no subchunks.
+impl ArrayPartialDecoderNoSubchunkingTraits for PackBitsPartialDecoder {}
+
 impl ArrayPartialDecoderTraits for PackBitsPartialDecoder {
     fn data_type(&self) -> &DataType {
         &self.data_type
@@ -193,13 +199,6 @@ impl ArrayPartialDecoderTraits for PackBitsPartialDecoder {
 
     fn size_held(&self) -> usize {
         self.input_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     fn partial_decode(
@@ -267,6 +266,9 @@ impl AsyncPackBitsPartialDecoder {
 }
 
 #[cfg(feature = "async")]
+impl ArrayPartialDecoderNoSubchunkingTraits for AsyncPackBitsPartialDecoder {}
+
+#[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialDecoderTraits for AsyncPackBitsPartialDecoder {
@@ -280,13 +282,6 @@ impl AsyncArrayPartialDecoderTraits for AsyncPackBitsPartialDecoder {
 
     fn size_held(&self) -> usize {
         self.input_handle.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_async.rs
@@ -23,9 +23,9 @@ use crate::array::{
 };
 use zarrs_codec::{
     ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayToBytesCodecTraits,
-    AsyncArrayPartialDecoderTraits, AsyncByteIntervalPartialDecoder,
-    AsyncBytesPartialDecoderTraits, CodecError, CodecOptions, InvalidNumberOfElementsError,
-    decode_into_array_bytes_target,
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncByteIntervalPartialDecoder, AsyncBytesPartialDecoderTraits, CodecError, CodecOptions,
+    InvalidNumberOfElementsError, decode_into_array_bytes_target,
 };
 use zarrs_plugin::ExtensionAliasesV3;
 use zarrs_storage::StorageError;
@@ -194,6 +194,22 @@ pub(crate) async fn partial_decode(
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl AsyncArrayPartialDecoderSubchunkingTraits for AsyncShardingPartialDecoder {
+    async fn local_subchunk_grids(
+        &self,
+        _options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        let shard_shape = bytemuck::must_cast_slice(&self.shard_shape).to_vec();
+        let subchunk_grid = ChunkGrid::new(
+            RegularChunkGrid::new(shard_shape, self.subchunk_shape.clone())
+                .map_err(|err| CodecError::Other(err.to_string()))?,
+        );
+        nested_local_subchunk_grids(subchunk_grid, &self.inner_codecs)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
     fn data_type(&self) -> &DataType {
         self.inner_codecs.data_type()
@@ -223,18 +239,6 @@ impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialDecoder {
             options,
         )
         .await
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        let shard_shape = bytemuck::must_cast_slice(&self.shard_shape).to_vec();
-        let subchunk_grid = ChunkGrid::new(
-            RegularChunkGrid::new(shard_shape, self.subchunk_shape.clone())
-                .map_err(|err| CodecError::Other(err.to_string()))?,
-        );
-        nested_local_subchunk_grids(subchunk_grid, &self.inner_codecs)
     }
 
     async fn partial_decode_into(

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_decoder_sync.rs
@@ -21,9 +21,10 @@ use crate::array::{
     IndexerError, ravel_indices,
 };
 use zarrs_codec::{
-    ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderTraits,
-    ArrayToBytesCodecTraits, ByteIntervalPartialDecoder, BytesPartialDecoderTraits, CodecError,
-    CodecOptions, InvalidNumberOfElementsError, decode_into_array_bytes_target,
+    ArrayBytesDecodeIntoTarget, ArrayCodecTraits, ArrayPartialDecoderSubchunkingTraits,
+    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, ByteIntervalPartialDecoder,
+    BytesPartialDecoderTraits, CodecError, CodecOptions, InvalidNumberOfElementsError,
+    decode_into_array_bytes_target,
 };
 use zarrs_plugin::ExtensionAliasesV3;
 use zarrs_storage::StorageError;
@@ -193,6 +194,20 @@ pub(crate) fn partial_decode(
     }
 }
 
+impl ArrayPartialDecoderSubchunkingTraits for ShardingPartialDecoder {
+    fn local_subchunk_grids(
+        &self,
+        _options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        let shard_shape = bytemuck::must_cast_slice(&self.shard_shape).to_vec();
+        let subchunk_grid = ChunkGrid::new(
+            RegularChunkGrid::new(shard_shape, self.subchunk_shape.clone())
+                .map_err(|err| CodecError::Other(err.to_string()))?,
+        );
+        nested_local_subchunk_grids(subchunk_grid, &self.inner_codecs)
+    }
+}
+
 impl ArrayPartialDecoderTraits for ShardingPartialDecoder {
     fn data_type(&self) -> &DataType {
         self.inner_codecs.data_type()
@@ -221,18 +236,6 @@ impl ArrayPartialDecoderTraits for ShardingPartialDecoder {
             indexer,
             options,
         )
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        let shard_shape = bytemuck::must_cast_slice(&self.shard_shape).to_vec();
-        let subchunk_grid = ChunkGrid::new(
-            RegularChunkGrid::new(shard_shape, self.subchunk_shape.clone())
-                .map_err(|err| CodecError::Other(err.to_string()))?,
-        );
-        nested_local_subchunk_grids(subchunk_grid, &self.inner_codecs)
     }
 
     fn partial_decode_into(

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder.rs
@@ -20,9 +20,9 @@ use crate::array::{
     DataType, IndexerError, ravel_indices, transmute_to_bytes,
 };
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
-    ArrayToBytesCodecTraits, BytesPartialDecoderTraits, BytesPartialEncoderTraits, CodecError,
-    CodecOptions, update_array_bytes,
+    ArrayCodecTraits, ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits,
+    ArrayPartialEncoderTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+    BytesPartialEncoderTraits, CodecError, CodecOptions, update_array_bytes,
 };
 use zarrs_storage::StorageError;
 use zarrs_storage::byte_range::ByteRange;
@@ -92,6 +92,20 @@ impl ShardingPartialEncoder {
     }
 }
 
+impl ArrayPartialDecoderSubchunkingTraits for ShardingPartialEncoder {
+    fn local_subchunk_grids(
+        &self,
+        _options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        let shard_shape = bytemuck::must_cast_slice(&self.shard_shape).to_vec();
+        let subchunk_grid = ChunkGrid::new(
+            RegularBoundedChunkGrid::new(shard_shape, self.subchunk_shape.clone())
+                .map_err(|err| CodecError::Other(err.to_string()))?,
+        );
+        nested_local_subchunk_grids(subchunk_grid, &self.inner_codecs)
+    }
+}
+
 impl ArrayPartialDecoderTraits for ShardingPartialEncoder {
     fn data_type(&self) -> &DataType {
         self.inner_codecs.data_type()
@@ -103,18 +117,6 @@ impl ArrayPartialDecoderTraits for ShardingPartialEncoder {
 
     fn size_held(&self) -> usize {
         self.shard_index.lock().unwrap().len()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        let shard_shape = bytemuck::must_cast_slice(&self.shard_shape).to_vec();
-        let subchunk_grid = ChunkGrid::new(
-            RegularBoundedChunkGrid::new(shard_shape, self.subchunk_shape.clone())
-                .map_err(|err| CodecError::Other(err.to_string()))?,
-        );
-        nested_local_subchunk_grids(subchunk_grid, &self.inner_codecs)
     }
 
     fn partial_decode(

--- a/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder_async.rs
+++ b/zarrs/src/array/codec/array_to_bytes/sharding/sharding_partial_encoder_async.rs
@@ -21,9 +21,9 @@ use crate::array::{
     DataType, IndexerError, ravel_indices, transmute_to_bytes,
 };
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayToBytesCodecTraits, AsyncArrayPartialDecoderTraits,
-    AsyncArrayPartialEncoderTraits, AsyncBytesPartialDecoderTraits, AsyncBytesPartialEncoderTraits,
-    CodecError, CodecOptions, update_array_bytes,
+    ArrayCodecTraits, ArrayToBytesCodecTraits, AsyncArrayPartialDecoderSubchunkingTraits,
+    AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits, AsyncBytesPartialDecoderTraits,
+    AsyncBytesPartialEncoderTraits, CodecError, CodecOptions, update_array_bytes,
 };
 use zarrs_storage::StorageError;
 use zarrs_storage::byte_range::ByteRange;
@@ -96,6 +96,22 @@ impl AsyncShardingPartialEncoder {
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl AsyncArrayPartialDecoderSubchunkingTraits for AsyncShardingPartialEncoder {
+    async fn local_subchunk_grids(
+        &self,
+        _options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        let shard_shape = bytemuck::must_cast_slice(&self.shard_shape).to_vec();
+        let subchunk_grid = ChunkGrid::new(
+            RegularBoundedChunkGrid::new(shard_shape, self.subchunk_shape.clone())
+                .map_err(|err| CodecError::Other(err.to_string()))?,
+        );
+        nested_local_subchunk_grids(subchunk_grid, &self.inner_codecs)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialEncoder {
     fn data_type(&self) -> &DataType {
         self.inner_codecs.data_type()
@@ -108,18 +124,6 @@ impl AsyncArrayPartialDecoderTraits for AsyncShardingPartialEncoder {
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
             + self.index_shape.num_elements_usize() * size_of::<u64>()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        let shard_shape = bytemuck::must_cast_slice(&self.shard_shape).to_vec();
-        let subchunk_grid = ChunkGrid::new(
-            RegularBoundedChunkGrid::new(shard_shape, self.subchunk_shape.clone())
-                .map_err(|err| CodecError::Other(err.to_string()))?,
-        );
-        nested_local_subchunk_grids(subchunk_grid, &self.inner_codecs)
     }
 
     async fn partial_decode(

--- a/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen/vlen_partial_decoder.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use crate::array::array_bytes_internal::extract_decoded_regions_vlen;
 use crate::array::{ArrayBytes, ArrayBytesRaw, CodecChainBound, DataType, FillValue};
-use zarrs_codec::{ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError, CodecOptions};
+use zarrs_codec::{
+    ArrayPartialDecoderNoSubchunkingTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits,
+    CodecError, CodecOptions,
+};
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
 use zarrs_metadata_ext::codec::vlen::VlenIndexLocation;
@@ -76,6 +79,9 @@ fn decode_vlen_bytes<'a>(
     }
 }
 
+/// The `vlen` codec encodes a chunk as a whole, so it has no subchunks.
+impl ArrayPartialDecoderNoSubchunkingTraits for VlenPartialDecoder {}
+
 impl ArrayPartialDecoderTraits for VlenPartialDecoder {
     fn data_type(&self) -> &DataType {
         &self.data_type
@@ -87,13 +93,6 @@ impl ArrayPartialDecoderTraits for VlenPartialDecoder {
 
     fn size_held(&self) -> usize {
         self.input_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     fn partial_decode(
@@ -159,6 +158,9 @@ impl AsyncVlenPartialDecoder {
 }
 
 #[cfg(feature = "async")]
+impl ArrayPartialDecoderNoSubchunkingTraits for AsyncVlenPartialDecoder {}
+
+#[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialDecoderTraits for AsyncVlenPartialDecoder {
@@ -172,13 +174,6 @@ impl AsyncArrayPartialDecoderTraits for AsyncVlenPartialDecoder {
 
     fn size_held(&self) -> usize {
         self.input_handle.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_partial_decoder.rs
+++ b/zarrs/src/array/codec/array_to_bytes/vlen_v2/vlen_v2_partial_decoder.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use crate::array::array_bytes_internal::extract_decoded_regions_vlen;
 use crate::array::{ArrayBytes, ArrayBytesRaw, DataType, FillValue};
-use zarrs_codec::{ArrayPartialDecoderTraits, BytesPartialDecoderTraits, CodecError, CodecOptions};
+use zarrs_codec::{
+    ArrayPartialDecoderNoSubchunkingTraits, ArrayPartialDecoderTraits, BytesPartialDecoderTraits,
+    CodecError, CodecOptions,
+};
 #[cfg(feature = "async")]
 use zarrs_codec::{AsyncArrayPartialDecoderTraits, AsyncBytesPartialDecoderTraits};
 use zarrs_storage::StorageError;
@@ -55,6 +58,9 @@ fn decode_vlen_bytes<'a>(
     }
 }
 
+/// The `vlen_*` codecs encode a chunk as a whole, so they have no subchunks.
+impl ArrayPartialDecoderNoSubchunkingTraits for VlenV2PartialDecoder {}
+
 impl ArrayPartialDecoderTraits for VlenV2PartialDecoder {
     fn data_type(&self) -> &DataType {
         &self.data_type
@@ -66,13 +72,6 @@ impl ArrayPartialDecoderTraits for VlenV2PartialDecoder {
 
     fn size_held(&self) -> usize {
         self.input_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     fn partial_decode(
@@ -124,6 +123,9 @@ impl AsyncVlenV2PartialDecoder {
 }
 
 #[cfg(feature = "async")]
+impl ArrayPartialDecoderNoSubchunkingTraits for AsyncVlenV2PartialDecoder {}
+
+#[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl AsyncArrayPartialDecoderTraits for AsyncVlenV2PartialDecoder {
@@ -137,13 +139,6 @@ impl AsyncArrayPartialDecoderTraits for AsyncVlenV2PartialDecoder {
 
     fn size_held(&self) -> usize {
         self.input_handle.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     async fn partial_decode<'a>(

--- a/zarrs/tests/local_subchunk_grid.rs
+++ b/zarrs/tests/local_subchunk_grid.rs
@@ -22,10 +22,10 @@ use zarrs::storage::byte_range::ByteRange;
 use zarrs::storage::store::MemoryStore;
 use zarrs_chunk_grid::ChunkGridCreateError;
 use zarrs_codec::{
-    ArrayCodecTraits, ArrayToArrayCodecTraits, ArrayToBytesCodecSubchunkingTraits,
-    ChunkGridDecoded, ChunkGridDecodedRef, ChunkGridEncoded, ChunkGridEncodedRef,
-    PartialDecoderCapability, PartialEncoderCapability, UnboundArrayToArrayCodecTraits,
-    register_codec_v3, unregister_codec_v3,
+    ArrayCodecTraits, ArrayPartialDecoderSubchunkingTraits, ArrayToArrayCodecTraits,
+    ArrayToBytesCodecSubchunkingTraits, ChunkGridDecoded, ChunkGridDecodedRef, ChunkGridEncoded,
+    ChunkGridEncodedRef, PartialDecoderCapability, PartialEncoderCapability,
+    UnboundArrayToArrayCodecTraits, register_codec_v3, unregister_codec_v3,
 };
 use zarrs_plugin::{ExtensionName, RuntimePlugin, ZarrVersion};
 
@@ -231,6 +231,27 @@ impl ArrayToBytesCodecTraits for DynamicLocalSubchunkCodecBound {
     }
 }
 
+impl ArrayPartialDecoderSubchunkingTraits for DynamicLocalSubchunkPartialDecoder {
+    fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        let Some(header) = self.input_handle.partial_decode(
+            ByteRange::FromStart(0, Some(header_len(self.shape.len()))),
+            options,
+        )?
+        else {
+            return Ok(vec![None]);
+        };
+        let subchunk_shape = decode_shape_header(&header, self.shape.len())?;
+        let chunk_shape = bytemuck::must_cast_slice(&self.shape).to_vec();
+        Ok(vec![Some(ChunkGrid::new(
+            RegularChunkGrid::new(chunk_shape, subchunk_shape)
+                .map_err(|err| CodecError::Other(err.to_string()))?,
+        ))])
+    }
+}
+
 impl ArrayPartialDecoderTraits for DynamicLocalSubchunkPartialDecoder {
     fn data_type(&self) -> &DataType {
         &self.data_type
@@ -250,25 +271,6 @@ impl ArrayPartialDecoderTraits for DynamicLocalSubchunkPartialDecoder {
         _options: &CodecOptions,
     ) -> Result<ArrayBytes<'_>, CodecError> {
         zero_bytes(&self.data_type, indexer.len())
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
-        let Some(header) = self.input_handle.partial_decode(
-            ByteRange::FromStart(0, Some(header_len(self.shape.len()))),
-            options,
-        )?
-        else {
-            return Ok(vec![None]);
-        };
-        let subchunk_shape = decode_shape_header(&header, self.shape.len())?;
-        let chunk_shape = bytemuck::must_cast_slice(&self.shape).to_vec();
-        Ok(vec![Some(ChunkGrid::new(
-            RegularChunkGrid::new(chunk_shape, subchunk_shape)
-                .map_err(|err| CodecError::Other(err.to_string()))?,
-        ))])
     }
 
     fn supports_partial_decode(&self) -> bool {

--- a/zarrs/tests/local_subchunk_grid_codecs.rs
+++ b/zarrs/tests/local_subchunk_grid_codecs.rs
@@ -1,0 +1,139 @@
+#![allow(missing_docs)]
+
+//! Chunk-local subchunk grid propagation through codec partial decoders/encoders.
+
+mod subchunk_grid_cases;
+
+use std::error::Error;
+use std::sync::Arc;
+
+use subchunk_grid_cases::{Case, cases, plain_sharding};
+use zarrs::array::chunk_cache::{
+    ChunkCache, ChunkCacheDecodedLruChunkLimit, ChunkCacheEncodedLruChunkLimit,
+    ChunkCachePartialDecoderLruChunkLimit,
+};
+use zarrs::array::{
+    Array, ArrayBuilder, ArrayCached, ArrayPartialEncoderTraits, CodecOptions, data_type,
+};
+use zarrs::storage::store::MemoryStore;
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// Build the array for `case` in a fresh store, with the chunk under test written.
+fn build(case: &Case) -> Result<Arc<Array<MemoryStore>>, Box<dyn Error>> {
+    let store = Arc::new(MemoryStore::default());
+    let array = case.builder().build_arc(store, "/array")?;
+    array.store_chunk(&case.chunk_indices, case.zero_chunk_bytes())?;
+    Ok(array)
+}
+
+#[test]
+fn local_subchunk_grid_propagates_through_partial_decoders() -> TestResult {
+    for case in cases() {
+        let array = build(&case)?;
+        let grid = array.local_subchunk_grid(&case.chunk_indices)?;
+        case.assert_local_grid(grid.as_ref());
+
+        // There is only one level of subchunking, so the next level down is absent.
+        assert!(
+            array
+                .local_subchunk_grid_at_level(1, &case.chunk_indices)?
+                .is_none(),
+            "{}: expected no second subchunk level",
+            case.name
+        );
+
+        // The partial decoder under test also has to report the decoded data type, and whether
+        // the chunk it was created for exists.
+        let written = array.partial_decoder(&case.chunk_indices)?;
+        assert_eq!(written.data_type(), &case.data_type, "{}", case.name);
+        assert!(written.exists()?, "{}: written chunk exists", case.name);
+
+        let unwritten = array.partial_decoder(&case.absent_chunk_indices)?;
+        assert_eq!(unwritten.data_type(), &case.data_type, "{}", case.name);
+        assert!(
+            !unwritten.exists()?,
+            "{}: unwritten chunk does not exist",
+            case.name
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn local_subchunk_grid_exposed_by_partial_encoders() -> TestResult {
+    let case = plain_sharding();
+    let array = build(&case)?;
+    let cached = ArrayCached::new(array.clone(), ChunkCachePartialDecoderLruChunkLimit::new(1));
+
+    let encoders: [(&str, Arc<dyn ArrayPartialEncoderTraits>); 2] = [
+        ("sharding", array.partial_encoder(&case.chunk_indices)?),
+        ("cached", cached.partial_encoder(&case.chunk_indices)?),
+    ];
+    for (name, encoder) in encoders {
+        let grids = encoder.local_subchunk_grids(&CodecOptions::default())?;
+        assert_eq!(grids.len(), 1, "{name}: one subchunk level");
+        case.assert_local_grid(grids[0].as_ref());
+        case.assert_local_grid(
+            encoder
+                .local_subchunk_grid(&CodecOptions::default())?
+                .as_ref(),
+        );
+    }
+    Ok(())
+}
+
+/// A cache only exposes subchunks if it caches something that can still resolve them.
+fn check_cache<C: ChunkCache + 'static>(
+    case: &Case,
+    array: &Arc<Array<MemoryStore>>,
+    cache: C,
+    expect_subchunks: bool,
+) -> TestResult {
+    let cached = ArrayCached::new(array.clone(), cache);
+    let grid = cached.local_subchunk_grid(&case.chunk_indices)?;
+    if expect_subchunks {
+        case.assert_local_grid(grid.as_ref());
+    } else {
+        assert!(grid.is_none());
+    }
+    Ok(())
+}
+
+#[test]
+fn local_subchunk_grid_via_chunk_caches() -> TestResult {
+    let case = plain_sharding();
+    let array = build(&case)?;
+
+    // A partial decoder cache holds the decoder itself, and an encoded cache builds one over the
+    // cached encoded chunk, so both keep subchunks visible. A decoded cache holds decoded chunk
+    // bytes, which cannot resolve subchunks.
+    check_cache(
+        &case,
+        &array,
+        ChunkCachePartialDecoderLruChunkLimit::new(1),
+        true,
+    )?;
+    check_cache(&case, &array, ChunkCacheEncodedLruChunkLimit::new(1), true)?;
+    check_cache(&case, &array, ChunkCacheDecodedLruChunkLimit::new(1), false)
+}
+
+#[test]
+fn local_subchunk_grid_absent_with_array_partial_decoder_cache() -> TestResult {
+    // `vlen-utf8` does not support partial decoding, so the codec chain inserts an
+    // `ArrayPartialDecoderCache` at the top of the partial decoder chain.
+    let store = Arc::new(MemoryStore::default());
+    let array =
+        ArrayBuilder::new(vec![4], vec![4], data_type::string(), "").build(store, "/array")?;
+    array.store_chunk(&[0], vec!["a", "bb", "ccc", "dddd"])?;
+
+    let partial_decoder = array.partial_decoder(&[0])?;
+    assert!(partial_decoder.supports_partial_decode());
+    assert!(
+        partial_decoder
+            .local_subchunk_grids(&CodecOptions::default())?
+            .is_empty()
+    );
+    assert!(array.local_subchunk_grid(&[0])?.is_none());
+    Ok(())
+}

--- a/zarrs/tests/local_subchunk_grid_codecs_async.rs
+++ b/zarrs/tests/local_subchunk_grid_codecs_async.rs
@@ -1,0 +1,169 @@
+#![allow(missing_docs)]
+#![cfg(feature = "async")]
+
+//! Asynchronous variant of `local_subchunk_grid_codecs.rs`, over the same scenarios.
+
+mod subchunk_grid_cases;
+
+use std::error::Error;
+use std::sync::Arc;
+
+use subchunk_grid_cases::{Case, cases, plain_sharding};
+use zarrs::array::chunk_cache::{
+    AsyncChunkCache, AsyncChunkCacheDecodedLruChunkLimit, AsyncChunkCacheEncodedLruChunkLimit,
+    AsyncChunkCachePartialDecoderLruChunkLimit,
+};
+use zarrs::array::{
+    Array, ArrayBuilder, ArrayCached, AsyncArrayPartialEncoderTraits, CodecOptions, data_type,
+};
+use zarrs_storage::store::AsyncMemoryStore;
+
+type TestResult = Result<(), Box<dyn Error>>;
+
+/// Build the array for `case` in a fresh store, with the chunk under test written.
+async fn build(case: &Case) -> Result<Arc<Array<AsyncMemoryStore>>, Box<dyn Error>> {
+    let store = Arc::new(AsyncMemoryStore::new());
+    let array = case.builder().build_arc(store, "/array")?;
+    array
+        .async_store_chunk(&case.chunk_indices, case.zero_chunk_bytes())
+        .await?;
+    Ok(array)
+}
+
+#[tokio::test]
+async fn async_local_subchunk_grid_propagates_through_partial_decoders() -> TestResult {
+    for case in cases() {
+        let array = build(&case).await?;
+        let grid = array.async_local_subchunk_grid(&case.chunk_indices).await?;
+        case.assert_local_grid(grid.as_ref());
+
+        // There is only one level of subchunking, so the next level down is absent.
+        assert!(
+            array
+                .async_local_subchunk_grid_at_level(1, &case.chunk_indices)
+                .await?
+                .is_none(),
+            "{}: expected no second subchunk level",
+            case.name
+        );
+
+        // The partial decoder under test also has to report the decoded data type and existence.
+        let partial_decoder = array.async_partial_decoder(&case.chunk_indices).await?;
+        assert_eq!(
+            partial_decoder.data_type(),
+            &case.data_type,
+            "{}",
+            case.name
+        );
+        assert!(partial_decoder.exists().await?, "{}", case.name);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn async_local_subchunk_grid_exposed_by_partial_encoders() -> TestResult {
+    let case = plain_sharding();
+    let array = build(&case).await?;
+    let cached = ArrayCached::new(
+        array.clone(),
+        AsyncChunkCachePartialDecoderLruChunkLimit::new(1),
+    );
+
+    let encoders: [(&str, Arc<dyn AsyncArrayPartialEncoderTraits>); 2] = [
+        (
+            "sharding",
+            array.async_partial_encoder(&case.chunk_indices).await?,
+        ),
+        (
+            "cached",
+            cached.async_partial_encoder(&case.chunk_indices).await?,
+        ),
+    ];
+    for (name, encoder) in encoders {
+        let grids = encoder
+            .local_subchunk_grids(&CodecOptions::default())
+            .await?;
+        assert_eq!(grids.len(), 1, "{name}: one subchunk level");
+        case.assert_local_grid(grids[0].as_ref());
+        case.assert_local_grid(
+            encoder
+                .local_subchunk_grid(&CodecOptions::default())
+                .await?
+                .as_ref(),
+        );
+    }
+    Ok(())
+}
+
+/// A cache only exposes subchunks if it caches something that can still resolve them.
+async fn check_cache<C: AsyncChunkCache + 'static>(
+    case: &Case,
+    array: &Arc<Array<AsyncMemoryStore>>,
+    cache: C,
+    expect_subchunks: bool,
+) -> TestResult {
+    let cached = ArrayCached::new(array.clone(), cache);
+    let grid = cached
+        .async_local_subchunk_grid(&case.chunk_indices)
+        .await?;
+    if expect_subchunks {
+        case.assert_local_grid(grid.as_ref());
+    } else {
+        assert!(grid.is_none());
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn async_local_subchunk_grid_via_chunk_caches() -> TestResult {
+    let case = plain_sharding();
+    let array = build(&case).await?;
+
+    // A partial decoder cache holds the decoder itself, and an encoded cache wraps a synchronous
+    // decoder over the cached encoded chunk, so both keep subchunks visible. A decoded cache holds
+    // decoded chunk bytes, which cannot resolve subchunks.
+    check_cache(
+        &case,
+        &array,
+        AsyncChunkCachePartialDecoderLruChunkLimit::new(1),
+        true,
+    )
+    .await?;
+    check_cache(
+        &case,
+        &array,
+        AsyncChunkCacheEncodedLruChunkLimit::new(1),
+        true,
+    )
+    .await?;
+    check_cache(
+        &case,
+        &array,
+        AsyncChunkCacheDecodedLruChunkLimit::new(1),
+        false,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn async_local_subchunk_grid_absent_with_array_partial_decoder_cache() -> TestResult {
+    // `vlen-utf8` does not support partial decoding, so the codec chain inserts an
+    // `ArrayPartialDecoderCache` at the top of the partial decoder chain.
+    let store = Arc::new(AsyncMemoryStore::new());
+    let array =
+        ArrayBuilder::new(vec![4], vec![4], data_type::string(), "").build(store, "/array")?;
+    array
+        .async_store_chunk(&[0], vec!["a", "bb", "ccc", "dddd"])
+        .await?;
+
+    let partial_decoder = array.async_partial_decoder(&[0]).await?;
+    assert!(partial_decoder.supports_partial_decode());
+    assert!(
+        partial_decoder
+            .local_subchunk_grids(&CodecOptions::default())
+            .await?
+            .is_empty()
+    );
+    assert!(array.async_local_subchunk_grid(&[0]).await?.is_none());
+    Ok(())
+}

--- a/zarrs/tests/subchunk_grid_cases/mod.rs
+++ b/zarrs/tests/subchunk_grid_cases/mod.rs
@@ -1,0 +1,331 @@
+//! Shared scenarios for the chunk-local subchunk grid tests.
+//!
+//! Every case wraps a `sharding_indexed` array-to-bytes codec (the source of subchunks) in an
+//! optional array-to-array codec, so that the chunk-local subchunk grid has to be forwarded or
+//! remapped by that codec's partial decoder.
+#![allow(dead_code)]
+
+use std::num::NonZeroU64;
+use std::sync::Arc;
+
+use zarrs::array::builder::ArrayBuilderFillValue;
+use zarrs::array::codec::array_to_array::reshape::ReshapeShape;
+use zarrs::array::codec::array_to_bytes::sharding::ShardingCodecBuilder;
+use zarrs::array::codec::{
+    BitroundCodec, CastValueCodec, ReshapeCodec, SqueezeCodec, TransposeCodec, TransposeOrder,
+};
+use zarrs::array::{
+    ArrayBuilder, ArrayBytes, ArrayToArrayCodecTraits, ChunkGrid, CodecCreateError,
+    CodecMetadataOptions, CodecOptions, CodecTraits, DataType, DataTypeSize, FillValue,
+    RecommendedConcurrency, UnboundArrayToArrayCodecTraits, data_type,
+};
+use zarrs::metadata::Configuration;
+use zarrs_codec::{
+    ArrayCodecTraits, ArrayToArrayCodecSubchunkingIdentityTraits, CodecError,
+    PartialDecoderCapability, PartialEncoderCapability,
+};
+use zarrs_plugin::ZarrVersion;
+
+pub(crate) const fn nz(value: u64) -> NonZeroU64 {
+    NonZeroU64::new(value).unwrap()
+}
+
+/// An identity array-to-array codec that deliberately does not implement `partial_decoder`.
+///
+/// It therefore always resolves to [`CodecPartialDefault`](zarrs_codec::CodecPartialDefault),
+/// unlike any real codec, which may gain a bespoke partial codec at any time.
+#[derive(Debug)]
+pub(crate) struct IdentityCodec;
+
+#[derive(Debug)]
+struct IdentityCodecBound {
+    data_type: DataType,
+    fill_value: FillValue,
+}
+
+zarrs_plugin::impl_extension_aliases!(IdentityCodec, v3: "zarrs.test.identity");
+
+impl CodecTraits for IdentityCodec {
+    fn configuration(
+        &self,
+        _version: ZarrVersion,
+        _options: &CodecMetadataOptions,
+    ) -> Option<Configuration> {
+        Some(Configuration::default())
+    }
+
+    fn partial_decoder_capability(&self) -> PartialDecoderCapability {
+        // The default array-to-array partial decoder supports partial read/decode.
+        PartialDecoderCapability {
+            partial_read: true,
+            partial_decode: true,
+        }
+    }
+
+    fn partial_encoder_capability(&self) -> PartialEncoderCapability {
+        PartialEncoderCapability {
+            partial_encode: false,
+        }
+    }
+}
+
+impl UnboundArrayToArrayCodecTraits for IdentityCodec {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn UnboundArrayToArrayCodecTraits> {
+        self
+    }
+
+    fn with_context(
+        &self,
+        data_type: DataType,
+        fill_value: FillValue,
+    ) -> Result<Arc<dyn ArrayToArrayCodecTraits>, CodecCreateError> {
+        Ok(Arc::new(IdentityCodecBound {
+            data_type,
+            fill_value,
+        }))
+    }
+}
+
+impl ArrayCodecTraits for IdentityCodecBound {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn recommended_concurrency(
+        &self,
+        _shape: &[NonZeroU64],
+    ) -> Result<RecommendedConcurrency, CodecError> {
+        Ok(RecommendedConcurrency::new_maximum(1))
+    }
+}
+
+impl ArrayToArrayCodecSubchunkingIdentityTraits for IdentityCodecBound {}
+
+impl ArrayToArrayCodecTraits for IdentityCodecBound {
+    fn into_dyn(self: Arc<Self>) -> Arc<dyn ArrayToArrayCodecTraits> {
+        self
+    }
+
+    fn encoded_data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn encoded_fill_value(&self) -> &FillValue {
+        &self.fill_value
+    }
+
+    fn encode<'a>(
+        &self,
+        bytes: ArrayBytes<'a>,
+        _shape: &[NonZeroU64],
+        _options: &CodecOptions,
+    ) -> Result<ArrayBytes<'a>, CodecError> {
+        Ok(bytes)
+    }
+
+    fn decode<'a>(
+        &self,
+        bytes: ArrayBytes<'a>,
+        _shape: &[NonZeroU64],
+        _options: &CodecOptions,
+    ) -> Result<ArrayBytes<'a>, CodecError> {
+        Ok(bytes)
+    }
+}
+
+pub(crate) struct Case {
+    /// Identifies the case in assertion failures.
+    pub(crate) name: &'static str,
+    /// The array-to-array codec under test, applied before the sharding codec.
+    pub(crate) codec: Option<Arc<dyn UnboundArrayToArrayCodecTraits>>,
+    pub(crate) data_type: DataType,
+    pub(crate) fill_value: ArrayBuilderFillValue,
+    /// The data type seen by the sharding codec, i.e. after `codec`.
+    pub(crate) encoded_data_type: DataType,
+    pub(crate) array_shape: Vec<u64>,
+    pub(crate) chunk_shape: Vec<u64>,
+    /// The sharding inner chunk shape, in the encoded representation.
+    pub(crate) encoded_subchunk_shape: Vec<NonZeroU64>,
+    /// The chunk to resolve the local subchunk grid for. It is written by the tests.
+    pub(crate) chunk_indices: Vec<u64>,
+    /// A chunk that the tests leave unwritten, for the absent/`exists` assertions.
+    pub(crate) absent_chunk_indices: Vec<u64>,
+    /// The expected local subchunk shape, in the decoded chunk representation.
+    pub(crate) local_subchunk_shape: Vec<NonZeroU64>,
+}
+
+impl Case {
+    /// An [`ArrayBuilder`] for this case, ready to `build` against a sync or async store.
+    pub(crate) fn builder(&self) -> ArrayBuilder {
+        let sharding =
+            ShardingCodecBuilder::new(self.encoded_subchunk_shape.clone(), &self.encoded_data_type)
+                .build_arc();
+        let mut builder = ArrayBuilder::new(
+            self.array_shape.clone(),
+            self.chunk_shape.clone(),
+            self.data_type.clone(),
+            self.fill_value.clone(),
+        );
+        if let Some(codec) = &self.codec {
+            builder.array_to_array_codecs(vec![codec.clone()]);
+        }
+        builder.array_to_bytes_codec(sharding);
+        builder
+    }
+
+    /// Zeroed chunk bytes, whatever the data type.
+    ///
+    /// Every case uses a non-zero fill value, so a zeroed chunk is never elided as empty.
+    pub(crate) fn zero_chunk_bytes(&self) -> ArrayBytes<'static> {
+        let DataTypeSize::Fixed(element_size) = self.data_type.size() else {
+            panic!("{}: expected a fixed-size data type", self.name);
+        };
+        let num_elements: u64 = self.chunk_shape.iter().product();
+        ArrayBytes::new_flen(vec![
+            0u8;
+            usize::try_from(num_elements).unwrap() * element_size
+        ])
+    }
+
+    /// Assert that `grid` is the expected chunk-local subchunk grid.
+    pub(crate) fn assert_local_grid(&self, grid: Option<&ChunkGrid>) {
+        let grid = grid.unwrap_or_else(|| panic!("{}: expected a local subchunk grid", self.name));
+        assert_eq!(
+            grid.array_shape(),
+            self.chunk_shape,
+            "{}: local grid covers the decoded chunk",
+            self.name
+        );
+        assert_eq!(
+            grid.chunk_shape(&vec![0; self.chunk_shape.len()]).unwrap(),
+            Some(self.local_subchunk_shape.clone()),
+            "{}: local subchunk shape",
+            self.name
+        );
+    }
+}
+
+/// A sharded array with no array-to-array codec, used by the partial encoder and cache tests.
+pub(crate) fn plain_sharding() -> Case {
+    Case {
+        name: "sharding",
+        codec: None,
+        data_type: data_type::uint16(),
+        fill_value: 1u16.into(),
+        encoded_data_type: data_type::uint16(),
+        array_shape: vec![8, 4],
+        chunk_shape: vec![4, 4],
+        encoded_subchunk_shape: vec![nz(2), nz(2)],
+        chunk_indices: vec![0, 0],
+        absent_chunk_indices: vec![1, 0],
+        local_subchunk_shape: vec![nz(2), nz(2)],
+    }
+}
+
+/// One case per array-to-array partial decoder that has to propagate a subchunk grid.
+pub(crate) fn cases() -> Vec<Case> {
+    vec![
+        plain_sharding(),
+        Case {
+            name: "bitround",
+            codec: Some(Arc::new(
+                BitroundCodec::new_with_configuration(
+                    &serde_json::from_str(r#"{"keepbits": 8}"#).unwrap(),
+                )
+                .unwrap(),
+            )),
+            data_type: data_type::float32(),
+            fill_value: 1.0f32.into(),
+            encoded_data_type: data_type::float32(),
+            array_shape: vec![8, 4],
+            chunk_shape: vec![4, 4],
+            encoded_subchunk_shape: vec![nz(2), nz(2)],
+            chunk_indices: vec![0, 0],
+            absent_chunk_indices: vec![1, 0],
+            local_subchunk_shape: vec![nz(2), nz(2)],
+        },
+        Case {
+            name: "cast_value",
+            codec: Some(Arc::new(
+                CastValueCodec::new_with_configuration(
+                    &serde_json::from_str(r#"{"data_type": "uint16"}"#).unwrap(),
+                )
+                .unwrap(),
+            )),
+            data_type: data_type::uint8(),
+            fill_value: 1u8.into(),
+            encoded_data_type: data_type::uint16(),
+            array_shape: vec![8, 4],
+            chunk_shape: vec![4, 4],
+            encoded_subchunk_shape: vec![nz(2), nz(2)],
+            chunk_indices: vec![0, 0],
+            absent_chunk_indices: vec![1, 0],
+            local_subchunk_shape: vec![nz(2), nz(2)],
+        },
+        // `IdentityCodec` has no bespoke partial decoder, so it exercises `CodecPartialDefault`.
+        Case {
+            name: "identity",
+            codec: Some(Arc::new(IdentityCodec)),
+            data_type: data_type::uint16(),
+            fill_value: 1u16.into(),
+            encoded_data_type: data_type::uint16(),
+            array_shape: vec![8, 4],
+            chunk_shape: vec![4, 4],
+            encoded_subchunk_shape: vec![nz(2), nz(2)],
+            chunk_indices: vec![0, 0],
+            absent_chunk_indices: vec![1, 0],
+            local_subchunk_shape: vec![nz(2), nz(2)],
+        },
+        Case {
+            name: "reshape",
+            codec: Some(Arc::new(ReshapeCodec::new(
+                ReshapeShape::new([nz(12).into()]).unwrap(),
+            ))),
+            data_type: data_type::uint16(),
+            fill_value: 1u16.into(),
+            encoded_data_type: data_type::uint16(),
+            array_shape: vec![4, 6],
+            chunk_shape: vec![2, 6],
+            encoded_subchunk_shape: vec![nz(3)],
+            chunk_indices: vec![1, 0],
+            absent_chunk_indices: vec![0, 0],
+            local_subchunk_shape: vec![nz(1), nz(3)],
+        },
+        Case {
+            name: "squeeze",
+            codec: Some(Arc::new(SqueezeCodec::new())),
+            data_type: data_type::uint16(),
+            fill_value: 1u16.into(),
+            encoded_data_type: data_type::uint16(),
+            array_shape: vec![2, 4],
+            chunk_shape: vec![1, 4],
+            encoded_subchunk_shape: vec![nz(2)],
+            chunk_indices: vec![1, 0],
+            absent_chunk_indices: vec![0, 0],
+            local_subchunk_shape: vec![nz(1), nz(2)],
+        },
+        Case {
+            name: "transpose",
+            codec: Some(Arc::new(TransposeCodec::new(
+                TransposeOrder::new(&[1, 0]).unwrap(),
+            ))),
+            data_type: data_type::uint16(),
+            fill_value: 1u16.into(),
+            encoded_data_type: data_type::uint16(),
+            array_shape: vec![8, 6],
+            chunk_shape: vec![4, 6],
+            encoded_subchunk_shape: vec![nz(3), nz(2)],
+            chunk_indices: vec![0, 0],
+            absent_chunk_indices: vec![1, 0],
+            local_subchunk_shape: vec![nz(2), nz(3)],
+        },
+    ]
+}

--- a/zarrs_codec/CHANGELOG.md
+++ b/zarrs_codec/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `CodecCreateError` for codec creation, reconfiguration, and binding failures
 - Add `UnboundArrayTo{Array,Bytes}CodecTraits`
 - Implement `[Async]BytesPartial{Encoder,Decoder}Traits` for `(Tstorage: *StorageTraits, StoreKey)`
-- Add `ChunkGrid{Encoded,Decoded}Ref` and `[Async]ArrayPartialDecoderTraits::local_subchunk_grid[s]` for chunk-local subchunk grids
+- Add `ChunkGrid{Encoded,Decoded}Ref` and `[Async]ArrayPartialDecoderSubchunkingTraits::local_subchunk_grid[s]` for chunk-local subchunk grids
 
 ### Changed
 - **Breaking**: Refactor `ArrayTo{Array,Bytes}CodecTraits`
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Breaking**: Add `data_type()`, `fill_value()`, `encoded_chunk_grid()` and `decoded_subchunk_grid[s]()` methods
   - **Breaking**: Remove `decoded_shape()` and `partial_decode_granularity()` methods
   - **Breaking**: Remove `data_type` and `fill_value` parameters from various methods
-  - **Breaking**: Add `ArrayTo{Array,Bytes}CodecSubchunkingTraits` supertraits for resolving subchunk grids
-    - `ArrayToArrayCodecSubchunkingIdentityTraits` and `ArrayToBytesCodecNoSubchunkingTraits` marker traits are available for common codecs
+- **Breaking**: Add `ArrayTo{Array,Bytes}CodecSubchunkingTraits` supertraits for resolving subchunk grids
+  - `ArrayToArrayCodecSubchunkingIdentityTraits` and `ArrayToBytesCodecNoSubchunkingTraits` marker traits are available for common codecs
+- **Breaking**: Add the `[Async]ArrayPartialDecoderSubchunkingTraits` supertraits of `[Async]ArrayPartialDecoderTraits`, which hold the subchunking surface of a partial decoder
+  - The `ArrayPartialDecoderNoSubchunkingTraits` marker trait default implements both for partial decoders without subchunks
 
 ### Removed
 - **Breaking**: Remove `ArrayCodecTraits::partial_decode_granularity`

--- a/zarrs_codec/src/codec_partial_default.rs
+++ b/zarrs_codec/src/codec_partial_default.rs
@@ -6,16 +6,17 @@ use zarrs_chunk_grid::Indexer;
 use zarrs_data_type::FillValue;
 
 use super::{
-    ArrayBytes, ArrayBytesOffsets, ArrayBytesRaw, ArrayPartialDecoderTraits,
-    ArrayPartialEncoderTraits, ArraySubset, ArrayToArrayCodecTraits, ArrayToBytesCodecTraits,
-    BytesPartialDecoderTraits, BytesPartialEncoderTraits, BytesRepresentation,
-    BytesToBytesCodecTraits, ChunkShape, CodecError, CodecOptions, DataType,
+    ArrayBytes, ArrayBytesOffsets, ArrayBytesRaw, ArrayPartialDecoderNoSubchunkingTraits,
+    ArrayPartialDecoderSubchunkingTraits, ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+    ArraySubset, ArrayToArrayCodecTraits, ArrayToBytesCodecTraits, BytesPartialDecoderTraits,
+    BytesPartialEncoderTraits, BytesRepresentation, BytesToBytesCodecTraits, ChunkShape,
+    CodecError, CodecOptions, DataType,
 };
 use crate::array_bytes::update_array_bytes;
 #[cfg(feature = "async")]
 use crate::{
-    AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits, AsyncBytesPartialDecoderTraits,
-    AsyncBytesPartialEncoderTraits,
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncArrayPartialEncoderTraits, AsyncBytesPartialDecoderTraits, AsyncBytesPartialEncoderTraits,
 };
 use zarrs_metadata::DataTypeSize;
 use zarrs_storage::byte_range::{ByteRangeIterator, extract_byte_ranges};
@@ -121,6 +122,19 @@ impl<T: ?Sized, C: ?Sized> CodecPartialDefault<T, BytesRepresentation, C> {
     }
 }
 
+impl<T: ?Sized> ArrayPartialDecoderSubchunkingTraits
+    for CodecPartialDefault<T, ArrayDecodedRepresentation, dyn ArrayToArrayCodecTraits>
+where
+    T: ArrayPartialDecoderTraits,
+{
+    fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<super::ChunkGrid>>, CodecError> {
+        self.input_output_handle.local_subchunk_grids(options)
+    }
+}
+
 impl<T: ?Sized> ArrayPartialDecoderTraits
     for CodecPartialDefault<T, ArrayDecodedRepresentation, dyn ArrayToArrayCodecTraits>
 where
@@ -166,13 +180,6 @@ where
                 }
             })
         }
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<super::ChunkGrid>>, CodecError> {
-        self.input_output_handle.local_subchunk_grids(options)
     }
 
     fn supports_partial_decode(&self) -> bool {
@@ -243,6 +250,13 @@ where
     }
 }
 
+// The default array-to-bytes partial codec decodes an entire chunk, so it exposes no subchunks.
+// A subchunking codec must implement its own partial decoder to expose them.
+impl<T: ?Sized> ArrayPartialDecoderNoSubchunkingTraits
+    for CodecPartialDefault<T, ArrayDecodedRepresentation, dyn ArrayToBytesCodecTraits>
+{
+}
+
 impl<T: ?Sized> ArrayPartialDecoderTraits
     for CodecPartialDefault<T, ArrayDecodedRepresentation, dyn ArrayToBytesCodecTraits>
 where
@@ -258,13 +272,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     fn partial_decode(
@@ -474,6 +481,22 @@ where
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T: ?Sized> AsyncArrayPartialDecoderSubchunkingTraits
+    for CodecPartialDefault<T, ArrayDecodedRepresentation, dyn ArrayToArrayCodecTraits>
+where
+    T: AsyncArrayPartialDecoderTraits,
+{
+    async fn local_subchunk_grids(
+        &self,
+        options: &CodecOptions,
+    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
+        self.input_output_handle.local_subchunk_grids(options).await
+    }
+}
+
+#[cfg(feature = "async")]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<T: ?Sized> AsyncArrayPartialDecoderTraits
     for CodecPartialDefault<T, ArrayDecodedRepresentation, dyn ArrayToArrayCodecTraits>
 where
@@ -485,13 +508,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        self.input_output_handle.local_subchunk_grids(options).await
     }
 
     fn data_type(&self) -> &super::DataType {
@@ -622,13 +638,6 @@ where
 
     fn size_held(&self) -> usize {
         self.input_output_handle.size_held()
-    }
-
-    async fn local_subchunk_grids(
-        &self,
-        _options: &CodecOptions,
-    ) -> Result<Vec<Option<zarrs_chunk_grid::ChunkGrid>>, CodecError> {
-        Ok(Vec::new())
     }
 
     async fn partial_decode<'a>(

--- a/zarrs_codec/src/codec_traits/array_partial_async.rs
+++ b/zarrs_codec/src/codec_traits/array_partial_async.rs
@@ -6,28 +6,20 @@ use zarrs_plugin::{MaybeSend, MaybeSync};
 use zarrs_storage::StorageError;
 
 use crate::{
-    ArrayBytes, ArrayBytesDecodeIntoTarget, CodecError, CodecOptions, InvalidNumberOfElementsError,
-    decode_into_array_bytes_target,
+    ArrayBytes, ArrayBytesDecodeIntoTarget, ArrayPartialDecoderNoSubchunkingTraits, CodecError,
+    CodecOptions, InvalidNumberOfElementsError, decode_into_array_bytes_target,
 };
 
-/// Asynchronous partial array decoder traits.
+/// Subchunking traits for an asynchronous partial array decoder.
+///
+/// This is the asynchronous equivalent of
+/// [`ArrayPartialDecoderSubchunkingTraits`](crate::ArrayPartialDecoderSubchunkingTraits).
+///
+/// Implement [`ArrayPartialDecoderNoSubchunkingTraits`] instead of this trait for a partial decoder
+/// without subchunks.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait AsyncArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
-    /// Return the data type of the partial decoder.
-    fn data_type(&self) -> &DataType;
-
-    /// Returns whether the chunk exists.
-    ///
-    /// # Errors
-    /// Returns [`StorageError`] if a storage operation fails.
-    async fn exists(&self) -> Result<bool, StorageError>;
-
-    /// Returns the size of chunk bytes held by the partial decoder.
-    ///
-    /// Intended for use by size-constrained partial decoder caches.
-    fn size_held(&self) -> usize;
-
+pub trait AsyncArrayPartialDecoderSubchunkingTraits: MaybeSend + MaybeSync {
     /// Return the chunk-local subchunk grid hierarchy for this decoder.
     ///
     /// Grids are ordered from outermost to innermost and are relative to the decoded
@@ -58,6 +50,41 @@ pub trait AsyncArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
             .next()
             .flatten())
     }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<T> AsyncArrayPartialDecoderSubchunkingTraits for T
+where
+    T: ArrayPartialDecoderNoSubchunkingTraits + MaybeSend + MaybeSync + ?Sized,
+{
+    async fn local_subchunk_grids(
+        &self,
+        _options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        Ok(Vec::new())
+    }
+}
+
+/// Asynchronous partial array decoder traits.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait AsyncArrayPartialDecoderTraits:
+    AsyncArrayPartialDecoderSubchunkingTraits + Any + MaybeSend + MaybeSync
+{
+    /// Return the data type of the partial decoder.
+    fn data_type(&self) -> &DataType;
+
+    /// Returns whether the chunk exists.
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] if a storage operation fails.
+    async fn exists(&self) -> Result<bool, StorageError>;
+
+    /// Returns the size of chunk bytes held by the partial decoder.
+    ///
+    /// Intended for use by size-constrained partial decoder caches.
+    fn size_held(&self) -> usize;
 
     /// Partially decode a chunk.
     ///

--- a/zarrs_codec/src/codec_traits/array_partial_sync.rs
+++ b/zarrs_codec/src/codec_traits/array_partial_sync.rs
@@ -10,22 +10,15 @@ use crate::{
     decode_into_array_bytes_target,
 };
 
-/// Partial array decoder traits.
-pub trait ArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
-    /// Return the data type of the partial decoder.
-    fn data_type(&self) -> &DataType;
-
-    /// Returns whether the chunk exists.
-    ///
-    /// # Errors
-    /// Returns [`StorageError`] if a storage operation fails.
-    fn exists(&self) -> Result<bool, StorageError>;
-
-    /// Returns the size of chunk bytes held by the partial decoder.
-    ///
-    /// Intended for use by size-constrained partial decoder caches.
-    fn size_held(&self) -> usize;
-
+/// Subchunking traits for a partial array decoder.
+///
+/// A partial decoder exposes subchunks if the codec that created it encodes a chunk as
+/// independently encoded subchunks (e.g. the `sharding_indexed` codec), or if it forwards the
+/// subchunks of an inner partial decoder.
+///
+/// Implement [`ArrayPartialDecoderNoSubchunkingTraits`] instead of this trait for a partial decoder
+/// without subchunks.
+pub trait ArrayPartialDecoderSubchunkingTraits: MaybeSend + MaybeSync {
     /// Return the chunk-local subchunk grid hierarchy for this decoder.
     ///
     /// Grids are ordered from outermost to innermost and are relative to the decoded
@@ -52,6 +45,40 @@ pub trait ArrayPartialDecoderTraits: Any + MaybeSend + MaybeSync {
             .next()
             .flatten())
     }
+}
+
+/// Marker trait for partial array decoders that do not expose subchunks.
+pub trait ArrayPartialDecoderNoSubchunkingTraits {}
+
+impl<T> ArrayPartialDecoderSubchunkingTraits for T
+where
+    T: ArrayPartialDecoderNoSubchunkingTraits + MaybeSend + MaybeSync + ?Sized,
+{
+    fn local_subchunk_grids(
+        &self,
+        _options: &CodecOptions,
+    ) -> Result<Vec<Option<ChunkGrid>>, CodecError> {
+        Ok(Vec::new())
+    }
+}
+
+/// Partial array decoder traits.
+pub trait ArrayPartialDecoderTraits:
+    ArrayPartialDecoderSubchunkingTraits + Any + MaybeSend + MaybeSync
+{
+    /// Return the data type of the partial decoder.
+    fn data_type(&self) -> &DataType;
+
+    /// Returns whether the chunk exists.
+    ///
+    /// # Errors
+    /// Returns [`StorageError`] if a storage operation fails.
+    fn exists(&self) -> Result<bool, StorageError>;
+
+    /// Returns the size of chunk bytes held by the partial decoder.
+    ///
+    /// Intended for use by size-constrained partial decoder caches.
+    fn size_held(&self) -> usize;
 
     /// Partially decode a chunk.
     ///

--- a/zarrs_codec/src/lib.rs
+++ b/zarrs_codec/src/lib.rs
@@ -22,7 +22,10 @@ pub use array_bytes_fixed_disjoint_view::{
 
 mod codec_traits;
 pub use codec_traits::array::ArrayCodecTraits;
-pub use codec_traits::array_partial_sync::{ArrayPartialDecoderTraits, ArrayPartialEncoderTraits};
+pub use codec_traits::array_partial_sync::{
+    ArrayPartialDecoderNoSubchunkingTraits, ArrayPartialDecoderSubchunkingTraits,
+    ArrayPartialDecoderTraits, ArrayPartialEncoderTraits,
+};
 pub use codec_traits::array_to_array::{
     ArrayToArrayCodecSubchunkingIdentityTraits, ArrayToArrayCodecSubchunkingTraits,
     ArrayToArrayCodecTraits, UnboundArrayToArrayCodecTraits,
@@ -37,7 +40,8 @@ pub use codec_traits::{CodecTraits, CodecTraitsV2, CodecTraitsV3};
 
 #[cfg(feature = "async")]
 pub use codec_traits::array_partial_async::{
-    AsyncArrayPartialDecoderTraits, AsyncArrayPartialEncoderTraits,
+    AsyncArrayPartialDecoderSubchunkingTraits, AsyncArrayPartialDecoderTraits,
+    AsyncArrayPartialEncoderTraits,
 };
 #[cfg(feature = "async")]
 pub use codec_traits::bytes_partial_async::{
@@ -159,7 +163,7 @@ mod chunk_grid_mapped {
         /// A chunk grid is resolvable for the whole array.
         Array(ChunkGrid),
         /// No global grid exists, but a grid is resolvable for each chunk via
-        /// [`ArrayPartialDecoderTraits::local_subchunk_grid`](crate::ArrayPartialDecoderTraits::local_subchunk_grid).
+        /// [`ArrayPartialDecoderSubchunkingTraits::local_subchunk_grid`](crate::ArrayPartialDecoderSubchunkingTraits::local_subchunk_grid).
         ChunkLocal,
     }
 


### PR DESCRIPTION
Move `ArrayPartialDecoderTraits::local_subchunk_grid` to newly created `ArrayPartialDecoderSubchunkingTraits` and add `ArrayPartialDecoderNoSubchunkingTraits` marker trait.

That new trait will support access to subchunking codecs later